### PR TITLE
Better runtime error message

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -57,7 +57,7 @@ end
 
 
 After do
-  expect(@last_run_result.error).to be_falsy, "Expected no runtime error" unless @error_expected
+  expect(@last_run_result.error).to be_falsy, 'Expected no runtime error' unless @error_expected
 end
 
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -57,7 +57,7 @@ end
 
 
 After do
-  expect(@last_run_result.error).to be_falsy unless @error_expected
+  expect(@last_run_result.error).to be_falsy, "Expected no runtime error" unless @error_expected
 end
 
 


### PR DESCRIPTION
@charlierudolph @allewun 

The current message "Expected falsey value, got true" is very confusing, and requires a look-up of the respective code. This error message makes it more clear that a run command failed when it shouldn't.