### PR TITLE
More robust Fish autocompletion installation

### DIFF
--- a/features/git-town/setup/install_fish_autocomplete.feature
+++ b/features/git-town/setup/install_fish_autocomplete.feature
@@ -24,7 +24,7 @@ Feature: Installing Fish Shell autocomplete definitions
 
 
   Scenario: with an existing Git autocompletion file
-    Given I have a different Git autocompletion file
+    Given I have an existing Git autocompletion file
     When I run `git town install-fish-autocompletion`
     Then it runs no shell commands
     And I get the error "You already have an existing Fish shell autocompletion definition for Git"

--- a/features/git-town/setup/install_fish_autocomplete.feature
+++ b/features/git-town/setup/install_fish_autocomplete.feature
@@ -10,17 +10,17 @@ Feature: Installing Fish Shell autocomplete definitions
     Given I have no fish autocompletion folder
     When I run `git town install-fish-autocompletion`
     Then it runs the following shell commands to install the Fish shell autocompletion
-      | COMMAND                                                                                |
-      | mkdir -p ~/.config/fish/completions                                                    |
-      | ln -s [[GIT_TOWN_DIRECTORY]]/autocomplete/git.fish ~/.config/fish/completions/git.fish |
+      | COMMAND                                                                                   |
+      | mkdir -p ~/.config/fish/completions                                                       |
+      | ln -s <%= GIT_TOWN_DIRECTORY %>/autocomplete/git.fish ~/.config/fish/completions/git.fish |
 
 
   Scenario: with empty fish autocompletion folder
     Given I have an empty fish autocompletion folder
     When I run `git town install-fish-autocompletion`
     Then it runs the following shell commands to install the Fish shell autocompletion
-      | COMMAND                                                                             |
-      | ln -s [[GIT_TOWN_DIRECTORY]]/autocomplete/git.fish ~/.config/fish/completions/git.fish |
+      | COMMAND                                                                                   |
+      | ln -s <%= GIT_TOWN_DIRECTORY %>/autocomplete/git.fish ~/.config/fish/completions/git.fish |
 
 
   Scenario: with an existing Git autocompletion file

--- a/features/git-town/setup/install_fish_autocomplete.feature
+++ b/features/git-town/setup/install_fish_autocomplete.feature
@@ -1,3 +1,4 @@
+@modifies-fish-completions
 Feature: Installing Fish Shell autocomplete definitions
 
   As a Fish shell user
@@ -5,9 +6,36 @@ Feature: Installing Fish Shell autocomplete definitions
   So that I can use this tool productively despite not having time for long installation procedures.
 
 
-  Scenario: with a standard Fish setup
+  Scenario: without existing fish autocompletion folder
+    Given I have no fish autocompletion folder
     When I run `git town install-fish-autocompletion`
     Then it runs the following shell commands to install the Fish shell autocompletion
-      | COMMAND                                                                                                                       |
-      | mkdir -p ~/.config/fish/completions                                                                                           |
-      | curl -o ~/.config/fish/completions/git.fish https://raw.githubusercontent.com/Originate/git-town/master/autocomplete/git.fish |
+      | COMMAND                                                                                |
+      | mkdir -p ~/.config/fish/completions                                                    |
+      | ln -s [[GIT_TOWN_DIRECTORY]]/autocomplete/git.fish ~/.config/fish/completions/git.fish |
+
+
+  Scenario: with empty fish autocompletion folder
+    Given I have an empty fish autocompletion folder
+    When I run `git town install-fish-autocompletion`
+    Then it runs the following shell commands to install the Fish shell autocompletion
+      | COMMAND                                                                             |
+      | ln -s [[GIT_TOWN_DIRECTORY]]/autocomplete/git.fish ~/.config/fish/completions/git.fish |
+
+
+  Scenario: with an existing Git autocompletion file
+    Given I have a different Git autocompletion file
+    When I run `git town install-fish-autocompletion`
+    Then it runs no shell commands
+    And I get the error "You already have an existing Fish shell autocompletion definition for Git"
+    And I get the error "Operation aborted"
+    And I still have my different Git autocompletion file
+
+
+  Scenario: with existing Git autocompletion symlink
+    Given I already have the Git autocompletion symlink
+    When I run `git town install-fish-autocompletion`
+    Then it runs no shell commands
+    And I get the error "You already have an existing Fish shell autocompletion definition for Git"
+    And I get the error "Operation aborted"
+    And I still have my Git autocompletion symlink

