### PR TITLE
Speed up tests

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,7 +3,6 @@ require 'kappamaki'
 require 'open4'
 require 'rspec'
 
-# rubocop:disable all
 
 SOURCE_DIRECTORY = "#{File.dirname(__FILE__)}/../../src"
 SHELL_OVERRIDE_DIRECTORY = "#{File.dirname(__FILE__)}/shell_overrides"
@@ -13,17 +12,18 @@ REPOSITORY_BASE = Dir.mktmpdir
 TOOLS_INSTALLED_FILENAME = "#{REPOSITORY_BASE}/tools_installed.txt"
 
 
-# copy entire contents of MEMOIZED_REPOSITORY_BASE to REPOSITORY_BASE
+# load memoized environment by copying contents
+# of MEMOIZED_REPOSITORY_BASE to REPOSITORY_BASE
 def setup_environment
   FileUtils.rm_rf Dir.glob("#{REPOSITORY_BASE}/*")
   FileUtils.cp_r "#{MEMOIZED_REPOSITORY_BASE}/.", REPOSITORY_BASE
 
-  Dir.chdir REPOSITORY_BASE
   go_to_repository :developer
 end
 
 
-def memoize_environment
+# rubocop:disable Style/GlobalVars, Metrics/AbcSize, Metrics/LineLength
+def initialize_environment
   FileUtils.rm_rf Dir.glob("#{MEMOIZED_REPOSITORY_BASE}/*")
   FileUtils.rm_rf Dir.glob("#{REPOSITORY_BASE}/*")
 
@@ -49,6 +49,7 @@ def memoize_environment
     run 'git branch -d master'
   end
 
+  # memoize environment by saving directory contents
   FileUtils.cp_r "#{REPOSITORY_BASE}/.", MEMOIZED_REPOSITORY_BASE
 
   $memoization_complete = true
@@ -57,7 +58,7 @@ end
 
 Before do
   $memoization_complete ||= false
-  memoize_environment unless $memoization_complete
+  initialize_environment unless $memoization_complete
   setup_environment
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,7 +20,7 @@ def setup_environment
 end
 
 
-# rubocop:disable Style/GlobalVars, Metrics/AbcSize, Metrics/MethodLength
+# rubocop:disable Metrics/MethodLength
 def initialize_environment
   # Create origin repository
   create_repository :origin
@@ -44,14 +44,16 @@ def initialize_environment
 
   # memoize environment by saving directory contents
   FileUtils.cp_r "#{REPOSITORY_BASE}/.", MEMOIZED_REPOSITORY_BASE
-  $memoization_complete = true
 end
-# rubocop:enable Style/GlobalVars, Metrics/AbcSize, Metrics/MethodLength
+# rubocop:enable Metrics/MethodLength
+
+
+AfterConfiguration do
+  initialize_environment
+end
 
 
 Before do
-  $memoization_complete ||= false
-  initialize_environment unless $memoization_complete
   setup_environment
   go_to_repository :developer
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,38 +6,87 @@ require 'rspec'
 SOURCE_DIRECTORY = "#{File.dirname(__FILE__)}/../../src"
 SHELL_OVERRIDE_DIRECTORY = "#{File.dirname(__FILE__)}/shell_overrides"
 
+# MEMOIZED_REPOSITORY_BASE = Dir.mktmpdir 'memoized'
 REPOSITORY_BASE = Dir.mktmpdir
 TOOLS_INSTALLED_FILENAME = "#{REPOSITORY_BASE}/tools_installed.txt"
 
-Before do
-  Dir.chdir REPOSITORY_BASE
-  FileUtils.rm_rf Dir.glob("#{REPOSITORY_BASE}/*")
-
-  # Create origin repository
-  create_repository :origin
-
-  # Create the local repository
-  clone_repository :origin, :developer
-
-  # Create the main branch
-  in_repository :developer do
-    run 'touch .gitignore ; git add .gitignore ; git commit -m "Initial commit"; git push -u origin master'
-    run 'git checkout -b main master ; git push -u origin main'
+class String
+  # colorization
+  def colorize(color_code)
+    "\e[#{color_code}m#{self}\e[0m"
   end
 
