### PR TITLE
update test repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,4 @@ rvm:
 cache: bundler
 
 script:
-  - git config --global user.email cucumber@git.town
-  - git config --global user.name "Git Town"
   - bin/travis

--- a/features/step_definitions/branch_steps.rb
+++ b/features/step_definitions/branch_steps.rb
@@ -1,6 +1,6 @@
 Given(/^(I|my coworker) (?:am|is) on the "(.+?)" branch$/) do |who, branch_name|
-  path = (who == 'I') ? local_repository_path : coworker_repository_path
-  at_path(path) do
+  user = (who == 'I') ? :developer : :coworker
+  in_repository user do
     run "git checkout #{branch_name}"
   end
 end
@@ -30,7 +30,7 @@ end
 
 
 Given(/^my coworker has a feature branch named "(.+?)"(?: (behind|ahead of) main)?$/) do |branch_name, relation|
-  at_path coworker_repository_path do
+  in_repository :coworker do
     create_branch branch_name
     if relation
       commit_to_branch = relation == 'behind' ? 'main' : branch_name
@@ -41,7 +41,7 @@ end
 
 
 Given(/the "(.+?)" branch gets deleted on the remote/) do |branch_name|
-  at_path coworker_repository_path do
+  in_repository :coworker do
     run "git push origin :#{branch_name}"
   end
 end

