### PR TITLE
git-hack and git-ship only fetch and push if remote repo exists

### DIFF
--- a/documentation/commands/git-hack.md
+++ b/documentation/commands/git-hack.md
@@ -13,7 +13,8 @@ git hack (--abort | --continue)
 
 #### DESCRIPTION
 
-Sync the main branch and create a new feature branch with the given name.
+Syncs the main branch if there is a remote repository.
+Creates a new feature branch with the given name.
 Brings over all uncommitted changes.
 
 

--- a/documentation/commands/git-ship.md
+++ b/documentation/commands/git-ship.md
@@ -15,11 +15,11 @@ git ship (--abort | --continue)
 
 Squash merges the current branch, or `<branchname>` if given, into the main branch, leading to linear history on the main branch.
 
-* sync the main branch
-* pull remote updates for `<branchname>`
+* sync the main branch if there is a remote repository
+* pull remote updates for `<branchname>` if there is a remote repository
 * merges the main branch into `<branchname>`
 * squash-merges `<branchname>` into the main branch
-* pushes the main branch to the remote repository
+* pushes the main branch to the remote repository if there is a remote repository
 * deletes `<branchname>` from the local and remote repositories
 
 

--- a/features/git-hack/on_feature_branch/with_remote_origin/with_open_changes.feature
+++ b/features/git-hack/on_feature_branch/with_remote_origin/with_open_changes.feature
@@ -1,6 +1,8 @@
-Feature: git hack: starting a new feature from a feature branch (without open changes)
+Feature: git hack: starting a new feature from a feature branch (with open changes and remote repo)
 
-  (see ./with_open_changes.feature)
+  As a developer working on something unrelated to my current feature branch
+  I want to be able to create a new up-to-date feature branch and continue my work there
+  So that my work can exist on its own branch, code reviews remain effective, and my team productive.
 
 
   Background:
