### PR TITLE
Verify against original commit data

### DIFF
--- a/features/git-extract/pull_main_branch_conflict_with_open_changes.feature
+++ b/features/git-extract/pull_main_branch_conflict_with_open_changes.feature
@@ -40,12 +40,7 @@ Feature: git extract: allows to resolve conflicting remote main branch updates (
     And I end up on the "feature" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "refactor" branch
-    And I have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
-      | main    | remote   | conflicting remote commit | conflicting_file |
-      |         | local    | conflicting local commit  | conflicting_file |
-      | feature | local    | feature commit            | feature_file     |
-      |         |          | refactor commit           | refactor_file    |
+    And I am left with my original commits
     And there is no rebase in progress
 
 

--- a/features/git-extract/pull_main_branch_conflict_without_open_changes.feature
+++ b/features/git-extract/pull_main_branch_conflict_without_open_changes.feature
@@ -32,12 +32,7 @@ Feature: git extract: resolving conflicting remote main branch updates (without 
       | main   | git checkout feature |
     And I end up on the "feature" branch
     And there is no "refactor" branch
-    And I have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
-      | main    | remote   | conflicting remote commit | conflicting_file |
-      |         | local    | conflicting local commit  | conflicting_file |
-      | feature | local    | feature commit            | feature_file     |
-      |         |          | refactor commit           | refactor_file    |
+    And I am left with my original commits
     And there is no rebase in progress
 
 

--- a/features/git-hack/pull_main_branch_conflicts_with_open_changes.feature
+++ b/features/git-hack/pull_main_branch_conflicts_with_open_changes.feature
@@ -38,10 +38,7 @@ Feature: git hack: handling conflicting remote main branch updates (with open ch
     And I end up on the "existing_feature" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no rebase in progress
-    And I have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
-      | main   | remote   | conflicting remote commit | conflicting_file |
-      |        | local    | conflicting local commit  | conflicting_file |
+    And I am left with my original commits
 
 
   @finishes-with-non-empty-stash

--- a/features/git-hack/pull_main_branch_conflicts_without_open_changes.feature
+++ b/features/git-hack/pull_main_branch_conflicts_without_open_changes.feature
@@ -30,10 +30,7 @@ Feature: git hack: handling conflicting remote main branch updates while startin
       | main   | git checkout existing_feature |
     And I end up on the "existing_feature" branch
     And there is no rebase in progress
-    And I have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
-      | main   | remote   | conflicting remote commit | conflicting_file |
-      |        | local    | conflicting local commit  | conflicting_file |
+    And I am left with my original commits
 
 
   Scenario: continuing without resolving conflicts

--- a/features/git-ship/current_branch/pull_feature_branch_conflict.feature
+++ b/features/git-ship/current_branch/pull_feature_branch_conflict.feature
@@ -35,10 +35,7 @@ Feature: git ship: resolving feature branch conflicts when shipping the current 
       | main    | git checkout feature |
     And I am still on the "feature" branch
     And there is no merge in progress
-    And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
-      | feature | local    | local conflicting commit  | conflicting_file |
-      |         | remote   | remote conflicting commit | conflicting_file |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH  | FILES            | CONTENT                   |
       | feature | conflicting_file | local conflicting content |

--- a/features/git-ship/current_branch/pull_main_branch_conflict.feature
+++ b/features/git-ship/current_branch/pull_main_branch_conflict.feature
@@ -33,11 +33,7 @@ Feature: git ship: resolving conflicts while updating the main branch
       | main   | git checkout feature |
     And I am still on the "feature" branch
     And there is no rebase in progress
-    And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
-      | main    | remote   | conflicting remote commit | conflicting_file |
-      |         | local    | conflicting local commit  | conflicting_file |
-      | feature | local    | feature commit            | feature_file     |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH  | FILES            | CONTENT                   |
       | main    | conflicting_file | local conflicting content |

--- a/features/git-ship/supplied_branch/pull_feature_branch_conflict_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_feature_branch_conflict_with_open_changes.feature
@@ -40,10 +40,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
     And I end up on the "other_feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no merge in progress
-    And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
-      | feature | local    | local conflicting commit  | conflicting_file |
-      |         | remote   | remote conflicting commit | conflicting_file |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH  | FILES            | CONTENT                   |
       | feature | conflicting_file | local conflicting content |

--- a/features/git-ship/supplied_branch/pull_feature_branch_conflict_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_feature_branch_conflict_without_open_changes.feature
@@ -34,10 +34,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
       | main    | git checkout other_feature |
     And I end up on the "other_feature" branch
     And there is no merge in progress
-    And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
-      | feature | local    | local conflicting commit  | conflicting_file |
-      |         | remote   | remote conflicting commit | conflicting_file |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH  | FILES            | CONTENT                   |
       | feature | conflicting_file | local conflicting content |

--- a/features/git-ship/supplied_branch/pull_main_branch_conflict_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_main_branch_conflict_with_open_changes.feature
@@ -37,11 +37,7 @@ Feature: git ship: resolving main branch updates when shipping a given feature b
     And I am still on the "other_feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no rebase in progress
-    And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
-      | main    | remote   | conflicting remote commit | conflicting_file |
-      |         | local    | conflicting local commit  | conflicting_file |
-      | feature | local    | feature commit            | feature_file     |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH  | FILES            | CONTENT                   |
       | main    | conflicting_file | local conflicting content |

--- a/features/git-ship/supplied_branch/pull_main_branch_conflict_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_main_branch_conflict_without_open_changes.feature
@@ -31,11 +31,7 @@ Feature: git ship: resolving conflicting main branch updates when shipping a giv
       | main   | git checkout other_feature |
     And I am still on the "other_feature" branch
     And there is no rebase in progress
-    And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
-      | main    | remote   | conflicting remote commit | conflicting_file |
-      |         | local    | conflicting local commit  | conflicting_file |
-      | feature | local    | feature commit            | feature_file     |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH  | FILES            | CONTENT                   |
       | main    | conflicting_file | local conflicting content |

--- a/features/git-sync-fork/main_branch/rebase_upstream_conflict_with_open_changes.feature
+++ b/features/git-sync-fork/main_branch/rebase_upstream_conflict_with_open_changes.feature
@@ -31,10 +31,7 @@ Feature: git-sync-fork: handling rebase conflicts between main branch and its re
     And I end up on the "main" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no rebase in progress
-    And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE         | FILE NAME        |
-      | main   | upstream | upstream commit | conflicting_file |
-      |        | local    | local commit    | conflicting_file |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH | FILES            | CONTENT       |
       | main   | conflicting_file | local content |

--- a/features/git-sync-fork/main_branch/rebase_upstream_conflict_without_open_changes.feature
+++ b/features/git-sync-fork/main_branch/rebase_upstream_conflict_without_open_changes.feature
@@ -25,10 +25,7 @@ Feature: git-sync-fork: handling rebase conflicts between main branch and its re
       | HEAD   | git rebase --abort |
     And I end up on the "main" branch
     And there is no rebase in progress
-    And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE         | FILE NAME        |
-      | main   | upstream | upstream commit | conflicting_file |
-      |        | local    | local commit    | conflicting_file |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH | FILES            | CONTENT       |
       | main   | conflicting_file | local content |

--- a/features/git-sync/feature_branch/pull_feature_branch_conflict_with_open_changes.feature
+++ b/features/git-sync/feature_branch/pull_feature_branch_conflict_with_open_changes.feature
@@ -37,10 +37,7 @@ Feature: Git Sync: handling conflicting remote feature branch updates when synci
     And I am still on the "feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no merge in progress
-    And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
-      | feature | local    | local conflicting commit  | conflicting_file |
-      |         | remote   | remote conflicting commit | conflicting_file |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH  | FILES            | CONTENT                   |
       | feature | conflicting_file | local conflicting content |

--- a/features/git-sync/feature_branch/pull_feature_branch_conflict_without_open_changes.feature
+++ b/features/git-sync/feature_branch/pull_feature_branch_conflict_without_open_changes.feature
@@ -31,10 +31,7 @@ Feature: Git Sync: handling conflicting remote feature branch updates when synci
       | main    | git checkout feature |
     And I am still on the "feature" branch
     And there is no merge in progress
-    And I still have the following commits
-      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        |
-      | feature | local    | local conflicting commit  | conflicting_file |
-      |         | remote   | remote conflicting commit | conflicting_file |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH  | FILES            | CONTENT                   |
       | feature | conflicting_file | local conflicting content |

--- a/features/git-sync/feature_branch/pull_main_branch_conflict_with_open_changes.feature
+++ b/features/git-sync/feature_branch/pull_main_branch_conflict_with_open_changes.feature
@@ -33,10 +33,7 @@ Feature: Git Sync: handling conflicting remote main branch updates when syncing 
     And I am still on the "feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no rebase in progress
-    And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
-      | main   | remote   | conflicting remote commit | conflicting_file |
-      |        | local    | conflicting local commit  | conflicting_file |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH | FILES            | CONTENT                   |
       | main   | conflicting_file | local conflicting content |

--- a/features/git-sync/feature_branch/pull_main_branch_conflict_without_open_changes.feature
+++ b/features/git-sync/feature_branch/pull_main_branch_conflict_without_open_changes.feature
@@ -27,10 +27,7 @@ Feature: Git Sync: handling conflicting remote main branch updates when syncing 
       | main   | git checkout feature |
     And I am still on the "feature" branch
     And there is no rebase in progress
-    And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
-      | main   | remote   | conflicting remote commit | conflicting_file |
-      |        | local    | conflicting local commit  | conflicting_file |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH | FILES            | CONTENT                   |
       | main   | conflicting_file | local conflicting content |

--- a/features/git-sync/main_branch/pull_branch_conflict_with_open_changes.feature
+++ b/features/git-sync/main_branch/pull_branch_conflict_with_open_changes.feature
@@ -30,10 +30,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing the m
     And I am still on the "main" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no rebase in progress
-    And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
-      | main   | remote   | conflicting remote commit | conflicting_file |
-      |        | local    | conflicting local commit  | conflicting_file |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH | FILES            | CONTENT                   |
       | main   | conflicting_file | local conflicting content |

--- a/features/git-sync/main_branch/pull_branch_conflict_without_open_changes.feature
+++ b/features/git-sync/main_branch/pull_branch_conflict_without_open_changes.feature
@@ -25,10 +25,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing the m
       | HEAD   | git rebase --abort |
     And I am still on the "main" branch
     And there is no rebase in progress
-    And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
-      | main   | remote   | conflicting remote commit | conflicting_file |
-      |        | local    | conflicting local commit  | conflicting_file |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH | FILES            | CONTENT                   |
       | main   | conflicting_file | local conflicting content |

--- a/features/git-sync/non_feature_branch/pull_branch_conflict_with_open_changes.feature
+++ b/features/git-sync/non_feature_branch/pull_branch_conflict_with_open_changes.feature
@@ -31,10 +31,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing a non
     And I am still on the "qa" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no rebase in progress
-    And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
-      | qa     | remote   | conflicting remote commit | conflicting_file |
-      |        | local    | conflicting local commit  | conflicting_file |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH | FILES            | CONTENT                   |
       | qa     | conflicting_file | local conflicting content |

--- a/features/git-sync/non_feature_branch/pull_branch_conflict_without_open_changes.feature
+++ b/features/git-sync/non_feature_branch/pull_branch_conflict_without_open_changes.feature
@@ -25,10 +25,7 @@ Feature: Git Sync: handling conflicting remote branch updates when syncing a non
       | HEAD   | git rebase --abort |
     And I am still on the "qa" branch
     And there is no rebase in progress
-    And I still have the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        |
-      | qa     | remote   | conflicting remote commit | conflicting_file |
-      |        | local    | conflicting local commit  | conflicting_file |
+    And I am left with my original commits
     And I still have the following committed files
       | BRANCH | FILES            | CONTENT                   |
       | qa     | conflicting_file | local conflicting content |

--- a/features/step_definitions/commit_steps.rb
+++ b/features/step_definitions/commit_steps.rb
@@ -1,6 +1,7 @@
 Given(/^the following commits? exists? in (my|my coworker's) repository$/) do |who, commits_table|
   path = (who == 'my') ? local_repository_path : coworker_repository_path
   commits_table.map_headers!(&:downcase)
+  @my_original_commits_table = commits_table.clone
   at_path(path) do
     create_commits commits_table.hashes
   end
@@ -14,6 +15,16 @@ Then(/^(?:now )?(I|my coworker) (?:still )?(?:have|has) the following commits$/)
   commits_table.map_headers!(&:downcase)
   at_path(path) do
     verify_commits commits_table.hashes
+  end
+end
+
+
+Then(/^I am left with my original commits$/) do
+  original_hashes = @my_original_commits_table.hashes.each do |hash|
+    hash.delete 'file content'
+  end
+  at_path(local_repository_path) do
+    verify_commits original_hashes
   end
 end
 


### PR DESCRIPTION
@charlierudolph @allewun 

This change dries up the feature specs if the expected commits are identical to the originally defined commits.

Implements #268 