### PR TITLE
Extract lengthy explanation into dedicated file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
-## _Git Automation for Agile Development Teams_
+# _Git Automation for Agile Development Teams_
+
 <a href="https://travis-ci.org/Originate/git-town" alt="Build Status" target="_blank"><img src="https://travis-ci.org/Originate/git-town.svg?branch=master"></a>
 [![License](http://img.shields.io/:license-MIT-blue.svg?style=flat)](MIT-LICENSE)
 
-Git Town provides a number of additional Git commands that
-automate the typical high-level operations in
-[GitHub Flow](http://scottchacon.com/2011/08/31/github-flow.html)
-and other workflows.
+Git Town makes software development teams who use Git even more productive and happy.
+It extends Git to support
+[GitHub Flow](http://scottchacon.com/2011/08/31/github-flow.html),
+[Git Flow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow),
+the [Nvie model](http://nvie.com/posts/a-successful-git-branching-model),
+[GitLab Flow](https://about.gitlab.com/2014/09/29/gitlab-flow/),
+and other workflows better, and allows to perform many common tasks faster and easier.
 
-It is designed for workflows that have a main branch
-(typically "development" or "master")
-from which feature branches are cut and into which they are merged,
-and it assumes you use a central code repository like
-[GitHub](http://github.com/) or [Bitbucket](https://bitbucket.org/).
+Check out [the big picture](documentation/big-picture.md) for more background on Git Town.
 
 
 ## Commands
+
+Git Town provides these additional Git commands:
 
 * [git extract](/documentation/git-extract.md) - copy selected commits from the current branch into their own branch
 * [git hack](/documentation/git-hack.md) - cut a new feature branch off the main branch
@@ -28,24 +30,15 @@ and it assumes you use a central code repository like
 * [git town](/documentation/git-town.md) - general Git Town help, view and change Git Town configuration
 
 
-#### Notes
-
-* minimizes network requests
-  * each command performs a single fetch
-  * skips unnecessary pushes
-* automatically prunes deleted remote branches
-
-
 ## Installation
 
-Git Town is written in Bash, so it runs anywhere Git and Bash runs.
-Installation on OS X can be done using [Homebrew](http://brew.sh/).
-Other platforms need to install manually.
+Git Town is written in 100% [Bash](https://www.gnu.org/software/bash/bash.html),
+so it runs anywhere Git and Bash runs.
 
 <table>
   <tr>
     <th width="300px">
-      Using Homebrew
+      Using <a href="http://brew.sh">Homebrew</a>
     </th>
     <th width="400px">
       Manually
@@ -62,7 +55,7 @@ Other platforms need to install manually.
       <code>brew install git-town</code>
     </td>
     <td>
-      <ol>
+      <ul>
         <li>clone the repo to your machine (into DIR)</li>
         <li>add DIR/src to your <code>$PATH</code></li>
         <li>add DIR/man to your <code>$MANPATH</code></li>
@@ -70,7 +63,7 @@ Other platforms need to install manually.
           install <a href="http://en.wikipedia.org/wiki/Dialog_(software)">Dialog</a>
           (used by <a href="/documentation/git-extract.md">git extract</a>)
         </li>
-      </ol>
+      </ul>
     </td>
   </tr>
   <tr>
@@ -84,9 +77,9 @@ Other platforms need to install manually.
       <code>brew upgrade git-town</code>
     </td>
     <td>
-      <ol>
+      <ul>
         <li>run <code>git pull</code> in DIR</li>
-      </ol>
+      </ul>
     </td>
   </tr>
   <tr>
@@ -100,11 +93,11 @@ Other platforms need to install manually.
       <code>brew untap Originate/gittown</code>
     </td>
     <td>
-      <ol>
+      <ul>
         <li>remove DIR</li>
         <li>remove DIR/src from your <code>$PATH</code></li>
         <li>remove DIR/man from your <code>$MANPATH</code></li>
-      </ol>
+      </ul>
     </td>
   </tr>
 </table>
@@ -122,8 +115,10 @@ Other platforms need to install manually.
 
 ## Configuration
 
-Git Town is configured on a per-repository basis. Upon first use in a given repository, Git Town will ask the user for all required
-configuration information. Use the [`git town`](/documentation/git-town.md) command to view and update your configuration at any time.
+Git Town is configured on a per-repository basis.
+Upon first use in a repository, Git Town will ask for all required
+configuration.
+Use the [git town](/documentation/git-town.md) command to view or update your configuration at any time.
 
 
 ## Documentation
@@ -140,20 +135,19 @@ for help on an individual command.
 Tests are written in [Cucumber](http://cukes.info/) and [RSpec](http://rspec.info/).
 
 ```bash
-# install tools
+# install tools needed for development
 bundle
 brew install shellcheck  # bash linter
 
-# rake tasks
-rake                # Run all linters and specs
-rake lint           # Run all linters
-rake lint:bash      # Run bash linter
-rake lint:ruby      # Run ruby linter
+# various ways to verify/test the code
+rake            # Run all linters and specs
+rake lint       # Run all linters
+rake lint:bash  # Run bash linter
+rake lint:ruby  # Run ruby linter
 rake lint:cucumber  # Run cucumber linter
-rake spec           # Run specs
+rake spec       # Run specs
 
-# run single test
-cucumber -n 'scenario/feature name'
+# run a single test
 cucumber [filename]:[lineno]
 
 # run cucumber in parallel
@@ -161,7 +155,7 @@ bin/cuke [<folder>...]
 ```
 
 Found a bug or want to contribute a feature?
-[Open an issue](https://github.com/Originate/git-town/issues/new)
+Please [open an issue](https://github.com/Originate/git-town/issues/new)
 or - even better - get down, go to town, and fire a feature-tested and linter-passing
 [pull request](https://help.github.com/articles/using-pull-requests/)
 our way!
@@ -173,8 +167,4 @@ The future roadmap is planned using [GitHub issues](https://github.com/Originate
 The past roadmap is in the [release notes](release-notes.md).
 
 If you have an idea about a cool feature you would like to see in Git Town,
-please [open a ticket](https://github.com/Originate/git-town/issues/new).
-Our team will add the [idea](https://github.com/Originate/git-town/labels/idea) tag.
-Once we reach agreement about this idea, it will be tagged as an
-[enhancement](https://github.com/Originate/git-town/labels/enhancement)
-or a [bug](https://github.com/Originate/git-town/labels/bug).
+please [open a ticket](https://github.com/Originate/git-town/issues/new)!

--- a/documentation/background.md
+++ b/documentation/background.md
@@ -1,0 +1,55 @@
+# The Big Picture
+
+Git is an intentionally generic and basic tool.
+It is designed to support many different ways of using it equally well.
+It is a really wonderful *foundation* for flexible and robust source code management.
+
+
+### Problem
+
+Most teams develop code in [feature branches](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) that are cut from and merged into a main branch (typically "development" or "master").
+They use a central repository like [GitHub](http://github.com/), [Bitbucket](https://bitbucket.org/), or their own Git server.
+
+Using Git as an intentionally generic and low-level tool directly for such high-level development workflows is possible but cumbersome and repetitive.
+
+* Creating a new feature branch in the middle of active development requires up to 6 individual Git commands.
+* Updating a feature branch with the latest changes from the main branch takes up to 7.
+* Even merging a finished feature into the main branch requires 5 commands when done correctly.
+
+Almost nobody has the time and energy to manually type and run all these commands at all times.
+Omitting them on larger development teams leads to problems like
+
+* frequently outdated feature branches that conflict with the main branch
+* sizable and therefore hard to review pull requests that contain several independent changes that shoud be in their own branch
+* breakage on the main branches after merging in conflicting features
+* a convoluted Git history that is hard to use
+* many other headaches that diminish productivity and happiness as the development teams grow.
+
+
+### Solution
+The underlying problem of all these issues is that an intentionally low-level and generic source code management tool (Git) is used directly for specific high-level development workflows.
+This will always be inefficient.
+
+_Git Town_ solves these issue by adding [high-level workflow commands](../readme.md#commands) to Git.
+These commands make it super easy to create, merge, synchronize, and clean up feature branches.
+They are robust, safe, and [well tested](https://github.com/Originate/git-town/tree/master/features).
+
+
+
+### Advantages
+
+Git Town increases team productivity and fun by helping achieve
+
+* smaller and more focussed feature branches that are easier and faster to review
+* less frequent and severe merge conflicts thanks to regular feature branch synchronization
+* less brokenness on the main branch thanks to resolving issues before merging feature branches
+* a more manageable repository thanks to automatic removal of old branches
+* less time spent using Git and more time spent coding, thanks to
+  * minimizing network requests: each command performs just a single fetch and skips unnecessary pushes
+  * executing several Git commands as a batch rather than them being typed and run interactively
+
+Git Town achieves all this in a completely natural and non-intrusive way that uses no special or magic tricks.
+It allows to use the rest of Git normally.
+
+Git Town reduces the Git learning curve for beginners. By doing the complicated stuff under the hood it allows them to use Git like experts.
+It also allows experts use Git more efficiently, by automating what they would have typed and processed manually over and over again.


### PR DESCRIPTION
@charlierudolph @allewun 

This extracts the lengthy background information about Git Town into a dedicated file outside of the main Readme.
I want to keep the main Readme as a short, to the point, and efficient intro to Git Town. Too much bla bla only turns people off here, because nobody reads long texts anyways.

I have also done another iteration on a lot of the existing content, and added the preliminary Git Town logo (to be improved upon later, but its good enough for starting to get a feel for it online imho).

Please take a look and let me know what you think!