+  def yellow
+    colorize(43)
+  end
+end
+
+class MemSingle
+  def initialize
+    @log = Dir.mktmpdir 'memoized2'
+  end
+
+  @@instance = MemSingle.new
+
+  def self.instance
+    return @@instance
+  end
+
+  def val
+    puts "Requested MEM DIR by #{caller_locations(1,1)[0].label} by #{caller_locations(2,1)[0].label} by #{caller_locations(3,1)[0].label}".yellow
+    @log
+  end
+
+  private_class_method :new
+end
+
+
+
+def setup_environment
+  FileUtils.rm_rf Dir.glob("#{REPOSITORY_BASE}/*")
+  FileUtils.cp_r "#{MemSingle.instance.val}/.", REPOSITORY_BASE
+  p 'NO MORE MEM ACCESS AFTER THIS POINT'
+
+  Dir.chdir REPOSITORY_BASE
+  go_to_repository :developer
+end
+
+def memoize_environment
+  Dir.chdir MemSingle.instance.val
+  FileUtils.rm_rf Dir.glob("#{MemSingle.instance.val}/*")
+
+  # Create origin repository
+  create_repository :origin, memoized: true
+
+  # Create the local repository (~1/3)
+  clone_repository :origin, :developer, memoized: true
+
   # Set main as the default branch
-  in_repository :origin do
+  in_repository :origin, memoized: true do
     run 'git symbolic-ref HEAD refs/heads/main'
   end
 
-  # Fetch the default branch, delete master
-  in_repository :developer do
+  in_repository :developer, memoized: true do
+    # Create the main branch (~1/3)
+    run 'touch .gitignore ; git add .gitignore ; git commit -m "Initial commit"; git push -u origin master'
+    run 'git checkout -b main master ; git push -u origin main'
+
+    # Fetch the default branch, delete master (~1/3)
     run 'git fetch'
     run 'git push origin :master'
     run 'git branch -d master'
   end
 
-  go_to_repository :developer
+  $memoization_complete = true
+  p 'DONE MEMOIZING ENVIRONMENT'
+end
+
+
+# rubocop:disable Style/GlobalVars
+Before do
+  $memoization_complete ||= false
+  memoize_environment unless $memoization_complete
+  setup_environment
 end
 
 
@@ -48,4 +97,10 @@ end
 
 at_exit do
   FileUtils.rm_rf REPOSITORY_BASE
+  FileUtils.rm_rf MemSingle.instance.val
 end
+
+# start = Time.now
+# finish = Time.now
+# x = finish - start
+# p "AA [#{x}]"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -24,9 +24,6 @@ end
 
 # rubocop:disable Style/GlobalVars, Metrics/AbcSize, Metrics/LineLength
 def initialize_environment
-  FileUtils.rm_rf Dir.glob("#{MEMOIZED_REPOSITORY_BASE}/*")
-  FileUtils.rm_rf Dir.glob("#{REPOSITORY_BASE}/*")
-
   # Create origin repository
   create_repository :origin
 
@@ -44,14 +41,11 @@ def initialize_environment
     run 'git checkout -b main master ; git push -u origin main'
 
     # Fetch the default branch, delete master
-    run 'git fetch'
-    run 'git push origin :master'
-    run 'git branch -d master'
+    run 'git fetch ; git push origin :master ; git branch -d master'
   end
 
   # memoize environment by saving directory contents
   FileUtils.cp_r "#{REPOSITORY_BASE}/.", MEMOIZED_REPOSITORY_BASE
-
   $memoization_complete = true
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,7 +20,6 @@ def setup_environment
 
   Dir.chdir REPOSITORY_BASE
   go_to_repository :developer
-  end_time = Time.now
 end
 
 
@@ -31,7 +30,7 @@ def memoize_environment
   # Create origin repository
   create_repository :origin
 