--- a/features/git-town/setup/install_fish_autocomplete.feature
+++ b/features/git-town/setup/install_fish_autocomplete.feature
@@ -27,7 +27,7 @@ Feature: Installing Fish Shell autocomplete definitions
     Given I have an existing Git autocompletion file
     When I run `git town install-fish-autocompletion`
     Then it runs no shell commands
-    And I get the error "You already have an existing Fish shell autocompletion definition for Git"
+    And I get the error "Git autocompletion for Fish shell already exists"
     And I get the error "Operation aborted"
     And I still have my original Git autocompletion file
 
@@ -36,6 +36,6 @@ Feature: Installing Fish Shell autocomplete definitions
     Given I already have the Git autocompletion symlink
     When I run `git town install-fish-autocompletion`
     Then it runs no shell commands
-    And I get the error "You already have an existing Fish shell autocompletion definition for Git"
+    And I get the error "Git autocompletion for Fish shell already exists"
     And I get the error "Operation aborted"
     And I still have my original Git autocompletion symlink

--- a/features/git-town/setup/install_fish_autocomplete.feature
+++ b/features/git-town/setup/install_fish_autocomplete.feature
@@ -29,7 +29,7 @@ Feature: Installing Fish Shell autocomplete definitions
     Then it runs no shell commands
     And I get the error "You already have an existing Fish shell autocompletion definition for Git"
     And I get the error "Operation aborted"
-    And I still have my different Git autocompletion file
+    And I still have my original Git autocompletion file
 
 
   Scenario: with existing Git autocompletion symlink
@@ -38,4 +38,4 @@ Feature: Installing Fish Shell autocomplete definitions
     Then it runs no shell commands
     And I get the error "You already have an existing Fish shell autocompletion definition for Git"
     And I get the error "Operation aborted"
-    And I still have my Git autocompletion symlink
+    And I still have my original Git autocompletion symlink

--- a/features/step_definitions/folder_steps.rb
+++ b/features/step_definitions/folder_steps.rb
@@ -1,14 +1,12 @@
 Given(/^I already have the Git autocompletion symlink$/) do
   FileUtils.rm FISH_AUTOCOMPLETIONS_PATH
-  FileUtils.symlink 'foo',
-                    FISH_AUTOCOMPLETIONS_PATH
+  FileUtils.symlink 'foo', FISH_AUTOCOMPLETIONS_PATH
 end
 
 
 Given(/^I have an existing Git autocompletion file$/) do
   FileUtils.rm FISH_AUTOCOMPLETIONS_PATH
-  IO.write FISH_AUTOCOMPLETIONS_PATH,
-           'existing Git autocompletion data'
+  IO.write FISH_AUTOCOMPLETIONS_PATH, 'existing Git autocompletion data'
 end
 
 

--- a/features/step_definitions/folder_steps.rb
+++ b/features/step_definitions/folder_steps.rb
@@ -26,12 +26,12 @@ end
 
 
 
-Then(/^I still have my different Git autocompletion file$/) do
   expect(IO.read File.expand_path('~/.config/fish/completions/git.fish'))
     .to eql 'existing Git autocompletion data'
+Then(/^I still have my original Git autocompletion file$/) do
 end
 
 
-Then(/^I still have my Git autocompletion symlink$/) do
   expect(File.symlink? File.expand_path('~/.config/fish/completions/git.fish')).to be_truthy
+Then(/^I still have my original Git autocompletion symlink$/) do
 end

--- a/features/step_definitions/folder_steps.rb
+++ b/features/step_definitions/folder_steps.rb
@@ -28,7 +28,7 @@ end
 
 Then(/^I still have my different Git autocompletion file$/) do
   expect(IO.read File.expand_path('~/.config/fish/completions/git.fish'))
