### PR TITLE
git ship: remove unneeded option

### DIFF
--- a/features/git-ship/current_branch/empty_commit_message.feature
+++ b/features/git-ship/current_branch/empty_commit_message.feature
@@ -24,7 +24,7 @@ Feature: git ship: aborting the shipping process by entering an empty commit mes
       | feature | git merge --no-edit main           |
       | feature | git checkout main                  |
       | main    | git merge --squash feature         |
-      | main    | git commit -a                      |
+      | main    | git commit                         |
       | main    | git reset --hard                   |
       | main    | git checkout feature               |
       | feature | git checkout main                  |

--- a/features/git-ship/current_branch/merge_main_branch_conflict.feature
+++ b/features/git-ship/current_branch/merge_main_branch_conflict.feature
@@ -52,14 +52,14 @@ Feature: git ship: resolving conflicts between feature and main branch
     Given I resolve the conflict in "conflicting_file"
     When I run `git ship --continue`
     Then it runs the Git commands
-      | BRANCH  | COMMAND                         |
-      | feature | git commit --no-edit            |
-      | feature | git checkout main               |
-      | main    | git merge --squash feature      |
-      | main    | git commit -a -m 'feature done' |
-      | main    | git push                        |
-      | main    | git push origin :feature        |
-      | main    | git branch -D feature           |
+      | BRANCH  | COMMAND                      |
+      | feature | git commit --no-edit         |
+      | feature | git checkout main            |
+      | main    | git merge --squash feature   |
+      | main    | git commit -m 'feature done' |
+      | main    | git push                     |
+      | main    | git push origin :feature     |
+      | main    | git branch -D feature        |
     And I end up on the "main" branch
     And there is no "feature" branch
     And I still have the following commits
@@ -75,13 +75,13 @@ Feature: git ship: resolving conflicts between feature and main branch
     Given I resolve the conflict in "conflicting_file"
     When I run `git commit --no-edit; git ship --continue`
     Then it runs the Git commands
-      | BRANCH  | COMMAND                         |
-      | feature | git checkout main               |
-      | main    | git merge --squash feature      |
-      | main    | git commit -a -m 'feature done' |
-      | main    | git push                        |
-      | main    | git push origin :feature        |
-      | main    | git branch -D feature           |
+      | BRANCH  | COMMAND                      |
+      | feature | git checkout main            |
+      | main    | git merge --squash feature   |
+      | main    | git commit -m 'feature done' |
+      | main    | git push                     |
+      | main    | git push origin :feature     |
+      | main    | git branch -D feature        |
     And I end up on the "main" branch
     And there is no "feature" branch
     And I still have the following commits

--- a/features/git-ship/current_branch/on_feature_branch_without_open_changes.feature
+++ b/features/git-ship/current_branch/on_feature_branch_without_open_changes.feature
@@ -13,17 +13,17 @@ Feature: git ship: shipping the current feature branch
     And I am on the "feature" branch
     When I run `git ship -m 'feature done'`
     Then it runs the Git commands
-      | BRANCH  | COMMAND                         |
-      | feature | git checkout main               |
-      | main    | git fetch --prune               |
-      | main    | git rebase origin/main          |
-      | main    | git checkout feature            |
-      | feature | git merge --no-edit main        |
-      | feature | git checkout main               |
-      | main    | git merge --squash feature      |
-      | main    | git commit -a -m 'feature done' |
-      | main    | git push                        |
-      | main    | git branch -D feature           |
+      | BRANCH  | COMMAND                      |
+      | feature | git checkout main            |
+      | main    | git fetch --prune            |
+      | main    | git rebase origin/main       |
+      | main    | git checkout feature         |
+      | feature | git merge --no-edit main     |
+      | feature | git checkout main            |
+      | main    | git merge --squash feature   |
+      | main    | git commit -m 'feature done' |
+      | main    | git push                     |
+      | main    | git branch -D feature        |
     And I end up on the "main" branch
     And there are no more feature branches
     And there are no open changes
@@ -52,7 +52,7 @@ Feature: git ship: shipping the current feature branch
       | feature | git merge --no-edit main           |
       | feature | git checkout main                  |
       | main    | git merge --squash feature         |
-      | main    | git commit -a -m 'feature done'    |
+      | main    | git commit -m 'feature done'       |
       | main    | git push                           |
       | main    | git push origin :feature           |
       | main    | git branch -D feature              |

