### PR TITLE
git ship: robust commit options

### DIFF
--- a/features/git-ship/current_branch/commit_message_containing_double_quote.feature
+++ b/features/git-ship/current_branch/commit_message_containing_double_quote.feature
@@ -10,30 +10,30 @@ Feature: git ship: shipping the current feature branch
       | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
       | feature | remote   | feature_file | feature content |
     And I am on the "feature" branch
-    When I run `git ship -m 'feature "done"'`
+    When I run `git ship -m 'feature done with "double quotes"'`
 
 
   Scenario: result
     Then it runs the Git commands
-      | BRANCH  | COMMAND                            |
-      | feature | git checkout main                  |
-      | main    | git fetch --prune                  |
-      | main    | git rebase origin/main             |
-      | main    | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      | feature | git merge --no-edit main           |
-      | feature | git checkout main                  |
-      | main    | git merge --squash feature         |
-      | main    | git commit -m "feature \"done\""   |
-      | main    | git push                           |
-      | main    | git push origin :feature           |
-      | main    | git branch -D feature              |
+      | BRANCH  | COMMAND                                             |
+      | feature | git checkout main                                   |
+      | main    | git fetch --prune                                   |
+      | main    | git rebase origin/main                              |
+      | main    | git checkout feature                                |
+      | feature | git merge --no-edit origin/feature                  |
+      | feature | git merge --no-edit main                            |
+      | feature | git checkout main                                   |
+      | main    | git merge --squash feature                          |
+      | main    | git commit -m "feature done with \"double quotes\"" |
+      | main    | git push                                            |
+      | main    | git push origin :feature                            |
+      | main    | git branch -D feature                               |
     And I end up on the "main" branch
     And there are no more feature branches
     And there are no open changes
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE        | FILE NAME    |
-      | main   | local and remote | feature "done" | feature_file |
+      | BRANCH | LOCATION         | MESSAGE                           | FILE NAME    |
+      | main   | local and remote | feature done with "double quotes" | feature_file |
     And now I have the following committed files
       | BRANCH | FILES        |
       | main   | feature_file |

--- a/features/git-ship/current_branch/commit_message_containing_double_quote.feature
+++ b/features/git-ship/current_branch/commit_message_containing_double_quote.feature
@@ -10,30 +10,30 @@ Feature: git ship: shipping the current feature branch
       | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
       | feature | remote   | feature_file | feature content |
     And I am on the "feature" branch
-    When I run `git ship -m 'feature done with "double quotes"'`
+    When I run `git ship -m 'message containing "double quotes"'`
 
 
   Scenario: result
     Then it runs the Git commands
-      | BRANCH  | COMMAND                                             |
-      | feature | git checkout main                                   |
-      | main    | git fetch --prune                                   |
-      | main    | git rebase origin/main                              |
-      | main    | git checkout feature                                |
-      | feature | git merge --no-edit origin/feature                  |
-      | feature | git merge --no-edit main                            |
-      | feature | git checkout main                                   |
-      | main    | git merge --squash feature                          |
-      | main    | git commit -m "feature done with \"double quotes\"" |
-      | main    | git push                                            |
-      | main    | git push origin :feature                            |
-      | main    | git branch -D feature                               |
+      | BRANCH  | COMMAND                                              |
+      | feature | git checkout main                                    |
+      | main    | git fetch --prune                                    |
+      | main    | git rebase origin/main                               |
+      | main    | git checkout feature                                 |
+      | feature | git merge --no-edit origin/feature                   |
+      | feature | git merge --no-edit main                             |
+      | feature | git checkout main                                    |
+      | main    | git merge --squash feature                           |
+      | main    | git commit -m "message containing \"double quotes\"" |
+      | main    | git push                                             |
+      | main    | git push origin :feature                             |
+      | main    | git branch -D feature                                |
     And I end up on the "main" branch
     And there are no more feature branches
     And there are no open changes
     And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE                           | FILE NAME    |
-      | main   | local and remote | feature done with "double quotes" | feature_file |
+      | BRANCH | LOCATION         | MESSAGE                            | FILE NAME    |
+      | main   | local and remote | message containing "double quotes" | feature_file |
     And now I have the following committed files
       | BRANCH | FILES        |
       | main   | feature_file |

