### PR TITLE
git ship: use commit options

### DIFF
--- a/documentation/git-ship.md
+++ b/documentation/git-ship.md
@@ -6,7 +6,7 @@ git-ship - deliver a completed feature branch
 #### SYNOPSIS
 
 ```
-git ship [<branchname>] [-m <message>]
+git ship [<branchname>] [<commit-options>]
 git ship --abort
 git ship --continue
 ```
@@ -31,9 +31,8 @@ Squash merges the current branch, or `<branchname>` if given, into the main bran
     The branch to ship.
     If not provided, uses the current branch.
 
--m <message>
-    The commit message for the squash merge.
-    If not provided, will be prompted for it.
+<commit-options>
+    Options to pass to 'git commit' when commiting the squash merge.
 
 --abort
     Cancel the operation and reset the workspace to a consistent state.

--- a/features/support/run_helpers.rb
+++ b/features/support/run_helpers.rb
@@ -10,7 +10,8 @@ def commands_of_last_run
     \[1m          # bold text
     \[(.*?)\]     # branch name in square brackets
     \s            # space between branch name and Git command
-    (.*?)         # the Git command
+    (.+?)         # the Git command
+    \s*           # any extra whitespace
     \n            # newline at the end
   /x
   @last_run_result.out.scan command_regex

--- a/man/man1/git-ship.1
+++ b/man/man1/git-ship.1
@@ -4,7 +4,7 @@
 git ship \- deliver a completed feature branch
 
 .SH "SYNOPSIS"
-\fIgit ship\fR [<branchname>] [-m <message>]
+\fIgit ship\fR [<branchname>] [<commit-options>]
 .br
 \fIgit ship\fR --abort
 .br
@@ -30,10 +30,8 @@ The branch to ship.
 .br
 If not provided, uses the current branch.
 
-.IP "-m <message>" 4
-The commit message for the squash merge.
-.br
-If not provided, will be prompted for it.
+.IP "<commit-options>" 4
+Options to pass to 'git commit' when commiting the squash merge.
 
 .IP "--abort" 4
 Cancel the operation and reset the workspace to a consistent state.

--- a/src/git-ship
+++ b/src/git-ship
@@ -11,20 +11,8 @@ function error_empty_commit {
   exit_with_error
 }
 
-
-function extract_message {
-  message=''
-
-  while getopts "m:" opt; do
-    case "$opt" in
-    m) message=$OPTARG
-    esac
-  done
-}
-
-
 function preconditions {
-  if [ "$#" -gt 0 ] && [ "$1" != "-m" ]; then
+  if [ "$#" -gt 0 ] && [[ ! "$1" =~ ^- ]]; then
     target_branch_name=$1
     ensure_has_branch "$target_branch_name"
     shift
@@ -34,7 +22,7 @@ function preconditions {
   fi
 
   ensure_is_feature_branch "$target_branch_name" "Only feature branches can be shipped."
-  extract_message "$@"
+  commit_options=$(parameters_as_string "$@")
 }
 
 
@@ -54,7 +42,8 @@ function steps {
   echo "merge $main_branch_name"
   echo "ensure_has_shippable_changes"
   echo "checkout_main_branch"
-  echo "squash_merge $target_branch_name '$message'"
+  echo "squash_merge $target_branch_name"
+  echo "commit_squash_merge $commit_options"
   echo "push"
   if [ "$(has_tracking_branch "$target_branch_name")" = true ]; then
     echo "delete_remote_branch $target_branch_name"

--- a/src/helpers/git_helpers/merge_helpers.sh
+++ b/src/helpers/git_helpers/merge_helpers.sh
@@ -25,13 +25,13 @@ function merge {
 # Squash merges the given branch into the current branch
 function squash_merge {
   local branch_name=$1
-  local commit_message=$2
   run_command "git merge --squash $branch_name"
-  if [ "$commit_message" == "" ]; then
-    run_command "git commit -a"
-  else
-    run_command "git commit -a -m '$commit_message'"
-  fi
+}
+
+
+function commit_squash_merge {
+  local options=$(parameters_as_string "$@")
+  run_command "git commit -a $options"
   if [ $? != 0 ]; then error_empty_commit; fi
 }
 

--- a/src/helpers/string_helpers.sh
+++ b/src/helpers/string_helpers.sh
@@ -51,5 +51,5 @@ function parameters_as_string {
     fi
     str="$str $arg"
   done
-  echo "$str" | sed 's/^ //'
+  echo "${str/ /}" # Remove initial space
 }

--- a/src/helpers/string_helpers.sh
+++ b/src/helpers/string_helpers.sh
@@ -41,3 +41,15 @@ function remove_string {
   local split="$(split_string "$delimiter_separated_string" "$delimiter")"
   join_string "$(echo "$split" | sed "s/^${string_to_remove}$//;/^$/d")" "$delimiter"
 }
+
+
+function parameters_as_string {
+  local str=""
+  for arg in "$@"; do
+    if [ "$arg" != "${arg/ /}" ]; then
+      arg="'${arg}'"
+    fi
+    str="$str $arg"
+  done
+  echo "$str" | sed 's/^ //'
+}


### PR DESCRIPTION
@kevgo @allewun 

Changed git ship to just pass in the additional options to git-ship.
That way we don't have to parse any options and get more stuff for free.

Known limitation: if a commit option contains a space and single quote it will break. This is a limitation with git ship currently with the message parameter. I've got a fix for it and will create a PR for it after this goes in. Wanted to keep this PR small so kept them separate.