--- a/features/git-ship/current_branch/pull_feature_branch_conflict.feature
+++ b/features/git-ship/current_branch/pull_feature_branch_conflict.feature
@@ -48,15 +48,15 @@ Feature: git ship: resolving feature branch conflicts when shipping the current 
     Given I resolve the conflict in "conflicting_file"
     When I run `git ship --continue`
     Then it runs the Git commands
-      | BRANCH  | COMMAND                         |
-      | feature | git commit --no-edit            |
-      | feature | git merge --no-edit main        |
-      | feature | git checkout main               |
-      | main    | git merge --squash feature      |
-      | main    | git commit -a -m 'feature done' |
-      | main    | git push                        |
-      | main    | git push origin :feature        |
-      | main    | git branch -D feature           |
+      | BRANCH  | COMMAND                      |
+      | feature | git commit --no-edit         |
+      | feature | git merge --no-edit main     |
+      | feature | git checkout main            |
+      | main    | git merge --squash feature   |
+      | main    | git commit -m 'feature done' |
+      | main    | git push                     |
+      | main    | git push origin :feature     |
+      | main    | git branch -D feature        |
     And I end up on the "main" branch
     And there is no "feature" branch
     And I still have the following commits
@@ -71,14 +71,14 @@ Feature: git ship: resolving feature branch conflicts when shipping the current 
     Given I resolve the conflict in "conflicting_file"
     When I run `git commit --no-edit; git ship --continue`
     Then it runs the Git commands
-      | BRANCH  | COMMAND                         |
-      | feature | git merge --no-edit main        |
-      | feature | git checkout main               |
-      | main    | git merge --squash feature      |
-      | main    | git commit -a -m 'feature done' |
-      | main    | git push                        |
-      | main    | git push origin :feature        |
-      | main    | git branch -D feature           |
+      | BRANCH  | COMMAND                      |
+      | feature | git merge --no-edit main     |
+      | feature | git checkout main            |
+      | main    | git merge --squash feature   |
+      | main    | git commit -m 'feature done' |
+      | main    | git push                     |
+      | main    | git push origin :feature     |
+      | main    | git branch -D feature        |
     And I end up on the "main" branch
     And there is no "feature" branch
     And I still have the following commits

--- a/features/git-ship/current_branch/pull_main_branch_conflict.feature
+++ b/features/git-ship/current_branch/pull_main_branch_conflict.feature
@@ -56,7 +56,7 @@ Feature: git ship: resolving conflicts while updating the main branch
       | feature | git merge --no-edit main           |
       | feature | git checkout main                  |
       | main    | git merge --squash feature         |
-      | main    | git commit -a -m 'feature done'    |
+      | main    | git commit -m 'feature done'       |
       | main    | git push                           |
       | main    | git push origin :feature           |
       | main    | git branch -D feature              |
@@ -83,7 +83,7 @@ Feature: git ship: resolving conflicts while updating the main branch
       | feature | git merge --no-edit main           |
       | feature | git checkout main                  |
       | main    | git merge --squash feature         |
-      | main    | git commit -a -m 'feature done'    |
+      | main    | git commit -m 'feature done'       |
       | main    | git push                           |
       | main    | git push origin :feature           |
       | main    | git branch -D feature              |

--- a/features/git-ship/supplied_branch/empty_commit_message_with_conflicting_changes.feature
+++ b/features/git-ship/supplied_branch/empty_commit_message_with_conflicting_changes.feature
@@ -26,7 +26,7 @@ Feature: git ship: abort shipping the given feature branch by entering an empty 
       | feature       | git merge --no-edit main              |
       | feature       | git checkout main                     |
       | main          | git merge --squash feature            |
-      | main          | git commit -a                         |
+      | main          | git commit                            |
       | main          | git reset --hard                      |
       | main          | git checkout feature                  |
       | feature       | git reset --hard [SHA:feature commit] |

--- a/features/git-ship/supplied_branch/empty_commit_message_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/empty_commit_message_with_open_changes.feature
@@ -25,7 +25,7 @@ Feature: git ship: abort shipping the given feature branch by entering an empty 
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -a                      |
+      | main          | git commit                         |
       | main          | git reset --hard                   |
       | main          | git checkout feature               |
       | feature       | git checkout main                  |