--- a/features/git-ship/current_branch/commit_message_containing_double_quote.feature
+++ b/features/git-ship/current_branch/commit_message_containing_double_quote.feature
@@ -1,0 +1,39 @@
+Feature: git ship: shipping the current feature branch
+
+  As a developer entering a commit message that contains a double quote
+  I want it to still work as expected
+  So shipping is a robust process.
+
+  Background:
+    Given I have a feature branch named "feature"
+    And the following commit exists in my repository
+      | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
+      | feature | remote   | feature_file | feature content |
+    And I am on the "feature" branch
+    When I run `git ship -m 'feature "done"'`
+
+
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH  | COMMAND                            |
+      | feature | git checkout main                  |
+      | main    | git fetch --prune                  |
+      | main    | git rebase origin/main             |
+      | main    | git checkout feature               |
+      | feature | git merge --no-edit origin/feature |
+      | feature | git merge --no-edit main           |
+      | feature | git checkout main                  |
+      | main    | git merge --squash feature         |
+      | main    | git commit -m "feature \"done\""   |
+      | main    | git push                           |
+      | main    | git push origin :feature           |
+      | main    | git branch -D feature              |
+    And I end up on the "main" branch
+    And there are no more feature branches
+    And there are no open changes
+    And I have the following commits
+      | BRANCH | LOCATION         | MESSAGE        | FILE NAME    |
+      | main   | local and remote | feature "done" | feature_file |
+    And now I have the following committed files
+      | BRANCH | FILES        |
+      | main   | feature_file |

--- a/features/git-ship/current_branch/merge_main_branch_conflict.feature
+++ b/features/git-ship/current_branch/merge_main_branch_conflict.feature
@@ -12,7 +12,7 @@ Feature: git ship: resolving conflicts between feature and main branch
       | main    | local    | conflicting main commit    | conflicting_file | main content    |
       | feature | local    | conflicting feature commit | conflicting_file | feature content |
     And I am on the "feature" branch
-    And I run `git ship -m 'feature done'` while allowing errors
+    And I run `git ship -m "feature done"` while allowing errors
 
 
   Scenario: result
@@ -56,7 +56,7 @@ Feature: git ship: resolving conflicts between feature and main branch
       | feature | git commit --no-edit         |
       | feature | git checkout main            |
       | main    | git merge --squash feature   |
-      | main    | git commit -m 'feature done' |
+      | main    | git commit -m "feature done" |
       | main    | git push                     |
       | main    | git push origin :feature     |
       | main    | git branch -D feature        |
@@ -78,7 +78,7 @@ Feature: git ship: resolving conflicts between feature and main branch
       | BRANCH  | COMMAND                      |
       | feature | git checkout main            |
       | main    | git merge --squash feature   |
-      | main    | git commit -m 'feature done' |
+      | main    | git commit -m "feature done" |
       | main    | git push                     |
       | main    | git push origin :feature     |
       | main    | git branch -D feature        |

--- a/features/git-ship/current_branch/on_feature_branch_with_open_changes.feature
+++ b/features/git-ship/current_branch/on_feature_branch_with_open_changes.feature
@@ -9,7 +9,7 @@ Feature: git ship: don't ship unfinished features
     Given I have a feature branch named "feature"
     And I have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I am on the "feature" branch
-    When I run `git ship -m 'feature done'` while allowing errors
+    When I run `git ship -m "feature done"` while allowing errors
 
 
   Scenario: result

--- a/features/git-ship/current_branch/on_feature_branch_without_open_changes.feature
+++ b/features/git-ship/current_branch/on_feature_branch_without_open_changes.feature
@@ -11,7 +11,7 @@ Feature: git ship: shipping the current feature branch
       | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
       | feature | local    | feature_file | feature content |
     And I am on the "feature" branch
-    When I run `git ship -m 'feature done'`
+    When I run `git ship -m "feature done"`
     Then it runs the Git commands
       | BRANCH  | COMMAND                      |
       | feature | git checkout main            |
@@ -21,7 +21,7 @@ Feature: git ship: shipping the current feature branch
       | feature | git merge --no-edit main     |
       | feature | git checkout main            |
       | main    | git merge --squash feature   |
-      | main    | git commit -m 'feature done' |
+      | main    | git commit -m "feature done" |
       | main    | git push                     |
       | main    | git branch -D feature        |
     And I end up on the "main" branch
