### PR TITLE
Output newlines when dumping actual console output

### DIFF
--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -37,7 +37,7 @@ Then(/^I get the error$/) do |error_message|
   expect(actual).to include(error_message), %(
     ACTUAL
     ***************************************************
-    #{actual.dump}
+    #{actual.dump.gsub '\n', "\n"}
     ***************************************************
     EXPECTED TO INCLUDE
     ***************************************************

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -41,7 +41,7 @@ Then(/^I get the error$/) do |error_message|
     ***************************************************
     EXPECTED TO INCLUDE
     ***************************************************
-    #{error_message.dump}
+    #{error_message.dump.gsub '\n', "\n"}
     ***************************************************
   ).gsub(/^ {4}/, '')
 end


### PR DESCRIPTION
@charlierudolph @allewun 

This improves the readability of console output when verifying error messages.