--- a/features/git-ship/supplied_branch/empty_commit_message_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/empty_commit_message_without_open_changes.feature
@@ -23,7 +23,7 @@ Feature: git ship: abort shipping the given feature branch by entering an empty 
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -a                      |
+      | main          | git commit                         |
       | main          | git reset --hard                   |
       | main          | git checkout feature               |
       | feature       | git checkout main                  |

--- a/features/git-ship/supplied_branch/merge_main_branch_conflict_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/merge_main_branch_conflict_with_open_changes.feature
@@ -56,16 +56,16 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
     Given I resolve the conflict in "conflicting_file"
     When I run `git ship --continue`
     Then it runs the Git commands
-      | BRANCH        | COMMAND                         |
-      | feature       | git commit --no-edit            |
-      | feature       | git checkout main               |
-      | main          | git merge --squash feature      |
-      | main          | git commit -a -m 'feature done' |
-      | main          | git push                        |
-      | main          | git push origin :feature        |
-      | main          | git branch -D feature           |
-      | main          | git checkout other_feature      |
-      | other_feature | git stash pop                   |
+      | BRANCH        | COMMAND                      |
+      | feature       | git commit --no-edit         |
+      | feature       | git checkout main            |
+      | main          | git merge --squash feature   |
+      | main          | git commit -m 'feature done' |
+      | main          | git push                     |
+      | main          | git push origin :feature     |
+      | main          | git branch -D feature        |
+      | main          | git checkout other_feature   |
+      | other_feature | git stash pop                |
     And I end up on the "other_feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "feature" branch
@@ -82,15 +82,15 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
     Given I resolve the conflict in "conflicting_file"
     When I run `git commit --no-edit; git ship --continue`
     Then it runs the Git commands
-      | BRANCH        | COMMAND                         |
-      | feature       | git checkout main               |
-      | main          | git merge --squash feature      |
-      | main          | git commit -a -m 'feature done' |
-      | main          | git push                        |
-      | main          | git push origin :feature        |
-      | main          | git branch -D feature           |
-      | main          | git checkout other_feature      |
-      | other_feature | git stash pop                   |
+      | BRANCH        | COMMAND                      |
+      | feature       | git checkout main            |
+      | main          | git merge --squash feature   |
+      | main          | git commit -m 'feature done' |
+      | main          | git push                     |
+      | main          | git push origin :feature     |
+      | main          | git branch -D feature        |
+      | main          | git checkout other_feature   |
+      | other_feature | git stash pop                |
     And I end up on the "other_feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "feature" branch

--- a/features/git-ship/supplied_branch/merge_main_branch_conflict_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/merge_main_branch_conflict_without_open_changes.feature
@@ -50,15 +50,15 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
     Given I resolve the conflict in "conflicting_file"
     When I run `git ship --continue`
     Then it runs the Git commands
-      | BRANCH  | COMMAND                         |
-      | feature | git commit --no-edit            |
-      | feature | git checkout main               |
-      | main    | git merge --squash feature      |
-      | main    | git commit -a -m 'feature done' |
-      | main    | git push                        |
-      | main    | git push origin :feature        |
-      | main    | git branch -D feature           |
-      | main    | git checkout other_feature      |
+      | BRANCH  | COMMAND                      |
+      | feature | git commit --no-edit         |
+      | feature | git checkout main            |
+      | main    | git merge --squash feature   |
+      | main    | git commit -m 'feature done' |
+      | main    | git push                     |
+      | main    | git push origin :feature     |
+      | main    | git branch -D feature        |
+      | main    | git checkout other_feature   |
     And I end up on the "other_feature" branch
     And there is no "feature" branch
     And I still have the following commits
@@ -74,14 +74,14 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
     Given I resolve the conflict in "conflicting_file"
     When I run `git commit --no-edit; git ship --continue`
     Then it runs the Git commands
-      | BRANCH  | COMMAND                         |
-      | feature | git checkout main               |
-      | main    | git merge --squash feature      |
-      | main    | git commit -a -m 'feature done' |
-      | main    | git push                        |
-      | main    | git push origin :feature        |
-      | main    | git branch -D feature           |
-      | main    | git checkout other_feature      |
+      | BRANCH  | COMMAND                      |
+      | feature | git checkout main            |
+      | main    | git merge --squash feature   |
+      | main    | git commit -m 'feature done' |
+      | main    | git push                     |
+      | main    | git push origin :feature     |
+      | main    | git branch -D feature        |
+      | main    | git checkout other_feature   |
     And I end up on the "other_feature" branch
     And there is no "feature" branch
     And I still have the following commits