@@ -41,7 +41,7 @@ Feature: git ship: shipping the current feature branch
       | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
       | feature | remote   | feature_file | feature content |
     And I am on the "feature" branch
-    When I run `git ship -m 'feature done'`
+    When I run `git ship -m "feature done"`
     Then it runs the Git commands
       | BRANCH  | COMMAND                            |
       | feature | git checkout main                  |
@@ -52,7 +52,7 @@ Feature: git ship: shipping the current feature branch
       | feature | git merge --no-edit main           |
       | feature | git checkout main                  |
       | main    | git merge --squash feature         |
-      | main    | git commit -m 'feature done'       |
+      | main    | git commit -m "feature done"       |
       | main    | git push                           |
       | main    | git push origin :feature           |
       | main    | git branch -D feature              |

--- a/features/git-ship/current_branch/on_non_feature_branch.feature
+++ b/features/git-ship/current_branch/on_non_feature_branch.feature
@@ -8,7 +8,7 @@ Feature: git ship: don't ship non-feature branches
   Background:
     Given non-feature branch configuration "qa, production"
     And I am on the "production" branch
-    When I run `git ship -m 'feature done'` while allowing errors
+    When I run `git ship -m "feature done"` while allowing errors
 
 
   Scenario: result

--- a/features/git-ship/current_branch/pull_feature_branch_conflict.feature
+++ b/features/git-ship/current_branch/pull_feature_branch_conflict.feature
@@ -11,7 +11,7 @@ Feature: git ship: resolving feature branch conflicts when shipping the current 
       | feature | remote   | remote conflicting commit | conflicting_file | remote conflicting content |
       |         | local    | local conflicting commit  | conflicting_file | local conflicting content  |
     And I am on the "feature" branch
-    When I run `git ship -m 'feature done'` while allowing errors
+    When I run `git ship -m "feature done"` while allowing errors
 
 
   Scenario: result
@@ -53,7 +53,7 @@ Feature: git ship: resolving feature branch conflicts when shipping the current 
       | feature | git merge --no-edit main     |
       | feature | git checkout main            |
       | main    | git merge --squash feature   |
-      | main    | git commit -m 'feature done' |
+      | main    | git commit -m "feature done" |
       | main    | git push                     |
       | main    | git push origin :feature     |
       | main    | git branch -D feature        |
@@ -75,7 +75,7 @@ Feature: git ship: resolving feature branch conflicts when shipping the current 
       | feature | git merge --no-edit main     |
       | feature | git checkout main            |
       | main    | git merge --squash feature   |
-      | main    | git commit -m 'feature done' |
+      | main    | git commit -m "feature done" |
       | main    | git push                     |
       | main    | git push origin :feature     |
       | main    | git branch -D feature        |

--- a/features/git-ship/current_branch/pull_main_branch_conflict.feature
+++ b/features/git-ship/current_branch/pull_main_branch_conflict.feature
@@ -13,7 +13,7 @@ Feature: git ship: resolving conflicts while updating the main branch
       |         | local    | conflicting local commit  | conflicting_file | local conflicting content  |
       | feature | local    | feature commit            | feature_file     | feature content            |
     And I am on the "feature" branch
-    When I run `git ship -m 'feature done'` while allowing errors
+    When I run `git ship -m "feature done"` while allowing errors
 
 
   Scenario: result
@@ -56,7 +56,7 @@ Feature: git ship: resolving conflicts while updating the main branch
       | feature | git merge --no-edit main           |
       | feature | git checkout main                  |
       | main    | git merge --squash feature         |
-      | main    | git commit -m 'feature done'       |
+      | main    | git commit -m "feature done"       |
       | main    | git push                           |
       | main    | git push origin :feature           |
       | main    | git branch -D feature              |
@@ -83,7 +83,7 @@ Feature: git ship: resolving conflicts while updating the main branch
       | feature | git merge --no-edit main           |
       | feature | git checkout main                  |
       | main    | git merge --squash feature         |
-      | main    | git commit -m 'feature done'       |
+      | main    | git commit -m "feature done"       |
       | main    | git push                           |
       | main    | git push origin :feature           |
       | main    | git branch -D feature              |