-      .to eql 'existing Git autocompletion data'
+    .to eql 'existing Git autocompletion data'
 end
 
 

--- a/features/step_definitions/folder_steps.rb
+++ b/features/step_definitions/folder_steps.rb
@@ -1,0 +1,37 @@
+Given(/^I already have the Git autocompletion symlink$/) do
+  FileUtils.rm File.expand_path('~/.config/fish/completions/git.fish')
+  FileUtils.symlink 'foo',
+                    File.expand_path('~/.config/fish/completions/git.fish')
+end
+
+
+Given(/^I have a different Git autocompletion file$/) do
+  FileUtils.rm File.expand_path('~/.config/fish/completions/git.fish')
+  IO.write File.expand_path('~/.config/fish/completions/git.fish'),
+           'existing Git autocompletion data'
+end
+
+
+Given(/^I have no fish autocompletion folder$/) do
+  FileUtils.rm_rf File.expand_path('~/.config/fish/completions')
+end
+
+
+Given(/^I have an empty fish autocompletion folder$/) do
+  suppress do
+    FileUtils.rm File.expand_path('~/.config/fish/completions/git.fish')
+  end
+end
+
+
+
+
+Then(/^I still have my different Git autocompletion file$/) do
+  expect(IO.read File.expand_path('~/.config/fish/completions/git.fish'))
+      .to eql 'existing Git autocompletion data'
+end
+
+
+Then(/^I still have my Git autocompletion symlink$/) do
+  expect(File.symlink? File.expand_path('~/.config/fish/completions/git.fish')).to be_truthy
+end

--- a/features/step_definitions/folder_steps.rb
+++ b/features/step_definitions/folder_steps.rb
@@ -18,9 +18,7 @@ end
 
 
 Given(/^I have an empty fish autocompletion folder$/) do
-  suppress do
-    FileUtils.rm FISH_AUTOCOMPLETIONS_PATH
-  end
+  FileUtils.rm_r FISH_AUTOCOMPLETIONS_PATH
 end
 
 

--- a/features/step_definitions/folder_steps.rb
+++ b/features/step_definitions/folder_steps.rb
@@ -1,13 +1,13 @@
 Given(/^I already have the Git autocompletion symlink$/) do
-  FileUtils.rm File.expand_path('~/.config/fish/completions/git.fish')
+  FileUtils.rm FISH_AUTOCOMPLETIONS_PATH
   FileUtils.symlink 'foo',
-                    File.expand_path('~/.config/fish/completions/git.fish')
+                    FISH_AUTOCOMPLETIONS_PATH
 end
 
 
 Given(/^I have an existing Git autocompletion file$/) do
-  FileUtils.rm File.expand_path('~/.config/fish/completions/git.fish')
-  IO.write File.expand_path('~/.config/fish/completions/git.fish'),
+  FileUtils.rm FISH_AUTOCOMPLETIONS_PATH
+  IO.write FISH_AUTOCOMPLETIONS_PATH,
            'existing Git autocompletion data'
 end
 
@@ -19,19 +19,18 @@ end
 
 Given(/^I have an empty fish autocompletion folder$/) do
   suppress do
-    FileUtils.rm File.expand_path('~/.config/fish/completions/git.fish')
+    FileUtils.rm FISH_AUTOCOMPLETIONS_PATH
   end
 end
 
 
 
 
-  expect(IO.read File.expand_path('~/.config/fish/completions/git.fish'))
-    .to eql 'existing Git autocompletion data'
 Then(/^I still have my original Git autocompletion file$/) do
+  expect(IO.read FISH_AUTOCOMPLETIONS_PATH).to eql 'existing Git autocompletion data'
 end
 
 
-  expect(File.symlink? File.expand_path('~/.config/fish/completions/git.fish')).to be_truthy
 Then(/^I still have my original Git autocompletion symlink$/) do
+  expect(File.symlink? FISH_AUTOCOMPLETIONS_PATH).to be_truthy
 end