-  # Create the local repository (~1/3)
+  # Create the local repository
   clone_repository :origin, :developer
 
   # Set main as the default branch
@@ -40,11 +39,11 @@ def memoize_environment
   end
 
   in_repository :developer do
-    # Create the main branch (~1/3)
+    # Create the main branch
     run 'touch .gitignore ; git add .gitignore ; git commit -m "Initial commit"; git push -u origin master'
     run 'git checkout -b main master ; git push -u origin main'
 
-    # Fetch the default branch, delete master (~1/3)
+    # Fetch the default branch, delete master
     run 'git fetch'
     run 'git push origin :master'
     run 'git branch -d master'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,7 +20,7 @@ def setup_environment
 end
 
 
-# rubocop:disable Style/GlobalVars, Metrics/AbcSize, Metrics/LineLength
+# rubocop:disable Style/GlobalVars, Metrics/AbcSize, Metrics/MethodLength
 def initialize_environment
   # Create origin repository
   create_repository :origin
@@ -46,6 +46,7 @@ def initialize_environment
   FileUtils.cp_r "#{REPOSITORY_BASE}/.", MEMOIZED_REPOSITORY_BASE
   $memoization_complete = true
 end
+# rubocop:enable Style/GlobalVars, Metrics/AbcSize, Metrics/MethodLength
 
 
 Before do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -15,10 +15,8 @@ TOOLS_INSTALLED_FILENAME = "#{REPOSITORY_BASE}/tools_installed.txt"
 # load memoized environment by copying contents
 # of MEMOIZED_REPOSITORY_BASE to REPOSITORY_BASE
 def setup_environment
-  FileUtils.rm_rf Dir.glob("#{REPOSITORY_BASE}/*")
+  FileUtils.rm_rf REPOSITORY_BASE
   FileUtils.cp_r "#{MEMOIZED_REPOSITORY_BASE}/.", REPOSITORY_BASE
-
-  go_to_repository :developer
 end
 
 
@@ -54,6 +52,7 @@ Before do
   $memoization_complete ||= false
   initialize_environment unless $memoization_complete
   setup_environment
+  go_to_repository :developer
 end
 
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,32 +20,24 @@ def setup_environment
 end
 
 
-# rubocop:disable Metrics/MethodLength
 def initialize_environment
-  # Create origin repository
-  create_repository :origin
-
-  # Create the local repository
-  clone_repository :origin, :developer
-
-  # Set main as the default branch
-  in_repository :origin do
+  # Create origin repo and set "main" as default branch
+  create_repository :origin do
     run 'git symbolic-ref HEAD refs/heads/main'
   end
 
-  in_repository :developer do
-    # Create the main branch
-    run 'touch .gitignore ; git add .gitignore ; git commit -m "Initial commit"; git push -u origin master'
-    run 'git checkout -b main master ; git push -u origin main'
+  clone_repository :origin, :developer
 
-    # Fetch the default branch, delete master
-    run 'git fetch ; git push origin :master ; git branch -d master'
+  # Initialize main branch
+  in_repository :developer do
+    run 'git checkout --orphan main'
+    run 'git commit --allow-empty -m "Initial commit"'
+    run 'git push -u origin main'
   end
 
   # memoize environment by saving directory contents
   FileUtils.cp_r "#{REPOSITORY_BASE}/.", MEMOIZED_REPOSITORY_BASE
 end
-# rubocop:enable Metrics/MethodLength
 
 
 AfterConfiguration do

--- a/features/support/files_helpers.rb
+++ b/features/support/files_helpers.rb
@@ -6,7 +6,7 @@ end
 
 # Provides the files that exist in the given branch
 def files_in branch:
-  array_output_of("git ls-tree -r --name-only #{branch}") - ['.gitignore']
+  array_output_of("git ls-tree -r --name-only #{branch}")
 end
 
 

--- a/features/support/repository_helpers.rb
+++ b/features/support/repository_helpers.rb
@@ -53,5 +53,5 @@ end
 
 # Returns the repository path for the given identifier
 def repository_path identifier, memoized: false