--- a/features/git-ship/supplied_branch/merge_main_branch_conflict_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/merge_main_branch_conflict_with_open_changes.feature
@@ -11,7 +11,7 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
       | feature | local    | conflicting feature commit | conflicting_file | feature content |
     And I am on the "other_feature" branch
     And I have an uncommitted file with name: "uncommitted" and content: "stuff"
-    And I run `git ship feature -m 'feature done'` while allowing errors
+    And I run `git ship feature -m "feature done"` while allowing errors
 
 
   @finishes-with-non-empty-stash
@@ -60,7 +60,7 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
       | feature       | git commit --no-edit         |
       | feature       | git checkout main            |
       | main          | git merge --squash feature   |
-      | main          | git commit -m 'feature done' |
+      | main          | git commit -m "feature done" |
       | main          | git push                     |
       | main          | git push origin :feature     |
       | main          | git branch -D feature        |
@@ -85,7 +85,7 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
       | BRANCH        | COMMAND                      |
       | feature       | git checkout main            |
       | main          | git merge --squash feature   |
-      | main          | git commit -m 'feature done' |
+      | main          | git commit -m "feature done" |
       | main          | git push                     |
       | main          | git push origin :feature     |
       | main          | git branch -D feature        |

--- a/features/git-ship/supplied_branch/merge_main_branch_conflict_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/merge_main_branch_conflict_without_open_changes.feature
@@ -10,7 +10,7 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
       | main    | local    | conflicting main commit    | conflicting_file | main content    |
       | feature | local    | conflicting feature commit | conflicting_file | feature content |
     And I am on the "other_feature" branch
-    And I run `git ship feature -m 'feature done'` while allowing errors
+    And I run `git ship feature -m "feature done"` while allowing errors
 
 
   Scenario: result
@@ -54,7 +54,7 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
       | feature | git commit --no-edit         |
       | feature | git checkout main            |
       | main    | git merge --squash feature   |
-      | main    | git commit -m 'feature done' |
+      | main    | git commit -m "feature done" |
       | main    | git push                     |
       | main    | git push origin :feature     |
       | main    | git branch -D feature        |
@@ -77,7 +77,7 @@ Feature: Git Ship: resolving conflicts between the supplied feature and main bra
       | BRANCH  | COMMAND                      |
       | feature | git checkout main            |
       | main    | git merge --squash feature   |
-      | main    | git commit -m 'feature done' |
+      | main    | git commit -m "feature done" |
       | main    | git push                     |
       | main    | git push origin :feature     |
       | main    | git branch -D feature        |