--- a/features/step_definitions/commit_steps.rb
+++ b/features/step_definitions/commit_steps.rb
@@ -1,7 +1,7 @@
 Given(/^the following commits? exists? in (my|my coworker's) repository$/) do |who, commits_table|
-  path = (who == 'my') ? local_repository_path : coworker_repository_path
+  user = (who == 'my') ? :developer : :coworker
   commits_table.map_headers!(&:downcase)
-  at_path(path) do
+  in_repository user do
     create_commits commits_table.hashes
   end
 end
@@ -10,9 +10,9 @@ end
 
 
 Then(/^(?:now )?(I|my coworker) (?:still )?(?:have|has) the following commits$/) do |who, commits_table|
-  path = (who == 'I') ? local_repository_path : coworker_repository_path
+  user = (who == 'I') ? :developer : :coworker
   commits_table.map_headers!(&:downcase)
-  at_path(path) do
+  in_repository user do
     verify_commits commits_table.hashes
   end
 end

--- a/features/step_definitions/remote_steps.rb
+++ b/features/step_definitions/remote_steps.rb
@@ -1,12 +1,12 @@
 Given(/^my repo has an upstream repo$/) do
-  clone_repository remote_repository_path, upstream_remote_repository_path, bare: true
-  clone_repository upstream_remote_repository_path, upstream_local_repository_path
+  clone_repository :origin, :upstream, bare: true
+  clone_repository :upstream, :upstream_developer
 
-  at_path upstream_local_repository_path do
+  in_repository :upstream_developer do
     run 'git checkout main'
   end
 
-  run "git remote add upstream #{upstream_remote_repository_path}"
+  run "git remote add upstream #{repository_path :upstream}"
 end
 
 

--- a/features/step_definitions/remote_steps.rb
+++ b/features/step_definitions/remote_steps.rb
@@ -1,11 +1,6 @@
 Given(/^my repo has an upstream repo$/) do
   clone_repository :origin, :upstream, bare: true
   clone_repository :upstream, :upstream_developer
-
-  in_repository :upstream_developer do
-    run 'git checkout main'
-  end
-
   run "git remote add upstream #{repository_path :upstream}"
 end
 

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -1,6 +1,6 @@
 When(/^(I|my coworker) runs? `([^`]+)`( while allowing errors)?$/) do |who, commands, allow_failures|
-  path = (who == 'I') ? local_repository_path : coworker_repository_path
-  at_path(path) do
+  user = (who == 'I') ? :developer : :coworker
+  in_repository user do
     commands.split(';').each do |command|
       run command.strip, allow_failures: allow_failures
     end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,5 +1,5 @@
 Given(/^my coworker fetches updates$/) do
-  at_path coworker_repository_path do
+  in_repository :coworker do
     run 'git fetch'
   end
 end

--- a/features/support/branch_helpers.rb
+++ b/features/support/branch_helpers.rb
@@ -14,7 +14,7 @@ def branches_for_repository repository
   case repository
   when 'local' then existing_local_branches
   when 'remote' then existing_remote_branches
-  when 'coworker' then at_path(coworker_repository_path) { existing_local_branches }
+  when 'coworker' then in_repository(:coworker) { existing_local_branches }
   else fail "Unknown repository: #{repository}"
   end
 end

--- a/features/support/commit_helpers.rb
+++ b/features/support/commit_helpers.rb
@@ -21,14 +21,14 @@ end
 
 
 def create_remote_commit commit_data
-  at_path coworker_repository_path do
+  in_secondary_repository do
     create_local_commit commit_data.merge(pull: true, push: true)
   end
 end
 
 
 def create_upstream_commit commit_data
-  at_path upstream_local_repository_path do
+  in_repository :upstream_developer do
     create_local_commit commit_data.merge(push: true)
   end
 end
@@ -41,7 +41,7 @@ def create_commit commit_data
   when %w(local) then create_local_commit commit_data
   when %w(remote) then create_remote_commit commit_data
   when %w(local remote) then create_local_commit commit_data.merge(push: true)
-  when %w(upstream) then  create_upstream_commit commit_data
+  when %w(upstream) then create_upstream_commit commit_data
   else fail "Unknown commit location: #{location}"
   end
 end

--- a/features/support/configuration_helpers.rb
+++ b/features/support/configuration_helpers.rb
@@ -1,0 +1,10 @@
+def configure_git user
+  run "git config user.name #{user}"
+  run "git config user.email #{user}@example.com"
+  run 'git config push.default simple'
+  run 'git config core.editor vim'
+
+  # Git Town Configuration
+  run 'git config git-town.main-branch-name main'
+  run 'git config git-town.non-feature-branch-names ""'
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -37,7 +37,7 @@ Before do
     run 'git branch -d master'
   end
 
-  goto_repository :developer
+  go_to_repository :developer
 end
 
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,44 +13,31 @@ Before do
   Dir.chdir REPOSITORY_BASE
   FileUtils.rm_rf Dir.glob("#{REPOSITORY_BASE}/*")
 
-  # Create remote repository
-  create_repository remote_repository_path
+  # Create origin repository
+  create_repository :origin
 
   # Create the local repository
-  clone_repository remote_repository_path, local_repository_path
-  at_path local_repository_path do
-    # Create the master branch
+  clone_repository :origin, :developer
+
+  # Create the main branch
+  in_repository :developer do
     run 'touch .gitignore ; git add .gitignore ; git commit -m "Initial commit"; git push -u origin master'
-
-    # Create the main branch
     run 'git checkout -b main master ; git push -u origin main'
-
-    # Configuration
-    run 'git config git-town.main-branch-name main'
-    run 'git config git-town.non-feature-branch-names ""'
-    run 'git config push.default simple'
-    run 'git config core.editor vim'
   end
 
-  # Set the default branch
-  at_path remote_repository_path do
+  # Set main as the default branch
+  in_repository :origin do
     run 'git symbolic-ref HEAD refs/heads/main'
   end
 
   # Fetch the default branch, delete master
-  at_path local_repository_path do
+  in_repository :developer do
     run 'git fetch'
     run 'git push origin :master'
     run 'git branch -d master'
   end
 
-  # Create the coworker repository
-  clone_repository remote_repository_path, coworker_repository_path
-  at_path coworker_repository_path do
-    run 'git config git-town.main-branch-name main'
-  end
-
-  Dir.chdir local_repository_path
+  goto_repository :developer
 end
 
 

--- a/features/support/repository_helpers.rb
+++ b/features/support/repository_helpers.rb
@@ -23,14 +23,14 @@ def clone_repository parent_identifier, child_identifier, bare: false
   run "git clone #{'--bare' if bare} #{parent_path} #{child_path}"
 
   in_repository child_identifier do
-    user = child_identifier.to_s.gsub('_secondary', '')
+    user = child_identifier.to_s.sub('_secondary', '')
     configure_git user
   end
 end
 
 
 # Move into the repository with the given repository
-def goto_repository identifier
+def go_to_repository identifier
   Dir.chdir repository_path identifier
 end
 

--- a/features/support/repository_helpers.rb
+++ b/features/support/repository_helpers.rb
@@ -1,36 +1,56 @@
-def remote_repository_path
-  "#{REPOSITORY_BASE}/git_town_specs_remote"
-end
-
-def coworker_repository_path
-  "#{REPOSITORY_BASE}/git_town_specs_coworker"
-end
-
-def local_repository_path
-  "#{REPOSITORY_BASE}/git_town_specs_local"
-end
-
-def upstream_remote_repository_path
-  "#{REPOSITORY_BASE}/git_town_specs_upstream_remote"
-end
-
-def upstream_local_repository_path
-  "#{REPOSITORY_BASE}/git_town_specs_upstream_local"
-end
-
-def create_repository path
-  Dir.mkdir path
-  run "git init --bare #{path}"
-end
-
-def clone_repository remote_path, path, bare: false
-  run "git clone #{'--bare' if bare} #{remote_path} #{path}"
-end
-
+# Execute the block at the given path
 def at_path path
   cwd = Dir.pwd
   Dir.chdir path
   result = yield
   Dir.chdir cwd
   result
+end
+
+
+# Create a repository for the given identifier
+def create_repository identifier
+  path = repository_path identifier
+  Dir.mkdir path
+  run "git init --bare #{path}"
+end
+
+
+# Clone the repository signified by parent_idenifier into child_identifier
+def clone_repository parent_identifier, child_identifier, bare: false
+  parent_path = repository_path parent_identifier
+  child_path = repository_path child_identifier
+  run "git clone #{'--bare' if bare} #{parent_path} #{child_path}"
+
+  in_repository child_identifier do
+    user = child_identifier.to_s.gsub('_secondary', '')
+    configure_git user
+  end
+end
+
+
+# Move into the repository with the given repository
+def goto_repository identifier
+  Dir.chdir repository_path identifier
+end
+
+
+# Execute the block in the repository for the given identifier
+def in_repository identifier, parent: :origin, &block
+  path = repository_path identifier
+  clone_repository parent, identifier unless File.directory? path
+  at_path path, &block
+end
+
+
+# Execute the block in a secondary repository of the current user
+def in_secondary_repository &block
+  current_idenitifer = Pathname.new(Dir.pwd).basename
+  in_repository "#{current_idenitifer}_secondary", &block
+end
+
+
+# Returns the repository path for the given identifier
+def repository_path identifier
+  "#{REPOSITORY_BASE}/#{identifier}"
 end

--- a/features/support/run_helpers.rb
+++ b/features/support/run_helpers.rb
@@ -73,7 +73,7 @@ end
 
 
 def run_shell_command command, inputs
-  result = OpenStruct.new(command: command, location: Dir.pwd.split(/[_\/]/).last)
+  result = OpenStruct.new(command: command, location: Pathname.new(Dir.pwd).basename)
   command = "#{shell_overrides}; #{command} 2>&1"
 
   status = Open4.popen4(command) do |_pid, stdin, stdout, _stderr|


### PR DESCRIPTION
@kevgo @allewun 

Repositories now are as follows:

* Before each test
  * create `origin` repository
  * create `developer` repository which is a clone of origin (user is "developer")
* When needed (repo are created on first use)
  * create `coworker` repository which is a clone of origin (user is "coworker")
* To create remote commits (repos are created on first use)
  * create a `developer_secondary` repository which is a clone of origin (user is "developer")
  * create a `coworker_secondary` repository which is a clone of origin (user is "coworker")
* A cucumber step is required to 
  * create `upstream` repository
  * create `upstream_developer` repository which is a clone of upstream (user is "upstream developer")

Also threw away use of the old path functions and now use an identifier (a symbol) to specify the repository