--- a/features/step_definitions/folder_steps.rb
+++ b/features/step_definitions/folder_steps.rb
@@ -5,7 +5,7 @@ Given(/^I already have the Git autocompletion symlink$/) do
 end
 
 
-Given(/^I have a different Git autocompletion file$/) do
+Given(/^I have an existing Git autocompletion file$/) do
   FileUtils.rm File.expand_path('~/.config/fish/completions/git.fish')
   IO.write File.expand_path('~/.config/fish/completions/git.fish'),
            'existing Git autocompletion data'

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -52,7 +52,7 @@ Then(/^I get the error "(.+?)"$/) do |error_message|
 end
 
 
-Then(/^it runs no Git commands$/) do
+Then(/^it runs no (?:Git|shell)? commands$/) do
   expect(commands_of_last_run).to be_empty
 end
 
@@ -73,6 +73,9 @@ end
 
 
 Then(/^it runs the following shell commands/) do |expected_commands|
+  expected_commands.map_column! 'COMMAND' do |command|
+    command.gsub '[[GIT_TOWN_DIRECTORY]]', File.expand_path('..', SOURCE_DIRECTORY)
+  end
   expected_commands.diff! commands_of_last_run_outside_git.unshift(expected_commands.headers)
 end
 

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -74,7 +74,8 @@ end
 
 Then(/^it runs the following shell commands/) do |expected_commands|
   expected_commands.map_column! 'COMMAND' do |command|
-    command.gsub '[[GIT_TOWN_DIRECTORY]]', File.expand_path('..', SOURCE_DIRECTORY)
+    GIT_TOWN_DIRECTORY = File.expand_path('..', SOURCE_DIRECTORY)
+    ERB.new(command).result
   end
   expected_commands.diff! commands_of_last_run_outside_git.unshift(expected_commands.headers)
 end

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -52,7 +52,7 @@ Then(/^I get the error "(.+?)"$/) do |error_message|
 end
 
 
-Then(/^it runs no (?:Git|shell)? commands$/) do
+Then(/^it runs no (?:Git|shell) commands$/) do
   expect(commands_of_last_run).to be_empty
 end
 

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -74,7 +74,6 @@ end
 
 Then(/^it runs the following shell commands/) do |expected_commands|
   expected_commands.map_column! 'COMMAND' do |command|
-    GIT_TOWN_DIRECTORY = File.expand_path('..', SOURCE_DIRECTORY)
     ERB.new(command).result
   end
   expected_commands.diff! commands_of_last_run_outside_git.unshift(expected_commands.headers)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,6 +12,8 @@ MEMOIZED_REPOSITORY_BASE = Dir.mktmpdir 'memoized'
 REPOSITORY_BASE = Dir.mktmpdir
 TOOLS_INSTALLED_FILENAME = "#{REPOSITORY_BASE}/tools_installed.txt"
 
+FISH_AUTOCOMPLETIONS_PATH = File.expand_path '~/.config/fish/completions/git.fish'
+
 
 # load memoized environment by copying contents
 # of MEMOIZED_REPOSITORY_BASE to REPOSITORY_BASE

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -66,7 +66,7 @@ After '~@finishes-with-non-empty-stash' do
 end
 
 
-Around '@modifies-fish-autocompletions' do |scenario, block|
+Around '@modifies-fish-autocompletions' do |_scenario, block|
   completions_path = File.expand_path('~/.config/fish/completions')
   backup_path = File.expand_path('~/__config_fish_backup__')
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,6 +5,7 @@ require 'rspec'
 
 
 SOURCE_DIRECTORY = "#{File.dirname(__FILE__)}/../../src"
+GIT_TOWN_DIRECTORY = File.expand_path('..', SOURCE_DIRECTORY)
 SHELL_OVERRIDE_DIRECTORY = "#{File.dirname(__FILE__)}/shell_overrides"
 
 MEMOIZED_REPOSITORY_BASE = Dir.mktmpdir 'memoized'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -66,6 +66,20 @@ After '~@finishes-with-non-empty-stash' do
 end
 
 
