### PR TITLE
Makes all test overrides have the same structure

### DIFF
--- a/features/support/shell_overrides/man
+++ b/features/support/shell_overrides/man
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# A test mock for "man" (displays documentation)
+
 echo "man called with: $@"


### PR DESCRIPTION
@charlierudolph @allewun 

This makes all test overrides have the same structure. The `man` override was missing this comment.