### PR TITLE
Unify declaration and verification table headers

### DIFF
--- a/features/git-extract/cherry_pick_conflict_with_open_changes.feature
+++ b/features/git-extract/cherry_pick_conflict_with_open_changes.feature
@@ -46,7 +46,7 @@ Feature: git extract: resolving conflicts with main branch (with open changes)
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "refactor" branch
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE         | FILE NAME        |
       | main    | local and remote | main commit     | conflicting_file |
       | feature | local            | feature commit  | feature_file     |
       |         |                  | refactor commit | conflicting_file |
@@ -74,7 +74,7 @@ Feature: git extract: resolving conflicts with main branch (with open changes)
     And I end up on the "refactor" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH   | LOCATION         | MESSAGE         | FILE NAME        |
       | main     | local and remote | main commit     | conflicting_file |
       | feature  | local            | feature commit  | feature_file     |
       |          |                  | refactor commit | conflicting_file |
@@ -92,7 +92,7 @@ Feature: git extract: resolving conflicts with main branch (with open changes)
     And I end up on the "refactor" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH   | LOCATION         | MESSAGE         | FILE NAME        |
       | main     | local and remote | main commit     | conflicting_file |
       | feature  | local            | feature commit  | feature_file     |
       |          |                  | refactor commit | conflicting_file |