+Around '@modifies-fish-autocompletions' do |scenario, block|
+  completions_path = File.expand_path('~/.config/fish/completions')
+  backup_path = File.expand_path('~/__config_fish_backup__')
+
+  FileUtils.cp_r completions_path, backup_path
+
+  block.call
+
+  FileUtils.rm_rf completions_path
+  FileUtils.cp_r backup_path, completions_path
+  FileUtils.rm_rf backup_path
+end
+
+
 at_exit do
   FileUtils.rm_rf REPOSITORY_BASE
   FileUtils.rm_rf MEMOIZED_REPOSITORY_BASE

--- a/src/git-town
+++ b/src/git-town
@@ -1,11 +1,29 @@
 #!/usr/bin/env bash
-source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/helpers/helpers.sh" --bypass-automatic-configuration --bypass-environment-checks
+base_dir=$( dirname "${BASH_SOURCE[0]}" )
+source "$( cd "$base_dir" && pwd )/helpers/helpers.sh" --bypass-automatic-configuration --bypass-environment-checks
 
 
 # Installs the autocompletion definition for Fish shell
 function install_fish_autocompletion {
-  run_command_outside_git "mkdir -p ~/.config/fish/completions"
-  run_command_outside_git "curl -o ~/.config/fish/completions/git.fish https://raw.githubusercontent.com/Originate/git-town/master/autocomplete/git.fish"
+
+  # Determine the Git Town source code directory that contains the autocompletion data
+  cd "$base_dir/../autocomplete"
+  autocomplete_folder=$(pwd)
+  cd -
+
+  # Optionally create the autocompeletion folder for Fish shell
+  if [ ! -d ~/.config/fish/completions ]; then
+    run_command_outside_git "mkdir -p ~/.config/fish/completions"
+  fi
+
+  # Ensure there are no existing autocompletions for Fish shell
+  if [ -e ~/.config/fish/completions/git.fish ] || [ -h ~/.config/fish/completions/git.fish ]; then
+    echo_inline_error 'You already have an existing Fish shell autocompletion definition for Git'
+    echo_inline_error 'Operation aborted'
+    exit_with_error
+  fi
+
+  run_command_outside_git "ln -s $autocomplete_folder/git.fish ~/.config/fish/completions/git.fish"
 }
 
 

--- a/src/git-town
+++ b/src/git-town
@@ -16,7 +16,7 @@ function install_fish_autocompletion {
 
   # Ensure there are no existing autocompletions for Fish shell
   if [ -e ~/.config/fish/completions/git.fish ] || [ -h ~/.config/fish/completions/git.fish ]; then
-    echo_inline_error 'You already have an existing Fish shell autocompletion definition for Git'
+    echo_inline_error 'Git autocompletion for Fish shell already exists'
     echo_inline_error 'Operation aborted'
     exit_with_error
   fi

--- a/src/git-town
+++ b/src/git-town
@@ -7,9 +7,7 @@ source "$( cd "$base_dir" && pwd )/helpers/helpers.sh" --bypass-automatic-config
 function install_fish_autocompletion {
 
   # Determine the Git Town source code directory that contains the autocompletion data
-  cd "$base_dir/../autocomplete"
-  autocomplete_folder=$(pwd)
-  cd -
+  local autocomplete_folder=$( cd "$base_dir/../autocomplete" && pwd )
 
   # Optionally create the autocompeletion folder for Fish shell
   if [ ! -d ~/.config/fish/completions ]; then

--- a/src/git-town
+++ b/src/git-town
@@ -13,7 +13,7 @@ function install_fish_autocompletion {
 
   # Optionally create the autocompeletion folder for Fish shell
   if [ ! -d ~/.config/fish/completions ]; then
-    run_command_outside_git "mkdir -p ~/.config/fish/completions"
+    run_command "mkdir -p ~/.config/fish/completions"
   fi
 
   # Ensure there are no existing autocompletions for Fish shell


### PR DESCRIPTION
@charlierudolph @allewun 

This extended autocompletion 
* uses the already downloaded autocompletion definition, as suggested by @allewun 
* uses a symlink to the downloaded autocompletion definition, so that it auto-updates as Git Town is updated
* doesn't overwrite existing Git autocompletion definition files
