### PR TITLE
Syntax improvements for CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,11 +43,12 @@ rake test    # Run feature tests
 
 # run single scenario/feature
 cucumber -n 'scenario/feature name'
-cucumber [filename]:[lineno]
+cucumber [filename][:lineno]
 
 # run features in parallel
 bin/cuke [<folder>...]
 ```
+
 
 ## Architecture
 


### PR DESCRIPTION
@charlierudolph @allewun 

The colon is part of the optional "lineno" parameter, and should only be there if the lineno is given. 