--- a/features/git-extract/cherry_pick_conflict_without_open_changes.feature
+++ b/features/git-extract/cherry_pick_conflict_without_open_changes.feature
@@ -38,7 +38,7 @@ Feature: git extract: resolving conflicts with main branch (without open changes
     And I end up on the "feature" branch
     And there is no "refactor" branch
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE         | FILE NAME        |
       | main    | local and remote | main commit     | conflicting_file |
       | feature | local            | feature commit  | feature_file     |
       |         |                  | refactor commit | conflicting_file |
@@ -62,7 +62,7 @@ Feature: git extract: resolving conflicts with main branch (without open changes
       | refactor | git push -u origin refactor |
     And I end up on the "refactor" branch
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH   | LOCATION         | MESSAGE         | FILE NAME        |
       | main     | local and remote | main commit     | conflicting_file |
       | feature  | local            | feature commit  | feature_file     |
       |          |                  | refactor commit | conflicting_file |
@@ -78,7 +78,7 @@ Feature: git extract: resolving conflicts with main branch (without open changes
       | refactor | git push -u origin refactor |
     And I end up on the "refactor" branch
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH   | LOCATION         | MESSAGE         | FILE NAME        |
       | main     | local and remote | main commit     | conflicting_file |
       | feature  | local            | feature commit  | feature_file     |
       |          |                  | refactor commit | conflicting_file |

--- a/features/git-extract/multiple_commits_with_open_changes.feature
+++ b/features/git-extract/multiple_commits_with_open_changes.feature
@@ -32,7 +32,7 @@ Feature: git extract: extracting multiple commits (with open changes)
     And I end up on the "refactor" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE            | FILES            |
+      | BRANCH   | LOCATION         | MESSAGE            | FILE NAME        |
       | main     | local and remote | remote main commit | remote_main_file |
       | feature  | local            | feature commit     | feature_file     |
       |          |                  | refactor1 commit   | refactor1_file   |

--- a/features/git-extract/multiple_commits_without_open_changes.feature
+++ b/features/git-extract/multiple_commits_without_open_changes.feature
@@ -26,7 +26,7 @@ Feature: git extract: extracting multiple commits (without open changes)
       | refactor | git push -u origin refactor                                   |
     And  I end up on the "refactor" branch
     And I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE            | FILES            |
+      | BRANCH   | LOCATION         | MESSAGE            | FILE NAME        |
       | main     | local and remote | remote main commit | remote_main_file |
       | feature  | local            | feature commit     | feature_file     |
       |          |                  | refactor1 commit   | refactor1_file   |

--- a/features/git-extract/pull_main_branch_conflict_with_open_changes.feature
+++ b/features/git-extract/pull_main_branch_conflict_with_open_changes.feature
@@ -41,7 +41,7 @@ Feature: git extract: allows to resolve conflicting remote main branch updates (
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "refactor" branch
     And I have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
       | main    | remote   | conflicting remote commit | conflicting_file |
       |         | local    | conflicting local commit  | conflicting_file |
       | feature | local    | feature commit            | feature_file     |
@@ -72,7 +72,7 @@ Feature: git extract: allows to resolve conflicting remote main branch updates (
     And I end up on the "refactor" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH   | LOCATION         | MESSAGE                   | FILE NAME        |
       | main     | local and remote | conflicting remote commit | conflicting_file |
       |          |                  | conflicting local commit  | conflicting_file |
       | feature  | local            | feature commit            | feature_file     |
@@ -95,7 +95,7 @@ Feature: git extract: allows to resolve conflicting remote main branch updates (
     And I end up on the "refactor" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH   | LOCATION         | MESSAGE                   | FILE NAME        |
       | main     | local and remote | conflicting remote commit | conflicting_file |
       |          |                  | conflicting local commit  | conflicting_file |
       | feature  | local            | feature commit            | feature_file     |

--- a/features/git-extract/pull_main_branch_conflict_without_open_changes.feature
+++ b/features/git-extract/pull_main_branch_conflict_without_open_changes.feature
@@ -33,7 +33,7 @@ Feature: git extract: resolving conflicting remote main branch updates (without 
     And I end up on the "feature" branch
     And there is no "refactor" branch
     And I have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
       | main    | remote   | conflicting remote commit | conflicting_file |
       |         | local    | conflicting local commit  | conflicting_file |
       | feature | local    | feature commit            | feature_file     |
@@ -60,7 +60,7 @@ Feature: git extract: resolving conflicting remote main branch updates (without 
       | refactor | git push -u origin refactor           |
     And I end up on the "refactor" branch
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH   | LOCATION         | MESSAGE                   | FILE NAME        |
       | main     | local and remote | conflicting remote commit | conflicting_file |
       |          |                  | conflicting local commit  | conflicting_file |
       | feature  | local            | feature commit            | feature_file     |
@@ -81,7 +81,7 @@ Feature: git extract: resolving conflicting remote main branch updates (without 
       | refactor | git push -u origin refactor           |
     And I end up on the "refactor" branch
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH   | LOCATION         | MESSAGE                   | FILE NAME        |
       | main     | local and remote | conflicting remote commit | conflicting_file |
       |          |                  | conflicting local commit  | conflicting_file |
       | feature  | local            | feature commit            | feature_file     |

--- a/features/git-extract/single_commit_with_open_changes.feature
+++ b/features/git-extract/single_commit_with_open_changes.feature
@@ -29,7 +29,7 @@ Feature: git extract: extracting a single commit (with open changes)
     And I end up on the "refactor" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE            | FILES            |
+      | BRANCH   | LOCATION         | MESSAGE            | FILE NAME        |
       | main     | local and remote | remote main commit | remote_main_file |
       | feature  | local            | feature commit     | feature_file     |
       |          |                  | refactor commit    | refactor_file    |

--- a/features/git-extract/single_commit_without_open_changes.feature
+++ b/features/git-extract/single_commit_without_open_changes.feature
@@ -25,7 +25,7 @@ Feature: git extract: extracting a single commit (without open changes)
       | refactor | git push -u origin refactor           |
     And I end up on the "refactor" branch
     And I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE            | FILES            |
+      | BRANCH   | LOCATION         | MESSAGE            | FILE NAME        |
       | main     | local and remote | remote main commit | remote_main_file |
       | feature  | local            | feature commit     | feature_file     |
       |          |                  | refactor commit    | refactor_file    |

--- a/features/git-hack/feature_branch_with_open_changes.feature
+++ b/features/git-hack/feature_branch_with_open_changes.feature
@@ -28,7 +28,7 @@ Feature: git hack: starting a new feature (with open changes)
     And I end up on the "new_feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I have the following commits
-      | BRANCH           | LOCATION         | MESSAGE                 | FILES        |
+      | BRANCH           | LOCATION         | MESSAGE                 | FILE NAME    |
       | main             | local and remote | main commit             | main_file    |
       | existing_feature | local            | existing feature commit | feature_file |
       | new_feature      | local            | main commit             | main_file    |

--- a/features/git-hack/feature_branch_without_open_changes.feature
+++ b/features/git-hack/feature_branch_without_open_changes.feature
@@ -22,7 +22,7 @@ Feature: git hack: starting a new feature (without open changes)
       | main             | git checkout -b new_feature main |
     And I end up on the "new_feature" branch
     And I have the following commits
-      | BRANCH           | LOCATION         | MESSAGE                 | FILES        |
+      | BRANCH           | LOCATION         | MESSAGE                 | FILE NAME    |
       | main             | local and remote | main commit             | main_file    |
       | existing_feature | local            | existing feature commit | feature_file |
       | new_feature      | local            | main commit             | main_file    |

--- a/features/git-hack/main_branch_with_open_changes.feature
+++ b/features/git-hack/main_branch_with_open_changes.feature
@@ -26,7 +26,7 @@ Feature: git hack: moving open changes on the main branch into a new feature bra
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And the branch "new_feature" has not been pushed to the repository
     And I have the following commits
-      | BRANCH      | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH      | LOCATION         | MESSAGE     | FILE NAME |
       | main        | local and remote | main_commit | main_file |
       | new_feature | local            | main_commit | main_file |
     And now I have the following committed files

--- a/features/git-hack/main_branch_without_open_changes.feature
+++ b/features/git-hack/main_branch_without_open_changes.feature
@@ -22,7 +22,7 @@ Feature: git hack: starting a new feature from the main branch
     And I end up on the "new_feature" branch
     And the branch "new_feature" has not been pushed to the repository
     And I have the following commits
-      | BRANCH      | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH      | LOCATION         | MESSAGE     | FILE NAME |
       | main        | local and remote | main_commit | main_file |
       | new_feature | local            | main_commit | main_file |
     And now I have the following committed files

--- a/features/git-hack/pull_main_branch_conflicts_with_open_changes.feature
+++ b/features/git-hack/pull_main_branch_conflicts_with_open_changes.feature
@@ -39,7 +39,7 @@ Feature: git hack: handling conflicting remote main branch updates (with open ch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no rebase in progress
     And I have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
       | main   | remote   | conflicting remote commit | conflicting_file |
       |        | local    | conflicting local commit  | conflicting_file |
 
@@ -64,7 +64,7 @@ Feature: git hack: handling conflicting remote main branch updates (with open ch
     And I end up on the "new_feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH      | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH      | LOCATION         | MESSAGE                   | FILE NAME        |
       | main        | local and remote | conflicting remote commit | conflicting_file |
       |             |                  | conflicting local commit  | conflicting_file |
       | new_feature | local            | conflicting remote commit | conflicting_file |
@@ -86,7 +86,7 @@ Feature: git hack: handling conflicting remote main branch updates (with open ch
     And I end up on the "new_feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH      | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH      | LOCATION         | MESSAGE                   | FILE NAME        |
       | main        | local and remote | conflicting remote commit | conflicting_file |
       |             |                  | conflicting local commit  | conflicting_file |
       | new_feature | local            | conflicting remote commit | conflicting_file |

--- a/features/git-hack/pull_main_branch_conflicts_without_open_changes.feature
+++ b/features/git-hack/pull_main_branch_conflicts_without_open_changes.feature
@@ -31,7 +31,7 @@ Feature: git hack: handling conflicting remote main branch updates while startin
     And I end up on the "existing_feature" branch
     And there is no rebase in progress
     And I have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
       | main   | remote   | conflicting remote commit | conflicting_file |
       |        | local    | conflicting local commit  | conflicting_file |
 
@@ -52,7 +52,7 @@ Feature: git hack: handling conflicting remote main branch updates while startin
       | main   | git checkout -b new_feature main |
     And I end up on the "new_feature" branch
     And now I have the following commits
-      | BRANCH      | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH      | LOCATION         | MESSAGE                   | FILE NAME        |
       | main        | local and remote | conflicting remote commit | conflicting_file |
       |             |                  | conflicting local commit  | conflicting_file |
       | new_feature | local            | conflicting remote commit | conflicting_file |
@@ -72,7 +72,7 @@ Feature: git hack: handling conflicting remote main branch updates while startin
       | main   | git checkout -b new_feature main |
     And I end up on the "new_feature" branch
     And now I have the following commits
-      | BRANCH      | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH      | LOCATION         | MESSAGE                   | FILE NAME        |
       | main        | local and remote | conflicting remote commit | conflicting_file |
       |             |                  | conflicting local commit  | conflicting_file |
       | new_feature | local            | conflicting remote commit | conflicting_file |

--- a/features/git-kill/current_branch/deleted_tracking_branch_with_open_changes.feature
+++ b/features/git-kill/current_branch/deleted_tracking_branch_with_open_changes.feature
@@ -32,7 +32,7 @@ Feature: git kill: killing the current feature branch with a deleted tracking br
       | local      | main, feature |
       | remote     | main, feature |
     And I have the following commits
-      | branch  | location         | message     | files     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |
 
 
@@ -50,6 +50,6 @@ Feature: git kill: killing the current feature branch with a deleted tracking br
       | local      | main, dead-feature, feature |
       | remote     | main, feature               |
     And I have the following commits
-      | BRANCH       | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH       | LOCATION         | MESSAGE         | FILE NAME        |
       | feature      | local and remote | good commit     | good_file        |
       | dead-feature | local            | dead-end commit | unfortunate_file |

--- a/features/git-kill/current_branch/deleted_tracking_branch_without_open_changes.feature
+++ b/features/git-kill/current_branch/deleted_tracking_branch_without_open_changes.feature
@@ -26,7 +26,7 @@ Feature: git kill: killing the current feature branch with a deleted tracking br
       | local      | main, feature |
       | remote     | main, feature |
     And I have the following commits
-      | branch  | location         | message     | files     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |
 
 
@@ -42,6 +42,6 @@ Feature: git kill: killing the current feature branch with a deleted tracking br
       | local      | main, dead-feature, feature |
       | remote     | main, feature               |
     And I have the following commits
-      | BRANCH       | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH       | LOCATION         | MESSAGE         | FILE NAME        |
       | feature      | local and remote | good commit     | good_file        |
       | dead-feature | local            | dead-end commit | unfortunate_file |

--- a/features/git-kill/current_branch/feature_branch_with_open_changes.feature
+++ b/features/git-kill/current_branch/feature_branch_with_open_changes.feature
@@ -31,7 +31,7 @@ Feature: git kill: removing the current feature branch (with open changes)
       | local      | main, feature |
       | remote     | main, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |
 
 
@@ -51,6 +51,6 @@ Feature: git kill: removing the current feature branch (with open changes)
       | local      | main, dead-feature, feature |
       | remote     | main, dead-feature, feature |
     And I have the following commits
-      | BRANCH       | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH       | LOCATION         | MESSAGE         | FILE NAME        |
       | feature      | local and remote | good commit     | good_file        |
       | dead-feature | local and remote | dead-end commit | unfortunate_file |

--- a/features/git-kill/current_branch/feature_branch_without_open_changes.feature
+++ b/features/git-kill/current_branch/feature_branch_without_open_changes.feature
@@ -26,7 +26,7 @@ Feature: git kill: removing the current feature branch (without open changes)
       | local      | main, feature |
       | remote     | main, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |
 
 
@@ -43,6 +43,6 @@ Feature: git kill: removing the current feature branch (without open changes)
       | local      | main, dead-feature, feature |
       | remote     | main, dead-feature, feature |
     And I have the following commits
-      | BRANCH       | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH       | LOCATION         | MESSAGE         | FILE NAME        |
       | feature      | local and remote | good commit     | good_file        |
       | dead-feature | local and remote | dead-end commit | unfortunate_file |

--- a/features/git-kill/current_branch/local_feature_branch_with_open_changes.feature
+++ b/features/git-kill/current_branch/local_feature_branch_with_open_changes.feature
@@ -31,7 +31,7 @@ Feature: git kill: removing the current local feature branch (with open changes)
       | local      | main, feature |
       | remote     | main, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |
 
 
@@ -49,6 +49,6 @@ Feature: git kill: removing the current local feature branch (with open changes)
       | local      | main, dead-feature, feature |
       | remote     | main, feature               |
     And I have the following commits
-      | BRANCH       | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH       | LOCATION         | MESSAGE         | FILE NAME        |
       | feature      | local and remote | good commit     | good_file        |
       | dead-feature | local            | dead-end commit | unfortunate_file |

--- a/features/git-kill/current_branch/local_feature_branch_without_open_changes.feature
+++ b/features/git-kill/current_branch/local_feature_branch_without_open_changes.feature
@@ -26,7 +26,7 @@ Feature: git kill: removing the current local feature branch (without open chang
       | local      | main, feature |
       | remote     | main, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |
 
 
@@ -42,6 +42,6 @@ Feature: git kill: removing the current local feature branch (without open chang
       | local      | main, dead-feature, feature |
       | remote     | main, feature               |
     And I have the following commits
-      | BRANCH       | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH       | LOCATION         | MESSAGE         | FILE NAME        |
       | feature      | local and remote | good commit     | good_file        |
       | dead-feature | local            | dead-end commit | unfortunate_file |

--- a/features/git-kill/current_branch/main_branch_with_open_changes.feature
+++ b/features/git-kill/current_branch/main_branch_with_open_changes.feature
@@ -25,5 +25,5 @@ Feature: git kill: don't remove the main branch (with open changes)
       | local      | main, feature |
       | remote     | main, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |

--- a/features/git-kill/current_branch/non_feature_branch_with_open_changes.feature
+++ b/features/git-kill/current_branch/non_feature_branch_with_open_changes.feature
@@ -27,6 +27,6 @@ Feature: git kill: don't remove non-feature branches (with open changes)
       | local      | main, qa, feature |
       | remote     | main, qa, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |
       | qa      | local and remote | qa commit   | qa_file   |

--- a/features/git-kill/current_branch/non_feature_branch_without_open_changes.feature
+++ b/features/git-kill/current_branch/non_feature_branch_without_open_changes.feature
@@ -23,6 +23,6 @@ Feature: git kill: don't remove non-feature branches (without open changes)
       | local      | main, qa, feature |
       | remote     | main, qa, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |
       | qa      | local and remote | qa commit   | qa_file   |

--- a/features/git-kill/supplied_branch/feature_branch_with_open_changes.feature
+++ b/features/git-kill/supplied_branch/feature_branch_with_open_changes.feature
@@ -30,7 +30,7 @@ Feature: git kill: removes the given feature branch (with open changes)
       | local      | main, feature |
       | remote     | main, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                              | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                              | FILE NAME        |
       | main    | local and remote | conflicting with uncommitted changes | conflicting_file |
       | feature | local and remote | good commit                          | good_file        |
 
@@ -48,7 +48,7 @@ Feature: git kill: removes the given feature branch (with open changes)
       | local      | main, dead-feature, feature |
       | remote     | main, dead-feature, feature |
     And I have the following commits
-      | BRANCH       | LOCATION         | MESSAGE                              | FILES            |
+      | BRANCH       | LOCATION         | MESSAGE                              | FILE NAME        |
       | main         | local and remote | conflicting with uncommitted changes | conflicting_file |
       | feature      | local and remote | good commit                          | good_file        |
       | dead-feature | local and remote | dead-end commit                      | unfortunate_file |

--- a/features/git-kill/supplied_branch/feature_branch_without_open_changes.feature
+++ b/features/git-kill/supplied_branch/feature_branch_without_open_changes.feature
@@ -25,7 +25,7 @@ Feature: git kill: removes the given feature branch (without open changes)
       | local      | main, feature |
       | remote     | main, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |
 
 
@@ -41,6 +41,6 @@ Feature: git kill: removes the given feature branch (without open changes)
       | local      | main, dead-feature, feature |
       | remote     | main, dead-feature, feature |
     And I have the following commits
-      | BRANCH       | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH       | LOCATION         | MESSAGE         | FILE NAME        |
       | feature      | local and remote | good commit     | good_file        |
       | dead-feature | local and remote | dead-end commit | unfortunate_file |

--- a/features/git-kill/supplied_branch/main_branch_with_open_changes.feature
+++ b/features/git-kill/supplied_branch/main_branch_with_open_changes.feature
@@ -21,6 +21,6 @@ Feature: git kill: don't remove the main branch (with open changes)
       | local      | main, feature |
       | remote     | main, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |
       | main    | local and remote | main commit | main_file |

--- a/features/git-kill/supplied_branch/main_branch_without_open_changes.feature
+++ b/features/git-kill/supplied_branch/main_branch_without_open_changes.feature
@@ -19,6 +19,6 @@ Feature: git kill: don't remove the main branch (with open changes)
       | local      | main, feature |
       | remote     | main, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |
       | main    | local and remote | main commit | main_file |

--- a/features/git-kill/supplied_branch/non_feature_branch_with_open_changes.feature
+++ b/features/git-kill/supplied_branch/non_feature_branch_with_open_changes.feature
@@ -25,6 +25,6 @@ Feature: git kill: don't remove a given non-feature branch (with open changes)
       | local      | main, qa, feature |
       | remote     | main, qa, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | qa      | local and remote | qa commit   | qa_file   |
       | feature | local and remote | good commit | good_file |

--- a/features/git-kill/supplied_branch/non_feature_branch_without_open_changes.feature
+++ b/features/git-kill/supplied_branch/non_feature_branch_without_open_changes.feature
@@ -23,6 +23,6 @@ Feature: git kill: don't remove a given non-feature branch (without open changes
       | local      | main, qa, feature |
       | remote     | main, qa, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | qa      | local and remote | qa commit   | qa_file   |
       | feature | local and remote | good commit | good_file |

--- a/features/git-kill/supplied_branch/on_the_supplied_feature_branch_with_open_changes.feature
+++ b/features/git-kill/supplied_branch/on_the_supplied_feature_branch_with_open_changes.feature
@@ -32,7 +32,7 @@ Feature: git kill: removes the given feature branch when on it (with open change
       | local      | main, feature |
       | remote     | main, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |
 
 
@@ -52,6 +52,6 @@ Feature: git kill: removes the given feature branch when on it (with open change
       | local      | main, dead-feature, feature |
       | remote     | main, dead-feature, feature |
     And I have the following commits
-      | BRANCH       | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH       | LOCATION         | MESSAGE         | FILE NAME        |
       | feature      | local and remote | good commit     | good_file        |
       | dead-feature | local and remote | dead-end commit | unfortunate_file |

--- a/features/git-kill/supplied_branch/on_the_supplied_feature_branch_without_open_changes.feature
+++ b/features/git-kill/supplied_branch/on_the_supplied_feature_branch_without_open_changes.feature
@@ -26,7 +26,7 @@ Feature: git kill: removes the given feature branch when on it (without open cha
       | local      | main, feature |
       | remote     | main, feature |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILES     |
+      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
       | feature | local and remote | good commit | good_file |
 
 
@@ -43,7 +43,7 @@ Feature: git kill: removes the given feature branch when on it (without open cha
       | local      | main, dead-feature, feature |
       | remote     | main, dead-feature, feature |
     And I have the following commits
-      | BRANCH       | LOCATION         | MESSAGE         | FILES            |
+      | BRANCH       | LOCATION         | MESSAGE         | FILE NAME        |
       | feature      | local and remote | good commit     | good_file        |
       | dead-feature | local and remote | dead-end commit | unfortunate_file |
 

--- a/features/git-ship/current_branch/empty_commit_message.feature
+++ b/features/git-ship/current_branch/empty_commit_message.feature
@@ -32,7 +32,7 @@ Feature: git ship: aborting the shipping process by entering an empty commit mes
     And I get the error "Aborting ship due to empty commit message"
     And I am still on the "feature" branch
     And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE        | FILES        |
+      | BRANCH  | LOCATION | MESSAGE        | FILE NAME    |
       | feature | local    | feature commit | feature_file |
     And I still have the following committed files
       | BRANCH  | FILES        | CONTENT         |

--- a/features/git-ship/current_branch/merge_main_branch_conflict.feature
+++ b/features/git-ship/current_branch/merge_main_branch_conflict.feature
@@ -39,7 +39,7 @@ Feature: git ship: resolving conflicts between feature and main branch
     And I am still on the "feature" branch
     And there is no merge in progress
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                    | FILE NAME        |
       | main    | local and remote | conflicting main commit    | conflicting_file |
       | feature | local            | conflicting feature commit | conflicting_file |
     And I still have the following committed files
@@ -63,7 +63,7 @@ Feature: git ship: resolving conflicts between feature and main branch
     And I end up on the "main" branch
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE                 | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                 | FILE NAME        |
       | main   | local and remote | conflicting main commit | conflicting_file |
       |        |                  | feature done            | conflicting_file |
     And now I have the following committed files
@@ -85,7 +85,7 @@ Feature: git ship: resolving conflicts between feature and main branch
     And I end up on the "main" branch
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE                 | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                 | FILE NAME        |
       | main   | local and remote | conflicting main commit | conflicting_file |
       |        |                  | feature done            | conflicting_file |
     And now I have the following committed files

--- a/features/git-ship/current_branch/on_feature_branch_without_open_changes.feature
+++ b/features/git-ship/current_branch/on_feature_branch_without_open_changes.feature
@@ -28,7 +28,7 @@ Feature: git ship: shipping the current feature branch
     And there are no more feature branches
     And there are no open changes
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES        |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME    |
       | main   | local and remote | feature done | feature_file |
     And now I have the following committed files
       | BRANCH | FILES        |
@@ -60,7 +60,7 @@ Feature: git ship: shipping the current feature branch
     And there are no more feature branches
     And there are no open changes
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES        |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME    |
       | main   | local and remote | feature done | feature_file |
     And now I have the following committed files
       | BRANCH | FILES        |

--- a/features/git-ship/current_branch/pull_feature_branch_conflict.feature
+++ b/features/git-ship/current_branch/pull_feature_branch_conflict.feature
@@ -36,7 +36,7 @@ Feature: git ship: resolving feature branch conflicts when shipping the current 
     And I am still on the "feature" branch
     And there is no merge in progress
     And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
       | feature | local    | local conflicting commit  | conflicting_file |
       |         | remote   | remote conflicting commit | conflicting_file |
     And I still have the following committed files
@@ -60,7 +60,7 @@ Feature: git ship: resolving feature branch conflicts when shipping the current 
     And I end up on the "main" branch
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES            |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME        |
       | main   | local and remote | feature done | conflicting_file |
     And now I have the following committed files
       | BRANCH | FILES            |
@@ -82,7 +82,7 @@ Feature: git ship: resolving feature branch conflicts when shipping the current 
     And I end up on the "main" branch
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES            |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME        |
       | main   | local and remote | feature done | conflicting_file |
     And now I have the following committed files
       | BRANCH | FILES            |

--- a/features/git-ship/current_branch/pull_main_branch_conflict.feature
+++ b/features/git-ship/current_branch/pull_main_branch_conflict.feature
@@ -34,7 +34,7 @@ Feature: git ship: resolving conflicts while updating the main branch
     And I am still on the "feature" branch
     And there is no rebase in progress
     And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
       | main    | remote   | conflicting remote commit | conflicting_file |
       |         | local    | conflicting local commit  | conflicting_file |
       | feature | local    | feature commit            | feature_file     |
@@ -63,7 +63,7 @@ Feature: git ship: resolving conflicts while updating the main branch
     And I end up on the "main" branch
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
       |        |                  | feature done              | feature_file     |
@@ -90,7 +90,7 @@ Feature: git ship: resolving conflicts while updating the main branch
     And I end up on the "main" branch
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
       |        |                  | feature done              | feature_file     |

--- a/features/git-ship/supplied_branch/empty_commit_message_with_conflicting_changes.feature
+++ b/features/git-ship/supplied_branch/empty_commit_message_with_conflicting_changes.feature
@@ -37,7 +37,7 @@ Feature: git ship: abort shipping the given feature branch by entering an empty 
     And I am still on the "other_feature" branch
     And I still have an uncommitted file with name: "main_file" and content: "conflicting content"
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE        | FILES        |
+      | BRANCH  | LOCATION         | MESSAGE        | FILE NAME    |
       | main    | local and remote | main commit    | main_file    |
       | feature | local            | feature commit | feature_file |
     And I still have the following committed files

--- a/features/git-ship/supplied_branch/empty_commit_message_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/empty_commit_message_with_open_changes.feature
@@ -35,7 +35,7 @@ Feature: git ship: abort shipping the given feature branch by entering an empty 
     And I am still on the "other_feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE        | FILES        |
+      | BRANCH  | LOCATION | MESSAGE        | FILE NAME    |
       | feature | local    | feature commit | feature_file |
     And I still have the following committed files
       | BRANCH  | FILES        | CONTENT         |

--- a/features/git-ship/supplied_branch/empty_commit_message_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/empty_commit_message_without_open_changes.feature
@@ -31,7 +31,7 @@ Feature: git ship: abort shipping the given feature branch by entering an empty 
     And I get the error "Aborting ship due to empty commit message"
     And I am still on the "other_feature" branch
     And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE        | FILES        |
+      | BRANCH  | LOCATION | MESSAGE        | FILE NAME    |
       | feature | local    | feature commit | feature_file |
     And I still have the following committed files
       | BRANCH  | FILES        | CONTENT         |

--- a/features/git-ship/supplied_branch/merge_main_branch_conflict_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/merge_main_branch_conflict_with_open_changes.feature
@@ -43,7 +43,7 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no merge in progress
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                    | FILE NAME        |
       | main    | local and remote | conflicting main commit    | conflicting_file |
       | feature | local            | conflicting feature commit | conflicting_file |
     And I still have the following committed files
@@ -70,7 +70,7 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE                 | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                 | FILE NAME        |
       | main   | local and remote | conflicting main commit | conflicting_file |
       |        |                  | feature done            | conflicting_file |
     And now I have the following committed files
@@ -95,7 +95,7 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE                 | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                 | FILE NAME        |
       | main   | local and remote | conflicting main commit | conflicting_file |
       |        |                  | feature done            | conflicting_file |
     And now I have the following committed files

--- a/features/git-ship/supplied_branch/merge_main_branch_conflict_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/merge_main_branch_conflict_without_open_changes.feature
@@ -37,7 +37,7 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
     And I end up on the "other_feature" branch
     And there is no merge in progress
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                    | FILE NAME        |
       | main    | local and remote | conflicting main commit    | conflicting_file |
       | feature | local            | conflicting feature commit | conflicting_file |
     And I still have the following committed files
@@ -62,7 +62,7 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
     And I end up on the "other_feature" branch
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE                 | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                 | FILE NAME        |
       | main   | local and remote | conflicting main commit | conflicting_file |
       |        |                  | feature done            | conflicting_file |
     And now I have the following committed files
@@ -85,7 +85,7 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
     And I end up on the "other_feature" branch
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE                 | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                 | FILE NAME        |
       | main   | local and remote | conflicting main commit | conflicting_file |
       |        |                  | feature done            | conflicting_file |
     And now I have the following committed files

--- a/features/git-ship/supplied_branch/no_conflicts_with_conflicting_changes.feature
+++ b/features/git-ship/supplied_branch/no_conflicts_with_conflicting_changes.feature
@@ -36,7 +36,7 @@ Feature: git ship: shipping the supplied feature branch (with conflicting change
     And I still have an uncommitted file with name: "main_file" and content: "conflicting content"
     And there is no "feature" branch
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES        |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME    |
       | main   | local and remote | main commit  | main_file    |
       | main   | local and remote | feature done | feature_file |
     And now I have the following committed files
@@ -73,7 +73,7 @@ Feature: git ship: shipping the supplied feature branch (with conflicting change
     And I still have an uncommitted file with name: "feature_file" and content: "conflicting content"
     And there is no "feature" branch
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES        |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME    |
       | main   | local and remote | feature done | feature_file |
     And now I have the following committed files
       | BRANCH | FILES        |

--- a/features/git-ship/supplied_branch/no_conflicts_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/no_conflicts_with_open_changes.feature
@@ -32,7 +32,7 @@ Feature: git ship: shipping the supplied feature branch (with open changes)
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "feature" branch
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES        |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME    |
       | main   | local and remote | feature done | feature_file |
     And now I have the following committed files
       | BRANCH | FILES        |
@@ -68,7 +68,7 @@ Feature: git ship: shipping the supplied feature branch (with open changes)
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "feature" branch
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES        |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME    |
       | main   | local and remote | feature done | feature_file |
     And now I have the following committed files
       | BRANCH | FILES        |

--- a/features/git-ship/supplied_branch/no_conflicts_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/no_conflicts_without_open_changes.feature
@@ -28,7 +28,7 @@ Feature: git ship: shipping the supplied feature branch (without open changes)
     And I end up on the "other_feature" branch
     And there is no "feature" branch
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES        |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME    |
       | main   | local and remote | feature done | feature_file |
     And now I have the following committed files
       | BRANCH | FILES        |
@@ -60,7 +60,7 @@ Feature: git ship: shipping the supplied feature branch (without open changes)
     And I end up on the "other_feature" branch
     And there is no "feature" branch
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES        |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME    |
       | main   | local and remote | feature done | feature_file |
     And now I have the following committed files
       | BRANCH | FILES        |

--- a/features/git-ship/supplied_branch/pull_feature_branch_conflict_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_feature_branch_conflict_with_open_changes.feature
@@ -41,7 +41,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no merge in progress
     And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
       | feature | local    | local conflicting commit  | conflicting_file |
       |         | remote   | remote conflicting commit | conflicting_file |
     And I still have the following committed files
@@ -68,7 +68,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES            |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME        |
       | main   | local and remote | feature done | conflicting_file |
     And now I have the following committed files
       | BRANCH | FILES            |
@@ -93,7 +93,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES            |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME        |
       | main   | local and remote | feature done | conflicting_file |
     And now I have the following committed files
       | BRANCH | FILES            |

--- a/features/git-ship/supplied_branch/pull_feature_branch_conflict_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_feature_branch_conflict_without_open_changes.feature
@@ -35,7 +35,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
     And I end up on the "other_feature" branch
     And there is no merge in progress
     And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
       | feature | local    | local conflicting commit  | conflicting_file |
       |         | remote   | remote conflicting commit | conflicting_file |
     And I still have the following committed files
@@ -60,7 +60,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
     And I end up on the "other_feature" branch
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES            |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME        |
       | main   | local and remote | feature done | conflicting_file |
     And now I have the following committed files
       | BRANCH | FILES            |
@@ -83,7 +83,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
     And I end up on the "other_feature" branch
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE      | FILES            |
+      | BRANCH | LOCATION         | MESSAGE      | FILE NAME        |
       | main   | local and remote | feature done | conflicting_file |
     And now I have the following committed files
       | BRANCH | FILES            |

--- a/features/git-ship/supplied_branch/pull_main_branch_conflict_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_main_branch_conflict_with_open_changes.feature
@@ -38,7 +38,7 @@ Feature: git ship: resolving main branch updates when shipping a given feature b
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no rebase in progress
     And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
       | main    | remote   | conflicting remote commit | conflicting_file |
       |         | local    | conflicting local commit  | conflicting_file |
       | feature | local    | feature commit            | feature_file     |
@@ -70,7 +70,7 @@ Feature: git ship: resolving main branch updates when shipping a given feature b
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
       |        |                  | feature done              | feature_file     |
@@ -100,7 +100,7 @@ Feature: git ship: resolving main branch updates when shipping a given feature b
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
       |        |                  | feature done              | feature_file     |

--- a/features/git-ship/supplied_branch/pull_main_branch_conflict_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_main_branch_conflict_without_open_changes.feature
@@ -32,7 +32,7 @@ Feature: git ship: resolving conflicting main branch updates when shipping a giv
     And I am still on the "other_feature" branch
     And there is no rebase in progress
     And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
       | main    | remote   | conflicting remote commit | conflicting_file |
       |         | local    | conflicting local commit  | conflicting_file |
       | feature | local    | feature commit            | feature_file     |
@@ -62,7 +62,7 @@ Feature: git ship: resolving conflicting main branch updates when shipping a giv
     And I end up on the "other_feature" branch
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
       |        |                  | feature done              | feature_file     |
@@ -90,7 +90,7 @@ Feature: git ship: resolving conflicting main branch updates when shipping a giv
     And I end up on the "other_feature" branch
     And there is no "feature" branch
     And I still have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
       |        |                  | feature done              | feature_file     |

--- a/features/git-sync-fork/feature_branch/no_conflicts_with_open_changes.feature
+++ b/features/git-sync-fork/feature_branch/no_conflicts_with_open_changes.feature
@@ -24,7 +24,7 @@ Feature: git-sync-fork on a feature branch with open changes
     And I am still on the "feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I have the following commits
-      | BRANCH | LOCATION                    | MESSAGE         | FILES         |
+      | BRANCH | LOCATION                    | MESSAGE         | FILE NAME     |
       | main   | local, remote, and upstream | upstream commit | upstream_file |
     And now I have the following committed files
       | BRANCH | FILES         |

--- a/features/git-sync-fork/feature_branch/no_conflicts_without_open_changes.feature
+++ b/features/git-sync-fork/feature_branch/no_conflicts_without_open_changes.feature
@@ -20,7 +20,7 @@ Feature: git-sync-fork on a feature branch without open changes
       | main    | git checkout feature     |
     And I am still on the "feature" branch
     And I have the following commits
-      | BRANCH | LOCATION                    | MESSAGE         | FILES         |
+      | BRANCH | LOCATION                    | MESSAGE         | FILE NAME     |
       | main   | local, remote, and upstream | upstream commit | upstream_file |
     And now I have the following committed files
       | BRANCH | FILES         |

--- a/features/git-sync-fork/main_branch/no_conflicts_with_open_changes.feature
+++ b/features/git-sync-fork/main_branch/no_conflicts_with_open_changes.feature
@@ -21,7 +21,7 @@ Feature: git-sync-fork on the main branch with open changes
     And I am still on the "main" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I have the following commits
-      | BRANCH | LOCATION                    | MESSAGE         | FILES         |
+      | BRANCH | LOCATION                    | MESSAGE         | FILE NAME     |
       | main   | local, remote, and upstream | upstream commit | upstream_file |
     And now I have the following committed files
       | BRANCH | FILES         |

--- a/features/git-sync-fork/main_branch/no_conflicts_without_open_changes.feature
+++ b/features/git-sync-fork/main_branch/no_conflicts_without_open_changes.feature
@@ -17,7 +17,7 @@ Feature: git-sync-fork on the main branch without open changes
       | main   | git push                 |
     And I am still on the "main" branch
     And I have the following commits
-      | BRANCH | LOCATION                    | MESSAGE         | FILES         |
+      | BRANCH | LOCATION                    | MESSAGE         | FILE NAME     |
       | main   | local, remote, and upstream | upstream commit | upstream_file |
     And now I have the following committed files
       | BRANCH | FILES         |

--- a/features/git-sync-fork/main_branch/rebase_upstream_conflict_with_open_changes.feature
+++ b/features/git-sync-fork/main_branch/rebase_upstream_conflict_with_open_changes.feature
@@ -32,7 +32,7 @@ Feature: git-sync-fork: handling rebase conflicts between main branch and its re
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no rebase in progress
     And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE         | FILES            |
+      | BRANCH | LOCATION | MESSAGE         | FILE NAME        |
       | main   | upstream | upstream commit | conflicting_file |
       |        | local    | local commit    | conflicting_file |
     And I still have the following committed files
@@ -51,7 +51,7 @@ Feature: git-sync-fork: handling rebase conflicts between main branch and its re
     And I end up on the "main" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I still have the following commits
-      | BRANCH | LOCATION                    | MESSAGE         | FILES            |
+      | BRANCH | LOCATION                    | MESSAGE         | FILE NAME        |
       | main   | local, remote, and upstream | upstream commit | conflicting_file |
       | main   | local, remote               | local commit    | conflicting_file |
     And now I have the following committed files
@@ -69,7 +69,7 @@ Feature: git-sync-fork: handling rebase conflicts between main branch and its re
     And I end up on the "main" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I still have the following commits
-      | BRANCH | LOCATION                    | MESSAGE         | FILES            |
+      | BRANCH | LOCATION                    | MESSAGE         | FILE NAME        |
       | main   | local, remote, and upstream | upstream commit | conflicting_file |
       | main   | local, remote               | local commit    | conflicting_file |
     And now I have the following committed files

--- a/features/git-sync-fork/main_branch/rebase_upstream_conflict_without_open_changes.feature
+++ b/features/git-sync-fork/main_branch/rebase_upstream_conflict_without_open_changes.feature
@@ -26,7 +26,7 @@ Feature: git-sync-fork: handling rebase conflicts between main branch and its re
     And I end up on the "main" branch
     And there is no rebase in progress
     And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE         | FILES            |
+      | BRANCH | LOCATION | MESSAGE         | FILE NAME        |
       | main   | upstream | upstream commit | conflicting_file |
       |        | local    | local commit    | conflicting_file |
     And I still have the following committed files
@@ -43,7 +43,7 @@ Feature: git-sync-fork: handling rebase conflicts between main branch and its re
       | main   | git push              |
     And I end up on the "main" branch
     And I still have the following commits
-      | BRANCH | LOCATION                    | MESSAGE         | FILES            |
+      | BRANCH | LOCATION                    | MESSAGE         | FILE NAME        |
       | main   | local, remote, and upstream | upstream commit | conflicting_file |
       | main   | local, remote               | local commit    | conflicting_file |
     And now I have the following committed files
@@ -59,7 +59,7 @@ Feature: git-sync-fork: handling rebase conflicts between main branch and its re
       | main   | git push |
     And I end up on the "main" branch
     And I still have the following commits
-      | BRANCH | LOCATION                    | MESSAGE         | FILES            |
+      | BRANCH | LOCATION                    | MESSAGE         | FILE NAME        |
       | main   | local, remote, and upstream | upstream commit | conflicting_file |
       | main   | local, remote               | local commit    | conflicting_file |
     And now I have the following committed files

--- a/features/git-sync/feature_branch/deleted_tracking_branch.feature
+++ b/features/git-sync/feature_branch/deleted_tracking_branch.feature
@@ -21,5 +21,5 @@ Feature: git-sync restores deleted tracking branch
       | feature | git push -u origin feature |
     And I am still on the "feature" branch
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE        | FILES        |
+      | BRANCH  | LOCATION         | MESSAGE        | FILE NAME    |
       | feature | local and remote | feature commit | feature_file |

--- a/features/git-sync/feature_branch/merge_main_branch_conflicts/with_tracking_branch_updates/with_open_changes.feature
+++ b/features/git-sync/feature_branch/merge_main_branch_conflicts/with_tracking_branch_updates/with_open_changes.feature
@@ -42,7 +42,7 @@ Feature: Git Sync: handling merge conflicts between feature and main branch when
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no merge in progress
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                    | FILE NAME        |
       | main    | local and remote | conflicting main commit    | conflicting_file |
       | feature | local            | conflicting feature commit | conflicting_file |
       |         | remote           | feature commit             | feature_file     |
@@ -73,7 +73,7 @@ Feature: Git Sync: handling merge conflicts between feature and main branch when
     And I am still on the "feature" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                                                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                                                    | FILE NAME        |
       | main    | local and remote | conflicting main commit                                    | conflicting_file |
       | feature | local and remote | Merge branch 'main' into feature                           |                  |
       |         |                  | conflicting main commit                                    | conflicting_file |
@@ -97,7 +97,7 @@ Feature: Git Sync: handling merge conflicts between feature and main branch when
     And I am still on the "feature" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                                                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                                                    | FILE NAME        |
       | main    | local and remote | conflicting main commit                                    | conflicting_file |
       | feature | local and remote | Merge branch 'main' into feature                           |                  |
       |         |                  | conflicting main commit                                    | conflicting_file |

--- a/features/git-sync/feature_branch/merge_main_branch_conflicts/with_tracking_branch_updates/without_open_changes.feature
+++ b/features/git-sync/feature_branch/merge_main_branch_conflicts/with_tracking_branch_updates/without_open_changes.feature
@@ -36,7 +36,7 @@ Feature: Git Sync: handling merge conflicts between feature and main branch when
     And I am still on the "feature" branch
     And there is no merge in progress
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                    | FILE NAME        |
       | main    | local and remote | conflicting main commit    | conflicting_file |
       | feature | local            | conflicting feature commit | conflicting_file |
       |         | remote           | feature commit             | feature_file     |
@@ -63,7 +63,7 @@ Feature: Git Sync: handling merge conflicts between feature and main branch when
       | feature | git push             |
     And I am still on the "feature" branch
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                                                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                                                    | FILE NAME        |
       | main    | local and remote | conflicting main commit                                    | conflicting_file |
       | feature | local and remote | Merge branch 'main' into feature                           |                  |
       |         |                  | conflicting main commit                                    | conflicting_file |
@@ -85,7 +85,7 @@ Feature: Git Sync: handling merge conflicts between feature and main branch when
       | feature | git push |
     And I am still on the "feature" branch
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                                                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                                                    | FILE NAME        |
       | main    | local and remote | conflicting main commit                                    | conflicting_file |
       | feature | local and remote | Merge branch 'main' into feature                           |                  |
       |         |                  | conflicting main commit                                    | conflicting_file |

--- a/features/git-sync/feature_branch/merge_main_branch_conflicts/without_tracking_branch_updates/with_open_changes.feature
+++ b/features/git-sync/feature_branch/merge_main_branch_conflicts/without_tracking_branch_updates/with_open_changes.feature
@@ -40,7 +40,7 @@ Feature: Git Sync: handling merge conflicts between feature and main branch when
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no merge in progress
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                    | FILE NAME        |
       | main    | local and remote | conflicting main commit    | conflicting_file |
       | feature | local            | conflicting feature commit | conflicting_file |
     And I still have the following committed files
@@ -70,7 +70,7 @@ Feature: Git Sync: handling merge conflicts between feature and main branch when
     And I am still on the "feature" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                          | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                          | FILE NAME        |
       | main    | local and remote | conflicting main commit          | conflicting_file |
       | feature | local and remote | Merge branch 'main' into feature |                  |
       |         |                  | conflicting main commit          | conflicting_file |
@@ -91,7 +91,7 @@ Feature: Git Sync: handling merge conflicts between feature and main branch when
     And I am still on the "feature" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                          | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                          | FILE NAME        |
       | main    | local and remote | conflicting main commit          | conflicting_file |
       | feature | local and remote | Merge branch 'main' into feature |                  |
       |         |                  | conflicting main commit          | conflicting_file |

--- a/features/git-sync/feature_branch/merge_main_branch_conflicts/without_tracking_branch_updates/without_open_changes.feature
+++ b/features/git-sync/feature_branch/merge_main_branch_conflicts/without_tracking_branch_updates/without_open_changes.feature
@@ -34,7 +34,7 @@ Feature: Git Sync: handling merge conflicts between feature and main branch when
     And I am still on the "feature" branch
     And there is no merge in progress
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                  | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                  | FILE NAME        |
       | main    | local and remote | conflicting main commit  | conflicting_file |
       | feature | local            | conflicting local commit | conflicting_file |
     And I still have the following committed files
@@ -60,7 +60,7 @@ Feature: Git Sync: handling merge conflicts between feature and main branch when
       | feature | git push             |
     And I am still on the "feature" branch
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                          | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                          | FILE NAME        |
       | main    | local and remote | conflicting main commit          | conflicting_file |
       | feature | local and remote | Merge branch 'main' into feature |                  |
       |         |                  | conflicting main commit          | conflicting_file |
@@ -79,7 +79,7 @@ Feature: Git Sync: handling merge conflicts between feature and main branch when
       | feature | git push |
     And I am still on the "feature" branch
     And I still have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                          | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                          | FILE NAME        |
       | main    | local and remote | conflicting main commit          | conflicting_file |
       | feature | local and remote | Merge branch 'main' into feature |                  |
       |         |                  | conflicting main commit          | conflicting_file |

--- a/features/git-sync/feature_branch/no_conflicts_with_open_changes.feature
+++ b/features/git-sync/feature_branch/no_conflicts_with_open_changes.feature
@@ -25,7 +25,7 @@ Feature: Git Sync: syncing a feature branch with open changes
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And all branches are now synchronized
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                          | FILES              |
+      | BRANCH  | LOCATION         | MESSAGE                          | FILE NAME          |
       | main    | local and remote | local main commit                | local_main_file    |
       |         |                  | remote main commit               | remote_main_file   |
       | feature | local and remote | Merge branch 'main' into feature |                    |
@@ -64,7 +64,7 @@ Feature: Git Sync: syncing a feature branch with open changes
     And I am still on the "feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                                                    | FILES               |
+      | BRANCH  | LOCATION         | MESSAGE                                                    | FILE NAME           |
       | main    | local and remote | local main commit                                          | local_main_file     |
       |         |                  | remote main commit                                         | remote_main_file    |
       | feature | local and remote | Merge branch 'main' into feature                           |                     |

--- a/features/git-sync/feature_branch/no_conflicts_without_open_changes.feature
+++ b/features/git-sync/feature_branch/no_conflicts_without_open_changes.feature
@@ -21,7 +21,7 @@ Feature: Git Sync: syncing a feature branch without open changes
     And I am still on the "feature" branch
     And all branches are now synchronized
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                          | FILES              |
+      | BRANCH  | LOCATION         | MESSAGE                          | FILE NAME          |
       | main    | local and remote | local main commit                | local_main_file    |
       |         |                  | remote main commit               | remote_main_file   |
       | feature | local and remote | Merge branch 'main' into feature |                    |
@@ -56,7 +56,7 @@ Feature: Git Sync: syncing a feature branch without open changes
       | feature | git push                           |
     And I am still on the "feature" branch
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                                                    | FILES               |
+      | BRANCH  | LOCATION         | MESSAGE                                                    | FILE NAME           |
       | main    | local and remote | local main commit                                          | local_main_file     |
       |         |                  | remote main commit                                         | remote_main_file    |
       | feature | local and remote | Merge branch 'main' into feature                           |                     |

--- a/features/git-sync/feature_branch/pull_feature_branch_conflict_with_open_changes.feature
+++ b/features/git-sync/feature_branch/pull_feature_branch_conflict_with_open_changes.feature
@@ -38,7 +38,7 @@ Feature: Git Sync: handling conflicting remote feature branch updates when synci
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no merge in progress
     And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
       | feature | local    | local conflicting commit  | conflicting_file |
       |         | remote   | remote conflicting commit | conflicting_file |
     And I still have the following committed files
@@ -67,7 +67,7 @@ Feature: Git Sync: handling conflicting remote feature branch updates when synci
     And I am still on the "feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                                                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                                                    | FILE NAME        |
       | feature | local and remote | Merge remote-tracking branch 'origin/feature' into feature |                  |
       |         |                  | remote conflicting commit                                  | conflicting_file |
       |         |                  | local conflicting commit                                   | conflicting_file |
@@ -87,7 +87,7 @@ Feature: Git Sync: handling conflicting remote feature branch updates when synci
     And I am still on the "feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                                                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                                                    | FILE NAME        |
       | feature | local and remote | Merge remote-tracking branch 'origin/feature' into feature |                  |
       |         |                  | remote conflicting commit                                  | conflicting_file |
       |         |                  | local conflicting commit                                   | conflicting_file |

--- a/features/git-sync/feature_branch/pull_feature_branch_conflict_without_open_changes.feature
+++ b/features/git-sync/feature_branch/pull_feature_branch_conflict_without_open_changes.feature
@@ -32,7 +32,7 @@ Feature: Git Sync: handling conflicting remote feature branch updates when synci
     And I am still on the "feature" branch
     And there is no merge in progress
     And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
       | feature | local    | local conflicting commit  | conflicting_file |
       |         | remote   | remote conflicting commit | conflicting_file |
     And I still have the following committed files
@@ -57,7 +57,7 @@ Feature: Git Sync: handling conflicting remote feature branch updates when synci
       | feature | git push                 |
     And I am still on the "feature" branch
     And now I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                                                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                                                    | FILE NAME        |
       | feature | local and remote | Merge remote-tracking branch 'origin/feature' into feature |                  |
       |         |                  | remote conflicting commit                                  | conflicting_file |
       |         |                  | local conflicting commit                                   | conflicting_file |
@@ -75,7 +75,7 @@ Feature: Git Sync: handling conflicting remote feature branch updates when synci
       | feature | git push                 |
     And I am still on the "feature" branch
     And now I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                                                    | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                                                    | FILE NAME        |
       | feature | local and remote | Merge remote-tracking branch 'origin/feature' into feature |                  |
       |         |                  | remote conflicting commit                                  | conflicting_file |
       |         |                  | local conflicting commit                                   | conflicting_file |

--- a/features/git-sync/feature_branch/pull_main_branch_conflict_with_open_changes.feature
+++ b/features/git-sync/feature_branch/pull_main_branch_conflict_with_open_changes.feature
@@ -34,7 +34,7 @@ Feature: Git Sync: handling conflicting remote main branch updates when syncing 
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no rebase in progress
     And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
       | main   | remote   | conflicting remote commit | conflicting_file |
       |        | local    | conflicting local commit  | conflicting_file |
     And I still have the following committed files
@@ -65,7 +65,7 @@ Feature: Git Sync: handling conflicting remote main branch updates when syncing 
     And I am still on the "feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                   | FILE NAME        |
       | main    | local and remote | conflicting remote commit | conflicting_file |
       |         |                  | conflicting local commit  | conflicting_file |
       | feature | local and remote | conflicting remote commit | conflicting_file |
@@ -90,7 +90,7 @@ Feature: Git Sync: handling conflicting remote main branch updates when syncing 
     And I am still on the "feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                   | FILE NAME        |
       | main    | local and remote | conflicting remote commit | conflicting_file |
       |         |                  | conflicting local commit  | conflicting_file |
       | feature | local and remote | conflicting remote commit | conflicting_file |

--- a/features/git-sync/feature_branch/pull_main_branch_conflict_without_open_changes.feature
+++ b/features/git-sync/feature_branch/pull_main_branch_conflict_without_open_changes.feature
@@ -28,7 +28,7 @@ Feature: Git Sync: handling conflicting remote main branch updates when syncing 
     And I am still on the "feature" branch
     And there is no rebase in progress
     And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
       | main   | remote   | conflicting remote commit | conflicting_file |
       |        | local    | conflicting local commit  | conflicting_file |
     And I still have the following committed files
@@ -56,7 +56,7 @@ Feature: Git Sync: handling conflicting remote main branch updates when syncing 
       | feature | git push                           |
     And I am still on the "feature" branch
     And now I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                   | FILE NAME        |
       | main    | local and remote | conflicting remote commit | conflicting_file |
       |         |                  | conflicting local commit  | conflicting_file |
       | feature | local and remote | conflicting remote commit | conflicting_file |
@@ -79,7 +79,7 @@ Feature: Git Sync: handling conflicting remote main branch updates when syncing 
       | feature | git push                           |
     And I am still on the "feature" branch
     And now I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH  | LOCATION         | MESSAGE                   | FILE NAME        |
       | main    | local and remote | conflicting remote commit | conflicting_file |
       |         |                  | conflicting local commit  | conflicting_file |
       | feature | local and remote | conflicting remote commit | conflicting_file |

--- a/features/git-sync/feature_branch/two_collaborators.feature
+++ b/features/git-sync/feature_branch/two_collaborators.feature
@@ -23,8 +23,8 @@ Feature: Git Sync: collaborative feature branch syncing
       | feature | git merge --no-edit main           |
       | feature | git push                           |
     And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE   | FILES   |
-      | feature | local and remote | my commit | my_file |
+      | BRANCH  | LOCATION         | MESSAGE   | FILE NAME |
+      | feature | local and remote | my commit | my_file   |
 
     Given my coworker is on the "feature" branch
     When my coworker runs `git sync`
@@ -38,7 +38,7 @@ Feature: Git Sync: collaborative feature branch syncing
       | feature | git merge --no-edit main           |
       | feature | git push                           |
     And now my coworker has the following commits
-      | BRANCH  | LOCATION         | MESSAGE                                                    | FILES         |
+      | BRANCH  | LOCATION         | MESSAGE                                                    | FILE NAME     |
       | feature | local and remote | Merge remote-tracking branch 'origin/feature' into feature |               |
       | feature |                  | coworker commit                                            | coworker_file |
       | feature |                  | my commit                                                  | my_file       |
@@ -54,7 +54,7 @@ Feature: Git Sync: collaborative feature branch syncing
       | feature | git merge --no-edit origin/feature |
       | feature | git merge --no-edit main           |
     And now I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                                                    | FILES         |
+      | BRANCH  | LOCATION         | MESSAGE                                                    | FILE NAME     |
       | feature | local and remote | Merge remote-tracking branch 'origin/feature' into feature |               |
       | feature |                  | coworker commit                                            | coworker_file |
       | feature |                  | my commit                                                  | my_file       |

--- a/features/git-sync/main_branch/no_conflicts_with_open_changes.feature
+++ b/features/git-sync/main_branch/no_conflicts_with_open_changes.feature
@@ -23,7 +23,7 @@ Feature: Git Sync: syncing the main branch with open changes
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And all branches are now synchronized
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE       | FILES       |
+      | BRANCH | LOCATION         | MESSAGE       | FILE NAME   |
       | main   | local and remote | local commit  | local_file  |
       |        |                  | remote commit | remote_file |
     And now I have the following committed files

--- a/features/git-sync/main_branch/no_conflicts_without_open_changes.feature
+++ b/features/git-sync/main_branch/no_conflicts_without_open_changes.feature
@@ -19,7 +19,7 @@ Feature: Git Sync: syncing the main branch without open changes
     And I am still on the "main" branch
     And all branches are now synchronized
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE       | FILES       |
+      | BRANCH | LOCATION         | MESSAGE       | FILE NAME   |
       | main   | local and remote | local commit  | local_file  |
       |        |                  | remote commit | remote_file |
     And now I have the following committed files

--- a/features/git-sync/main_branch/pull_branch_conflict_with_open_changes.feature
+++ b/features/git-sync/main_branch/pull_branch_conflict_with_open_changes.feature
@@ -31,7 +31,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing the m
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no rebase in progress
     And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
       | main   | remote   | conflicting remote commit | conflicting_file |
       |        | local    | conflicting local commit  | conflicting_file |
     And I still have the following committed files
@@ -60,7 +60,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing the m
     And I am still on the "main" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
@@ -79,7 +79,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing the m
     And I am still on the "main" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files

--- a/features/git-sync/main_branch/pull_branch_conflict_without_open_changes.feature
+++ b/features/git-sync/main_branch/pull_branch_conflict_without_open_changes.feature
@@ -26,7 +26,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing the m
     And I am still on the "main" branch
     And there is no rebase in progress
     And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
       | main   | remote   | conflicting remote commit | conflicting_file |
       |        | local    | conflicting local commit  | conflicting_file |
     And I still have the following committed files
@@ -52,7 +52,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing the m
       | main   | git push --tags       |
     And I am still on the "main" branch
     And now I have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
@@ -69,7 +69,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing the m
       | main   | git push --tags |
     And I am still on the "main" branch
     And now I have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files

--- a/features/git-sync/non_feature_branch/no_conflicts_with_open_changes.feature
+++ b/features/git-sync/non_feature_branch/no_conflicts_with_open_changes.feature
@@ -25,7 +25,7 @@ Feature: Git Sync: syncing a non-feature branch with open changes
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And all branches are now synchronized
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE       | FILES       |
+      | BRANCH | LOCATION         | MESSAGE       | FILE NAME   |
       | qa     | local and remote | local commit  | local_file  |
       |        |                  | remote commit | remote_file |
       | main   | local and remote | main commit   | main_file   |

--- a/features/git-sync/non_feature_branch/no_conflicts_without_open_changes.feature
+++ b/features/git-sync/non_feature_branch/no_conflicts_without_open_changes.feature
@@ -21,7 +21,7 @@ Feature: Git Sync: syncing a non-feature branch without open changes
     And I am still on the "qa" branch
     And all branches are now synchronized
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE       | FILES       |
+      | BRANCH | LOCATION         | MESSAGE       | FILE NAME   |
       | qa     | local and remote | local commit  | local_file  |
       |        |                  | remote commit | remote_file |
       | main   | local and remote | main commit   | main_file   |

--- a/features/git-sync/non_feature_branch/pull_branch_conflict_with_open_changes.feature
+++ b/features/git-sync/non_feature_branch/pull_branch_conflict_with_open_changes.feature
@@ -32,7 +32,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing a non
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no rebase in progress
     And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
       | qa     | remote   | conflicting remote commit | conflicting_file |
       |        | local    | conflicting local commit  | conflicting_file |
     And I still have the following committed files
@@ -61,7 +61,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing a non
     And I am still on the "qa" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | qa     | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
@@ -80,7 +80,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing a non
     And I am still on the "qa" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | qa     | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files

--- a/features/git-sync/non_feature_branch/pull_branch_conflict_without_open_changes.feature
+++ b/features/git-sync/non_feature_branch/pull_branch_conflict_without_open_changes.feature
@@ -26,7 +26,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing a non
     And I am still on the "qa" branch
     And there is no rebase in progress
     And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
       | qa     | remote   | conflicting remote commit | conflicting_file |
       |        | local    | conflicting local commit  | conflicting_file |
     And I still have the following committed files
@@ -51,7 +51,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing a non
       | qa     | git push --tags       |
     And I am still on the "qa" branch
     And now I have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | qa     | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
@@ -68,7 +68,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing a non
       | qa     | git push --tags |
     And I am still on the "qa" branch
     And now I have the following commits
-      | BRANCH | LOCATION         | MESSAGE                   | FILES            |
+      | BRANCH | LOCATION         | MESSAGE                   | FILE NAME        |
       | qa     | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files

--- a/features/support/commit_helpers.rb
+++ b/features/support/commit_helpers.rb
@@ -81,7 +81,7 @@ def commits_for_branch branch_name
     sha, message = commit.split(' ', 2)
 
     unless message == 'Initial commit'
-      { branch: branch_name, message: message, files: committed_files(sha) }
+      { branch: branch_name, message: message, file_name: committed_files(sha) }
     end
   end.compact
 end
@@ -112,7 +112,7 @@ end
 # Returns an array of commit_data
 def normalize_expected_commit_data commit_data
   # Convert file string list into real array
-  commit_data[:files] = Kappamaki.from_sentence commit_data[:files]
+  commit_data[:file_name] = Kappamaki.from_sentence commit_data[:file_name]
 
   # Create individual expected commits for each location provided
   Kappamaki.from_sentence(commit_data.delete(:location)).map do |location|


### PR DESCRIPTION
@charlierudolph @allewun  This creates a more uniform structure for the tables that declare commits and those that verify them.

This opens the path to do #268 later. But I think this change has value on its own already, so let's review it separately.