--- a/features/git-ship/supplied_branch/no_conflicts_with_conflicting_changes.feature
+++ b/features/git-ship/supplied_branch/no_conflicts_with_conflicting_changes.feature
@@ -13,7 +13,7 @@ Feature: git ship: shipping the supplied feature branch (with conflicting change
       | feature | local    | feature commit | feature_file | feature content |
     And I am on the "other_feature" branch
     And I have an uncommitted file with name: "main_file" and content: "conflicting content"
-    When I run `git ship feature -m 'feature done'`
+    When I run `git ship feature -m "feature done"`
     Then it runs the Git commands
       | BRANCH        | COMMAND                            |
       | other_feature | git stash -u                       |
@@ -26,7 +26,7 @@ Feature: git ship: shipping the supplied feature branch (with conflicting change
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -m 'feature done'       |
+      | main          | git commit -m "feature done"       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |
@@ -51,7 +51,7 @@ Feature: git ship: shipping the supplied feature branch (with conflicting change
       | feature | remote   | feature_file | feature content |
     And I am on the "other_feature" branch
     And I have an uncommitted file with name: "feature_file" and content: "conflicting content"
-    When I run `git ship feature -m 'feature done'`
+    When I run `git ship feature -m "feature done"`
     Then it runs the Git commands
       | BRANCH        | COMMAND                            |
       | other_feature | git stash -u                       |
@@ -63,7 +63,7 @@ Feature: git ship: shipping the supplied feature branch (with conflicting change
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -m 'feature done'       |
+      | main          | git commit -m "feature done"       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |

--- a/features/git-ship/supplied_branch/no_conflicts_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/no_conflicts_with_open_changes.feature
@@ -10,7 +10,7 @@ Feature: git ship: shipping the supplied feature branch (with open changes)
       | feature | local    | feature_file | feature content |
     And I am on the "other_feature" branch
     And I have an uncommitted file with name: "uncommitted" and content: "stuff"
-    When I run `git ship feature -m 'feature done'`
+    When I run `git ship feature -m "feature done"`
     Then it runs the Git commands
       | BRANCH        | COMMAND                            |
       | other_feature | git stash -u                       |
@@ -22,7 +22,7 @@ Feature: git ship: shipping the supplied feature branch (with open changes)
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -m 'feature done'       |
+      | main          | git commit -m "feature done"       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |
@@ -46,7 +46,7 @@ Feature: git ship: shipping the supplied feature branch (with open changes)
       | feature | remote   | feature_file | feature content |
     And I am on the "other_feature" branch
     And I have an uncommitted file with name: "uncommitted" and content: "stuff"
-    When I run `git ship feature -m 'feature done'`
+    When I run `git ship feature -m "feature done"`
     Then it runs the Git commands
       | BRANCH        | COMMAND                            |
       | other_feature | git stash -u                       |
@@ -58,7 +58,7 @@ Feature: git ship: shipping the supplied feature branch (with open changes)
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -m 'feature done'       |
+      | main          | git commit -m "feature done"       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |

--- a/features/git-ship/supplied_branch/no_conflicts_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/no_conflicts_without_open_changes.feature
@@ -9,7 +9,7 @@ Feature: git ship: shipping the supplied feature branch (without open changes)
       | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
       | feature | local    | feature_file | feature content |
     And I am on the "other_feature" branch
-    When I run `git ship feature -m 'feature done'`
+    When I run `git ship feature -m "feature done"`
     Then it runs the Git commands
       | BRANCH        | COMMAND                            |
       | other_feature | git checkout main                  |
@@ -20,7 +20,7 @@ Feature: git ship: shipping the supplied feature branch (without open changes)
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -m 'feature done'       |
+      | main          | git commit -m "feature done"       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |
@@ -41,7 +41,7 @@ Feature: git ship: shipping the supplied feature branch (without open changes)
       | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
       | feature | remote   | feature_file | feature content |
     And I am on the "other_feature" branch
-    When I run `git ship feature -m 'feature done'`
+    When I run `git ship feature -m "feature done"`
     Then it runs the Git commands
       | BRANCH        | COMMAND                            |
       | other_feature | git checkout main                  |
@@ -52,7 +52,7 @@ Feature: git ship: shipping the supplied feature branch (without open changes)
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -m 'feature done'       |
+      | main          | git commit -m "feature done"       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |

--- a/features/git-ship/supplied_branch/pull_feature_branch_conflict_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_feature_branch_conflict_with_open_changes.feature
@@ -11,7 +11,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
       |         | local    | local conflicting commit  | conflicting_file | local conflicting content  |
     And I am on the "other_feature" branch
     And I have an uncommitted file with name: "uncommitted" and content: "stuff"
-    And I run `git ship feature -m 'feature done'` while allowing errors
+    And I run `git ship feature -m "feature done"` while allowing errors
 
 
   @finishes-with-non-empty-stash
@@ -58,7 +58,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
       | feature       | git merge --no-edit main     |
       | feature       | git checkout main            |
       | main          | git merge --squash feature   |
-      | main          | git commit -m 'feature done' |
+      | main          | git commit -m "feature done" |
       | main          | git push                     |
       | main          | git push origin :feature     |
       | main          | git branch -D feature        |
@@ -83,7 +83,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
       | feature       | git merge --no-edit main     |
       | feature       | git checkout main            |
       | main          | git merge --squash feature   |
-      | main          | git commit -m 'feature done' |
+      | main          | git commit -m "feature done" |
       | main          | git push                     |
       | main          | git push origin :feature     |
       | main          | git branch -D feature        |

--- a/features/git-ship/supplied_branch/pull_feature_branch_conflict_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_feature_branch_conflict_without_open_changes.feature
@@ -10,7 +10,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
       | feature | remote   | remote conflicting commit | conflicting_file | remote conflicting content |
       |         | local    | local conflicting commit  | conflicting_file | local conflicting content  |
     And I am on the "other_feature" branch
-    And I run `git ship feature -m 'feature done'` while allowing errors
+    And I run `git ship feature -m "feature done"` while allowing errors
 
 
   Scenario: result
@@ -52,7 +52,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
       | feature | git merge --no-edit main     |
       | feature | git checkout main            |
       | main    | git merge --squash feature   |
-      | main    | git commit -m 'feature done' |
+      | main    | git commit -m "feature done" |
       | main    | git push                     |
       | main    | git push origin :feature     |
       | main    | git branch -D feature        |
@@ -75,7 +75,7 @@ Feature: git ship: resolving remote feature branch updates when shipping a given
       | feature | git merge --no-edit main     |
       | feature | git checkout main            |
       | main    | git merge --squash feature   |
-      | main    | git commit -m 'feature done' |
+      | main    | git commit -m "feature done" |
       | main    | git push                     |
       | main    | git push origin :feature     |
       | main    | git branch -D feature        |

--- a/features/git-ship/supplied_branch/pull_main_branch_conflict_with_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_main_branch_conflict_with_open_changes.feature
@@ -12,7 +12,7 @@ Feature: git ship: resolving main branch updates when shipping a given feature b
       | feature | local    | feature commit            | feature_file     | feature content            |
     And I am on the "other_feature" branch
     And I have an uncommitted file with name: "uncommitted" and content: "stuff"
-    And I run `git ship feature -m 'feature done'` while allowing errors
+    And I run `git ship feature -m "feature done"` while allowing errors
 
 
   @finishes-with-non-empty-stash
@@ -60,7 +60,7 @@ Feature: git ship: resolving main branch updates when shipping a given feature b
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -m 'feature done'       |
+      | main          | git commit -m "feature done"       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |
@@ -90,7 +90,7 @@ Feature: git ship: resolving main branch updates when shipping a given feature b
       | feature       | git merge --no-edit main           |
       | feature       | git checkout main                  |
       | main          | git merge --squash feature         |
-      | main          | git commit -m 'feature done'       |
+      | main          | git commit -m "feature done"       |
       | main          | git push                           |
       | main          | git push origin :feature           |
       | main          | git branch -D feature              |

--- a/features/git-ship/supplied_branch/pull_main_branch_conflict_without_open_changes.feature
+++ b/features/git-ship/supplied_branch/pull_main_branch_conflict_without_open_changes.feature
@@ -11,7 +11,7 @@ Feature: git ship: resolving conflicting main branch updates when shipping a giv
       |         | local    | conflicting local commit  | conflicting_file | local conflicting content  |
       | feature | local    | feature commit            | feature_file     | feature content            |
     And I am on the "other_feature" branch
-    And I run `git ship feature -m 'feature done'` while allowing errors
+    And I run `git ship feature -m "feature done"` while allowing errors
 
 
   Scenario: result
@@ -54,7 +54,7 @@ Feature: git ship: resolving conflicting main branch updates when shipping a giv
       | feature | git merge --no-edit main           |
       | feature | git checkout main                  |
       | main    | git merge --squash feature         |
-      | main    | git commit -m 'feature done'       |
+      | main    | git commit -m "feature done"       |
       | main    | git push                           |
       | main    | git push origin :feature           |
       | main    | git branch -D feature              |
@@ -82,7 +82,7 @@ Feature: git ship: resolving conflicting main branch updates when shipping a giv
       | feature | git merge --no-edit main           |
       | feature | git checkout main                  |
       | main    | git merge --squash feature         |
-      | main    | git commit -m 'feature done'       |
+      | main    | git commit -m "feature done"       |
       | main    | git push                           |
       | main    | git push origin :feature           |
       | main    | git branch -D feature              |

--- a/src/helpers/string_helpers.sh
+++ b/src/helpers/string_helpers.sh
@@ -47,6 +47,7 @@ function parameters_as_string {
   local str=""
   for arg in "$@"; do
     if [ "$arg" != "${arg/ /}" ]; then
+      # Wrap arg in double quotes, escape double quotes within arg
       arg="\"${arg//\"/\\\"}\""
     fi
     str="$str $arg"

--- a/src/helpers/string_helpers.sh
+++ b/src/helpers/string_helpers.sh
@@ -47,7 +47,7 @@ function parameters_as_string {
   local str=""
   for arg in "$@"; do
     if [ "$arg" != "${arg/ /}" ]; then
-      arg="'${arg}'"
+      arg="\"${arg//\"/\\\"}\""
     fi
     str="$str $arg"
   done


### PR DESCRIPTION
@kevgo @allewun

All commit options that contain a space will be wrapped in double quotes and have their double quotes escaped.