### PR TITLE
Improve error message for missing runtime errors

### DIFF
--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -32,7 +32,7 @@ end
 
 Then(/^I get the error$/) do |error_message|
   @error_expected = true
-  expect(@last_run_result).to_not be_nil, "Error message expected, but no commands were run"
+  expect(@last_run_result).to_not be_nil, 'Error message expected, but no commands were run'
   expect(@last_run_result.error).to be_truthy
   actual = unformatted_last_run_output
   expect(actual).to include(error_message), %(

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -32,6 +32,7 @@ end
 
 Then(/^I get the error$/) do |error_message|
   @error_expected = true
+  expect(@last_run_result).to_not be_nil, "Error message expected, but no commands were run"
   expect(@last_run_result.error).to be_truthy
   actual = unformatted_last_run_output
   expect(actual).to include(error_message), %(

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -57,7 +57,9 @@ end
 
 
 After do
-  expect(@last_run_result.try :error).to be_falsy, 'Expected no runtime error' unless @error_expected
+  if @last_run_result && !@error_expected
+    expect(@last_run_result.error).to be_falsy, 'Expected no runtime error'
+  end
 end
 
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -57,7 +57,7 @@ end
 
 
 After do
-  expect(@last_run_result.error).to be_falsy, 'Expected no runtime error' unless @error_expected
+  expect(@last_run_result.try :error).to be_falsy, 'Expected no runtime error' unless @error_expected
 end
 
 


### PR DESCRIPTION
@charlierudolph @allewun 

I never liked the obscure error message `undefined method 'errors' for nil` when there were runtime errors expected and they didn't happen. This fixes it.