-  "#{memoized ? MemSingle.instance.val : REPOSITORY_BASE}/#{identifier}"
+  "#{memoized ? MEMOIZED_REPOSITORY_BASE : REPOSITORY_BASE}/#{identifier}"
 end

--- a/features/support/repository_helpers.rb
+++ b/features/support/repository_helpers.rb
@@ -20,7 +20,6 @@ end
 def clone_repository parent_identifier, child_identifier, bare: false
   parent_path = repository_path parent_identifier
   child_path = repository_path child_identifier
-
   run "git clone #{'--bare' if bare} #{parent_path} #{child_path}"
 
   in_repository child_identifier do

--- a/features/support/repository_helpers.rb
+++ b/features/support/repository_helpers.rb
@@ -9,10 +9,11 @@ end
 
 
 # Create a repository for the given identifier
-def create_repository identifier
+def create_repository identifier, &block
   path = repository_path identifier
   Dir.mkdir path
   run "git init --bare #{path}"
+  at_path path, &block
 end
 
 

--- a/features/support/repository_helpers.rb
+++ b/features/support/repository_helpers.rb
@@ -9,21 +9,21 @@ end
 
 
 # Create a repository for the given identifier
-def create_repository identifier, memoized: false
-  path = repository_path identifier, memoized: memoized
+def create_repository identifier
+  path = repository_path identifier
   Dir.mkdir path
   run "git init --bare #{path}"
 end
 
 
 # Clone the repository signified by parent_idenifier into child_identifier
-def clone_repository parent_identifier, child_identifier, bare: false, memoized: false
-  parent_path = repository_path parent_identifier, memoized: memoized
-  child_path = repository_path child_identifier, memoized: memoized
+def clone_repository parent_identifier, child_identifier, bare: false
+  parent_path = repository_path parent_identifier
+  child_path = repository_path child_identifier
 
   run "git clone #{'--bare' if bare} #{parent_path} #{child_path}"
 
-  in_repository child_identifier, memoized: memoized do
+  in_repository child_identifier do
     user = child_identifier.to_s.sub('_secondary', '')
     configure_git user
   end
@@ -37,9 +37,9 @@ end
 
 
 # Execute the block in the repository for the given identifier
-def in_repository identifier, parent: :origin, memoized: false, &block
-  path = repository_path identifier, memoized: memoized
-  clone_repository parent, identifier, memoized: memoized unless File.directory? path
+def in_repository identifier, parent: :origin, &block
+  path = repository_path identifier
+  clone_repository parent, identifier unless File.directory? path
   at_path path, &block
 end
 
@@ -52,6 +52,6 @@ end
 
 
 # Returns the repository path for the given identifier
-def repository_path identifier, memoized: false
-  "#{memoized ? MEMOIZED_REPOSITORY_BASE : REPOSITORY_BASE}/#{identifier}"
+def repository_path identifier
+  "#{REPOSITORY_BASE}/#{identifier}"
 end


### PR DESCRIPTION
Just experimenting, not sure if the gains are significant.

Setup overhead for each cucumber scenario:

Before | After
----------|-----------
~0.35 sec | ~0.04 sec

**How it works**
I created a "memoized" directory where the initial setup takes place (everything inside the `Before` block in [env.rb](https://github.com/Originate/git-town/blob/be82092bae1d4a068ecbcce6e0bdedaeabd61868/features/support/env.rb#L12-L40)).
Rather than doing this identical setup for every scenario, I just copy the contents of the memoized directory (`MEMOIZED_REPOSITORY_BASE`) into the scenario's working directory (`REPOSITORY_BASE`).

Could use extra eyes to find the problem that I'm having. Some of the tests aren't referencing the correct directory and are mutating the memoized version, which breaks subsequent tests.

From cucumber's output, you can tell since they reference the memoized dir:
`error: failed to push some refs to '/var/folders/ww/55nzqhln637fv4tx_qnlg5_w0000gn/T/memoized20150119-34510-1b144jr/origin'`

@charlierudolph @kevgo 