--- a/features/git-ship/supplied_branch/no_conflicts_with_conflicting_changes.feature
+++ b/features/git-ship/supplied_branch/no_conflicts_with_conflicting_changes.feature
@@ -26,7 +26,7 @@ Feature: git ship: shipping the supplied feature branch (with conflicting change
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -a -m 'feature done'    |
+      | main          | git commit -m 'feature done'       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |
@@ -63,7 +63,7 @@ Feature: git ship: shipping the supplied feature branch (with conflicting change
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -a -m 'feature done'    |
+      | main          | git commit -m 'feature done'       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |

--- a/features/git-ship/supplied_branch/no_conflicts_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/no_conflicts_with_open_changes.feature
@@ -22,7 +22,7 @@ Feature: git ship: shipping the supplied feature branch (with open changes)
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -a -m 'feature done'    |
+      | main          | git commit -m 'feature done'       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |
@@ -58,7 +58,7 @@ Feature: git ship: shipping the supplied feature branch (with open changes)
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -a -m 'feature done'    |
+      | main          | git commit -m 'feature done'       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |

--- a/features/git-ship/supplied_branch/no_conflicts_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/no_conflicts_without_open_changes.feature
@@ -20,7 +20,7 @@ Feature: git ship: shipping the supplied feature branch (without open changes)
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -a -m 'feature done'    |
+      | main          | git commit -m 'feature done'       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |
@@ -52,7 +52,7 @@ Feature: git ship: shipping the supplied feature branch (without open changes)
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -a -m 'feature done'    |
+      | main          | git commit -m 'feature done'       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |

--- a/features/git-ship/supplied_branch/pull_feature_branch_conflict_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_feature_branch_conflict_with_open_changes.feature
@@ -53,17 +53,17 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
     Given I resolve the conflict in "conflicting_file"
     When I run `git ship --continue`
     Then it runs the Git commands
-      | BRANCH        | COMMAND                         |
-      | feature       | git commit --no-edit            |
-      | feature       | git merge --no-edit main        |
-      | feature       | git checkout main               |
-      | main          | git merge --squash feature      |
-      | main          | git commit -a -m 'feature done' |
-      | main          | git push                        |
-      | main          | git push origin :feature        |
-      | main          | git branch -D feature           |
-      | main          | git checkout other_feature      |
-      | other_feature | git stash pop                   |
+      | BRANCH        | COMMAND                      |
+      | feature       | git commit --no-edit         |
+      | feature       | git merge --no-edit main     |
+      | feature       | git checkout main            |
+      | main          | git merge --squash feature   |
+      | main          | git commit -m 'feature done' |
+      | main          | git push                     |
+      | main          | git push origin :feature     |
+      | main          | git branch -D feature        |
+      | main          | git checkout other_feature   |
+      | other_feature | git stash pop                |
     And I end up on the "other_feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "feature" branch
@@ -79,16 +79,16 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
     Given I resolve the conflict in "conflicting_file"
     When I run `git commit --no-edit; git ship --continue`
     Then it runs the Git commands
-      | BRANCH        | COMMAND                         |
-      | feature       | git merge --no-edit main        |
-      | feature       | git checkout main               |
-      | main          | git merge --squash feature      |
-      | main          | git commit -a -m 'feature done' |
-      | main          | git push                        |
-      | main          | git push origin :feature        |
-      | main          | git branch -D feature           |
-      | main          | git checkout other_feature      |
-      | other_feature | git stash pop                   |
+      | BRANCH        | COMMAND                      |
+      | feature       | git merge --no-edit main     |
+      | feature       | git checkout main            |
+      | main          | git merge --squash feature   |
+      | main          | git commit -m 'feature done' |
+      | main          | git push                     |
+      | main          | git push origin :feature     |
+      | main          | git branch -D feature        |
+      | main          | git checkout other_feature   |
+      | other_feature | git stash pop                |
     And I end up on the "other_feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "feature" branch

--- a/features/git-ship/supplied_branch/pull_feature_branch_conflict_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_feature_branch_conflict_without_open_changes.feature
@@ -47,16 +47,16 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
     Given I resolve the conflict in "conflicting_file"
     When I run `git ship --continue`
     Then it runs the Git commands
-      | BRANCH  | COMMAND                         |
-      | feature | git commit --no-edit            |
-      | feature | git merge --no-edit main        |
-      | feature | git checkout main               |
-      | main    | git merge --squash feature      |
-      | main    | git commit -a -m 'feature done' |
-      | main    | git push                        |
-      | main    | git push origin :feature        |
-      | main    | git branch -D feature           |
-      | main    | git checkout other_feature      |
+      | BRANCH  | COMMAND                      |
+      | feature | git commit --no-edit         |
+      | feature | git merge --no-edit main     |
+      | feature | git checkout main            |
+      | main    | git merge --squash feature   |
+      | main    | git commit -m 'feature done' |
+      | main    | git push                     |
+      | main    | git push origin :feature     |
+      | main    | git branch -D feature        |
+      | main    | git checkout other_feature   |
     And I end up on the "other_feature" branch
     And there is no "feature" branch
     And I still have the following commits
@@ -71,15 +71,15 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
     Given I resolve the conflict in "conflicting_file"
     When I run `git commit --no-edit; git ship --continue`
     Then it runs the Git commands
-      | BRANCH  | COMMAND                         |
-      | feature | git merge --no-edit main        |
-      | feature | git checkout main               |
-      | main    | git merge --squash feature      |
-      | main    | git commit -a -m 'feature done' |
-      | main    | git push                        |
-      | main    | git push origin :feature        |
-      | main    | git branch -D feature           |
-      | main    | git checkout other_feature      |
+      | BRANCH  | COMMAND                      |
+      | feature | git merge --no-edit main     |
+      | feature | git checkout main            |
+      | main    | git merge --squash feature   |
+      | main    | git commit -m 'feature done' |
+      | main    | git push                     |
+      | main    | git push origin :feature     |
+      | main    | git branch -D feature        |
+      | main    | git checkout other_feature   |
     And I end up on the "other_feature" branch
     And there is no "feature" branch
     And I still have the following commits

--- a/features/git-ship/supplied_branch/pull_main_branch_conflict_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_main_branch_conflict_with_open_changes.feature
@@ -60,7 +60,7 @@ Feature: git ship: resolving main branch updates when shipping a given feature b
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -a -m 'feature done'    |
+      | main          | git commit -m 'feature done'       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |
@@ -90,7 +90,7 @@ Feature: git ship: resolving main branch updates when shipping a given feature b
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -a -m 'feature done'    |
+      | main          | git commit -m 'feature done'       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |

--- a/features/git-ship/supplied_branch/pull_main_branch_conflict_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_main_branch_conflict_without_open_changes.feature
@@ -54,7 +54,7 @@ Feature: git ship: resolving conflicting main branch updates when shipping a giv
       | feature | git merge --no-edit main           |
       | feature | git checkout main                  |
       | main    | git merge --squash feature         |
-      | main    | git commit -a -m 'feature done'    |
+      | main    | git commit -m 'feature done'       |
       | main    | git push                           |
       | main    | git push origin :feature           |
       | main    | git branch -D feature              |
@@ -82,7 +82,7 @@ Feature: git ship: resolving conflicting main branch updates when shipping a giv
       | feature | git merge --no-edit main           |
       | feature | git checkout main                  |
       | main    | git merge --squash feature         |
-      | main    | git commit -a -m 'feature done'    |
+      | main    | git commit -m 'feature done'       |
       | main    | git push                           |
       | main    | git push origin :feature           |
       | main    | git branch -D feature              |

--- a/src/helpers/git_helpers/merge_helpers.sh
+++ b/src/helpers/git_helpers/merge_helpers.sh
@@ -28,9 +28,9 @@ function squash_merge {
   local commit_message=$2
   run_command "git merge --squash $branch_name"
   if [ "$commit_message" == "" ]; then
-    run_command "git commit -a"
+    run_command "git commit"
   else
-    run_command "git commit -a -m '$commit_message'"
+    run_command "git commit -m '$commit_message'"
   fi
   if [ $? != 0 ]; then error_empty_commit; fi
 }


### PR DESCRIPTION
@kevgo @allewun 

`-a` is apparently unnecessary. I guess squash merge automatically stages all the files.