@@ -10,6 +12,7 @@ Feature: git hack: starting a new feature from a feature branch (without open ch
       | main             | remote   | main commit             | main_file    |
       | existing_feature | local    | existing feature commit | feature_file |
     And I am on the "existing_feature" branch
+    And I have an uncommitted file with name: "uncommitted" and content: "stuff"
     When I run `git hack new_feature`
 
 
@@ -17,10 +20,13 @@ Feature: git hack: starting a new feature from a feature branch (without open ch
     Then it runs the Git commands
       | BRANCH           | COMMAND                          |
       | existing_feature | git fetch --prune                |
+      | existing_feature | git stash -u                     |
       | existing_feature | git checkout main                |
       | main             | git rebase origin/main           |
       | main             | git checkout -b new_feature main |
+      | new_feature      | git stash pop                    |
     And I end up on the "new_feature" branch
+    And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I have the following commits
       | BRANCH           | LOCATION         | MESSAGE                 | FILE NAME    |
       | main             | local and remote | main commit             | main_file    |

--- a/features/git-hack/on_feature_branch/with_remote_origin/without_open_changes.feature
+++ b/features/git-hack/on_feature_branch/with_remote_origin/without_open_changes.feature
@@ -1,0 +1,28 @@
+Feature: git hack: starting a new feature from a feature branch (without open changes and with remote repo)
+
+  (see ./with_open_changes.feature)
+
+
+  Background:
+    Given I have a feature branch named "existing_feature"
+    And the following commits exist in my repository
+      | BRANCH           | LOCATION | MESSAGE                 | FILE NAME    |
+      | main             | remote   | main commit             | main_file    |
+      | existing_feature | local    | existing feature commit | feature_file |
+    And I am on the "existing_feature" branch
+    When I run `git hack new_feature`
+
+
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH           | COMMAND                          |
+      | existing_feature | git fetch --prune                |
+      | existing_feature | git checkout main                |
+      | main             | git rebase origin/main           |
+      | main             | git checkout -b new_feature main |
+    And I end up on the "new_feature" branch
+    And I have the following commits
+      | BRANCH           | LOCATION         | MESSAGE                 | FILE NAME    |
+      | main             | local and remote | main commit             | main_file    |
+      | existing_feature | local            | existing feature commit | feature_file |
+      | new_feature      | local            | main commit             | main_file    |

--- a/features/git-hack/on_feature_branch/without_remote_origin/with_open_changes.feature
+++ b/features/git-hack/on_feature_branch/without_remote_origin/with_open_changes.feature
@@ -1,15 +1,16 @@
-Feature: git hack: starting a new feature from a feature branch (with open changes)
+Feature: git hack: starting a new feature from a feature branch (with open changes and without remote repo)
 
-  As a developer working on something unrelated to my current feature branch
+  As a developer working on something unrelated to my current feature branch and without a remote repository
   I want to be able to create a new up-to-date feature branch and continue my work there
   So that my work can exist on its own branch, code reviews remain effective, and my team productive.
 
 
   Background:
     Given I have a feature branch named "existing_feature"
+    And my repo does not have a remote origin
     And the following commits exist in my repository
       | BRANCH           | LOCATION | MESSAGE                 | FILE NAME    |
-      | main             | remote   | main commit             | main_file    |
+      | main             | local    | main commit             | main_file    |
       | existing_feature | local    | existing feature commit | feature_file |
     And I am on the "existing_feature" branch
     And I have an uncommitted file with name: "uncommitted" and content: "stuff"
@@ -19,16 +20,13 @@ Feature: git hack: starting a new feature from a feature branch (with open chang
   Scenario: result
     Then it runs the Git commands
       | BRANCH           | COMMAND                          |
-      | existing_feature | git fetch --prune                |
       | existing_feature | git stash -u                     |
-      | existing_feature | git checkout main                |
-      | main             | git rebase origin/main           |
-      | main             | git checkout -b new_feature main |
+      | existing_feature | git checkout -b new_feature main |
       | new_feature      | git stash pop                    |
     And I end up on the "new_feature" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I have the following commits
-      | BRANCH           | LOCATION         | MESSAGE                 | FILE NAME    |
-      | main             | local and remote | main commit             | main_file    |
-      | existing_feature | local            | existing feature commit | feature_file |
-      | new_feature      | local            | main commit             | main_file    |
+      | BRANCH           | LOCATION | MESSAGE                 | FILE NAME    |
+      | main             | local    | main commit             | main_file    |
+      | existing_feature | local    | existing feature commit | feature_file |
+      | new_feature      | local    | main commit             | main_file    |

--- a/features/git-hack/on_feature_branch/without_remote_origin/without_open_changes.feature
+++ b/features/git-hack/on_feature_branch/without_remote_origin/without_open_changes.feature
@@ -1,0 +1,26 @@
+Feature: git hack: starting a new feature from a feature branch (without open changes or remote repo)
+
+  (see ./with_open_changes.feature)
+
+
+  Background:
+    Given I have a feature branch named "existing_feature"
+    And my repo does not have a remote origin
+    And the following commits exist in my repository
+      | BRANCH           | LOCATION | MESSAGE                 | FILE NAME    |
+      | main             | local    | main commit             | main_file    |
+      | existing_feature | local    | existing feature commit | feature_file |
+    And I am on the "existing_feature" branch
+    When I run `git hack new_feature`
+
+
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH           | COMMAND                          |
+      | existing_feature | git checkout -b new_feature main |
+    And I end up on the "new_feature" branch
+    And I have the following commits
+      | BRANCH           | LOCATION | MESSAGE                 | FILE NAME    |
+      | main             | local    | main commit             | main_file    |
+      | existing_feature | local    | existing feature commit | feature_file |
+      | new_feature      | local    | main commit             | main_file    |

--- a/features/git-hack/on_main_branch/with_remote_origin/with_open_changes.feature
+++ b/features/git-hack/on_main_branch/with_remote_origin/with_open_changes.feature
@@ -1,4 +1,4 @@
-Feature: git hack: starting a new feature from the main branch (with open changes)
+Feature: git hack: starting a new feature from the main branch (with open changes and remote repo)
 
   As a developer working on a new feature on the main branch
   I want to be able to create a new up-to-date feature branch and continue my work there

--- a/features/git-hack/on_main_branch/with_remote_origin/without_open_changes.feature
+++ b/features/git-hack/on_main_branch/with_remote_origin/without_open_changes.feature
@@ -1,4 +1,4 @@
-Feature: git hack: starting a new feature from the main branch (without open changes)
+Feature: git hack: starting a new feature from the main branch (without open changes and with remote repo)
 
   (see ./with_open_changes.feature)
 

--- a/features/git-hack/on_main_branch/without_remote_origin/with_open_changes.feature
+++ b/features/git-hack/on_main_branch/without_remote_origin/with_open_changes.feature
@@ -1,0 +1,29 @@
+Feature: git hack: starting a new feature from the main branch (with open changes and without remote repo)
+
+  As a developer working on a new feature on the main branch and without a remote repository
+  I want to be able to create a new up-to-date feature branch and continue my work there
+  So that my work can exist on its own branch, code reviews remain effective, and my team productive.
+
+
+  Background:
+    Given my repo does not have a remote origin
+    And the following commit exists in my repository
+      | BRANCH | LOCATION | MESSAGE     | FILE NAME |
+      | main   | local    | main_commit | main_file |
+    And I am on the "main" branch
+    And I have an uncommitted file with name: "uncommitted" and content: "stuff"
+    When I run `git hack new_feature`
+
+
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH      | COMMAND                          |
+      | main        | git stash -u                     |
+      | main        | git checkout -b new_feature main |
+      | new_feature | git stash pop                    |
+    And I end up on the "new_feature" branch
+    And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
+    And I have the following commits
+      | BRANCH      | LOCATION | MESSAGE     | FILE NAME |
+      | main        | local    | main_commit | main_file |
+      | new_feature | local    | main_commit | main_file |

--- a/features/git-hack/on_main_branch/without_remote_origin/without_open_changes.feature
+++ b/features/git-hack/on_main_branch/without_remote_origin/without_open_changes.feature
@@ -1,0 +1,23 @@
+Feature: git hack: starting a new feature from the main branch (without open changes or remote repo)
+
+  (see ./with_open_changes.feature)
+
+
+  Background:
+    Given my repo does not have a remote origin
+    And the following commit exists in my repository
+      | BRANCH | LOCATION | MESSAGE     | FILE NAME |
+      | main   | local    | main_commit | main_file |
+    And I am on the "main" branch
+    When I run `git hack new_feature`
+
+
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH | COMMAND                          |
+      | main   | git checkout -b new_feature main |
+    And I end up on the "new_feature" branch
+    And I have the following commits
+      | BRANCH      | LOCATION | MESSAGE     | FILE NAME |
+      | main        | local    | main_commit | main_file |
+      | new_feature | local    | main_commit | main_file |

--- a/features/git-ship/current_branch/on_feature_branch/without_open_changes/without_remote_origin.feature
+++ b/features/git-ship/current_branch/on_feature_branch/without_open_changes/without_remote_origin.feature
@@ -1,0 +1,30 @@
+Feature: git ship: shipping the current feature branch without a remote origin
+
+  As a developer having finished a feature and on repo without a remote origin
+  I want to be able to ship it safely in one easy step
+  So that I can quickly move on to the next feature and remain productive.
+
+
+  Background:
+    Given I have a feature branch named "feature"
+    And my repo does not have a remote origin
+    And the following commit exists in my repository
+      | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
+      | feature | local    | feature_file | feature content |
+    And I am on the "feature" branch
+    When I run `git ship -m "feature done"`
+
+
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH  | COMMAND                      |
+      | feature | git merge --no-edit main     |
+      | feature | git checkout main            |
+      | main    | git merge --squash feature   |
+      | main    | git commit -m "feature done" |
+      | main    | git branch -D feature        |
+    And I end up on the "main" branch
+    And there is no "feature" branch
+    And I have the following commits
+      | BRANCH | LOCATION | MESSAGE      | FILE NAME    |
+      | main   | local    | feature done | feature_file |

--- a/features/git-ship/supplied_branch/feature_branch/without_remote_origin.feature
+++ b/features/git-ship/supplied_branch/feature_branch/without_remote_origin.feature
@@ -1,0 +1,52 @@
+Feature: git ship: shipping the supplied feature branch without a remote origin
+
+  (see ../../current_branch/on_feature_branch/without_open_changes/without_remote_origin.feature)
+
+
+  Background:
+    Given I have feature branches named "feature" and "other_feature"
+    And my repo does not have a remote origin
+    And the following commit exists in my repository
+      | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
+      | feature | local    | feature commit | feature_file | feature content |
+    And I am on the "other_feature" branch
+
+
+  Scenario: with open changes
+    Given I have an uncommitted file with name: "feature_file" and content: "conflicting content"
+    When I run `git ship feature -m "feature done"`
+    Then it runs the Git commands
+      | BRANCH        | COMMAND                      |
+      | other_feature | git stash -u                 |
+      | other_feature | git checkout feature         |
+      | feature       | git merge --no-edit main     |
+      | feature       | git checkout main            |
+      | main          | git merge --squash feature   |
+      | main          | git commit -m "feature done" |
+      | main          | git branch -D feature        |
+      | main          | git checkout other_feature   |
+      | other_feature | git stash pop                |
+    And I end up on the "other_feature" branch
+    And I still have an uncommitted file with name: "feature_file" and content: "conflicting content"
+    And there is no "feature" branch
+    And I have the following commits
+      | BRANCH | LOCATION | MESSAGE      | FILE NAME    |
+      | main   | local    | feature done | feature_file |
+
+
+  Scenario: without open changes
+    When I run `git ship feature -m "feature done"`
+    Then it runs the Git commands
+      | BRANCH        | COMMAND                      |
+      | other_feature | git checkout feature         |
+      | feature       | git merge --no-edit main     |
+      | feature       | git checkout main            |
+      | main          | git merge --squash feature   |
+      | main          | git commit -m "feature done" |
+      | main          | git branch -D feature        |
+      | main          | git checkout other_feature   |
+    And I end up on the "other_feature" branch
+    And there is no "feature" branch
+    And I have the following commits
+      | BRANCH | LOCATION | MESSAGE      | FILE NAME    |
+      | main   | local    | feature done | feature_file |

--- a/features/step_definitions/remote_steps.rb
+++ b/features/step_definitions/remote_steps.rb
@@ -5,6 +5,11 @@ Given(/^my repo has an upstream repo$/) do
 end
 
 
+Given(/^my repo does not have a remote origin$/) do
+  run 'git remote rm origin'
+end
+
+
 Given(/^my remote origin is (.+?)$/) do |origin|
   run "git remote set-url origin #{origin}"
 end

--- a/src/git-hack
+++ b/src/git-hack
@@ -14,7 +14,11 @@ function ensure_has_target_branch {
 function preconditions {
   target_branch_name=$1
   ensure_has_target_branch
-  fetch
+
+  if [ "$(has_remote_url)" = true ]; then
+    fetch
+  fi
+
   ensure_does_not_have_branch "$target_branch_name"
 }
 
@@ -24,9 +28,12 @@ function steps {
     echo "stash_open_changes"
   fi
 
-  echo "checkout_main_branch"
-  echo "rebase_tracking_branch"
-  echo "push"
+  if [ "$(has_remote_url)" = true ]; then
+    echo "checkout_main_branch"
+    echo "rebase_tracking_branch"
+    echo "push"
+  fi
+
   echo "create_and_checkout_feature_branch '$target_branch_name'"
 
   if [ "$initial_open_changes" = true ]; then

--- a/src/git-ship
+++ b/src/git-ship
@@ -27,16 +27,21 @@ function preconditions {
 
 
 function steps {
+  local has_remote="$(has_remote_url)"
+
   if [ "$target_branch_name" != "$initial_branch_name" ]; then
     if [ "$initial_open_changes" = true ]; then
       echo "stash_open_changes"
     fi
   fi
 
-  echo "checkout_main_branch"
-  echo "fetch"
-  echo "rebase_tracking_branch"
-  echo "push"
+  if [ "$has_remote" = true ]; then
+    echo "checkout_main_branch"
+    echo "fetch"
+    echo "rebase_tracking_branch"
+    echo "push"
+  fi
+
   echo "checkout $target_branch_name"
   echo "merge_tracking_branch"
   echo "merge $main_branch_name"
@@ -44,7 +49,11 @@ function steps {
   echo "checkout_main_branch"
   echo "squash_merge $target_branch_name"
   echo "commit_squash_merge $target_branch_name $commit_options"
-  echo "push"
+
+  if [ "$has_remote" = true ]; then
+    echo "push"
+  fi
+
   if [ "$(has_tracking_branch "$target_branch_name")" = true ]; then
     echo "delete_remote_branch $target_branch_name"
   fi

--- a/src/helpers/configuration.sh
+++ b/src/helpers/configuration.sh
@@ -16,7 +16,7 @@ export non_feature_branch_names=$(get_configuration non-feature-branch-names)
 
 
 # Bypass the configuration if requested by caller (e.g. git-town)
-if [[ $@ =~ --bypass-automatic-configuration ]]; then
+if [[ "$@" =~ --bypass-automatic-configuration ]]; then
   return 0
 fi
 

--- a/src/helpers/environment.sh
+++ b/src/helpers/environment.sh
@@ -16,6 +16,6 @@ function ensure_git_repository {
 }
 
 
-if [[ ! $@ =~ --bypass-environment-checks ]]; then
+if [[ ! "$@" =~ --bypass-environment-checks ]]; then
   ensure_git_repository
 fi

--- a/src/helpers/git_helpers/remote_helpers.sh
+++ b/src/helpers/git_helpers/remote_helpers.sh
@@ -18,3 +18,13 @@ function remote_repository_name {
   local domain=$(remote_domain)
   remote_url | sed -E "s#.*$domain[/:](.+)#\1#" | sed "s/\.git$//"
 }
+
+
+# Returns true if the repository has a remote configured
+function has_remote_url {
+  if [ -z "$(remote_url)" ]; then
+    echo false
+  else
+    echo true
+  fi
+}


### PR DESCRIPTION
If the repo has a remote url, then do as before, otherwise skip any remote operations. Closes #370 

This definitely came up when I wanted to just try it out at first.