### PR TITLE
Support git-kill and git-sync without remote

### DIFF
--- a/features/git-kill/current_branch/on_feature_branch/without_tracking_branch/without_remote_origin.feature
+++ b/features/git-kill/current_branch/on_feature_branch/without_tracking_branch/without_remote_origin.feature
@@ -1,0 +1,45 @@
+Feature: git kill: killing the current feature branch without a tracking branch (without open changes or remote origin)
+
+  (see ./with_open_changes.feature)
+
+
+  Background:
+    Given I have a feature branch named "feature"
+    And my repo does not have a remote origin
+    And I have a local feature branch named "dead-feature"
+    And the following commits exist in my repository
+      | BRANCH       | LOCATION | MESSAGE         | FILE NAME        |
+      | feature      | local    | good commit     | good_file        |
+      | dead-feature | local    | dead-end commit | unfortunate_file |
+    And I am on the "dead-feature" branch
+    When I run `git kill`
+
+
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH       | COMMAND                    |
+      | dead-feature | git checkout main          |
+      | main         | git branch -D dead-feature |
+    And I end up on the "main" branch
+    And the existing branches are
+      | REPOSITORY | BRANCHES      |
+      | local      | main, feature |
+    And I have the following commits
+      | BRANCH  | LOCATION | MESSAGE     | FILE NAME |
+      | feature | local    | good commit | good_file |
+
+
+  Scenario: Undoing a kill of a local feature branch
+    When I run `git kill --undo`
+    Then it runs the Git commands
+      | BRANCH | COMMAND                                       |
+      | main   | git branch dead-feature [SHA:dead-end commit] |
+      | main   | git checkout dead-feature                     |
+    And I end up on the "dead-feature" branch
+    And the existing branches are
+      | REPOSITORY | BRANCHES                    |
+      | local      | main, dead-feature, feature |
+    And I have the following commits
+      | BRANCH       | LOCATION | MESSAGE         | FILE NAME        |
+      | feature      | local    | good commit     | good_file        |
+      | dead-feature | local    | dead-end commit | unfortunate_file |

--- a/features/git-kill/supplied_branch/feature_branch/without_remote_origin.feature
+++ b/features/git-kill/supplied_branch/feature_branch/without_remote_origin.feature
@@ -1,0 +1,42 @@
+Feature: git kill: killing the given feature branch (without open changes or remote origin)
+
+  (see ./with_open_changes.feature)
+
+
+  Background:
+    Given I have feature branches named "feature" and "dead-feature"
+    And my repo does not have a remote origin
+    And the following commits exist in my repository
+      | BRANCH       | LOCATION | MESSAGE         | FILE NAME        |
+      | feature      | local    | good commit     | good_file        |
+      | dead-feature | local    | dead-end commit | unfortunate_file |
+    And I am on the "feature" branch
+    When I run `git kill dead-feature`
+
+
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH  | COMMAND                    |
+      | feature | git branch -D dead-feature |
+    And I am still on the "feature" branch
+    And the existing branches are
+      | REPOSITORY | BRANCHES      |
+      | local      | main, feature |
+    And I have the following commits
+      | BRANCH  | LOCATION | MESSAGE     | FILE NAME |
+      | feature | local    | good commit | good_file |
+
+
+  Scenario: undoing the kill
+    When I run `git kill --undo`
+    Then it runs the Git commands
+      | BRANCH  | COMMAND                                       |
+      | feature | git branch dead-feature [SHA:dead-end commit] |
+    And I am still on the "feature" branch
+    And the existing branches are
+      | REPOSITORY | BRANCHES                    |
+      | local      | main, dead-feature, feature |
+    And I have the following commits
+      | BRANCH       | LOCATION | MESSAGE         | FILE NAME        |
+      | feature      | local    | good commit     | good_file        |
+      | dead-feature | local    | dead-end commit | unfortunate_file |

--- a/features/git-kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
+++ b/features/git-kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
@@ -1,0 +1,45 @@
+Feature: git kill: killing the given feature branch when on it (without open changes or remote origin)
+
+  (see ./with_open_changes.feature)
+
+
+  Background:
+    Given I have feature branches named "feature" and "dead-feature"
+    And my repo does not have a remote origin
+    And the following commits exist in my repository
+      | BRANCH       | LOCATION | MESSAGE         | FILE NAME        |
+      | feature      | local    | good commit     | good_file        |
+      | dead-feature | local    | dead-end commit | unfortunate_file |
+    And I am on the "dead-feature" branch
+    When I run `git kill dead-feature`
+
+
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH       | COMMAND                    |
+      | dead-feature | git checkout main          |
+      | main         | git branch -D dead-feature |
+    And I end up on the "main" branch
+    And the existing branches are
+      | REPOSITORY | BRANCHES      |
+      | local      | main, feature |
+    And I have the following commits
+      | BRANCH  | LOCATION | MESSAGE     | FILE NAME |
+      | feature | local    | good commit | good_file |
+
+
+  Scenario: undoing the kill
+    When I run `git kill --undo`
+    Then it runs the Git commands
+      | BRANCH | COMMAND                                       |
+      | main   | git branch dead-feature [SHA:dead-end commit] |
+      | main   | git checkout dead-feature                     |
+    And I end up on the "dead-feature" branch
+    And the existing branches are
+      | REPOSITORY | BRANCHES                    |
+      | local      | main, dead-feature, feature |
+    And I have the following commits
+      | BRANCH       | LOCATION | MESSAGE         | FILE NAME        |
+      | feature      | local    | good commit     | good_file        |
+      | dead-feature | local    | dead-end commit | unfortunate_file |
+

--- a/features/git-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch/first_branch/with_open_changes.feature
+++ b/features/git-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch/first_branch/with_open_changes.feature
@@ -1,0 +1,122 @@
+Feature: git sync --all: handling merge conflicts between feature branch and main branch (with open changes and without remote origin)
+
+  Background:
+    Given I have feature branches named "feature1" and "feature2"
+    And my repo does not have a remote origin
+    And the following commits exist in my repository
+      | BRANCH   | LOCATION | MESSAGE         | FILE NAME        | FILE CONTENT     |
+      | main     | local    | main commit     | conflicting_file | main content     |
+      | feature1 | local    | feature1 commit | conflicting_file | feature1 content |
+      | feature2 | local    | feature2 commit | feature2_file    | feature2 content |
+    And I am on the "main" branch
+    And I have an uncommitted file with name: "uncommitted" and content: "stuff"
+    When I run `git sync --all`
+
+
+  @finishes-with-non-empty-stash
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH   | COMMAND                  |
+      | main     | git stash -u             |
+      | main     | git checkout feature1    |
+      | feature1 | git merge --no-edit main |
+    And I get the error
+      """
+      To abort, run "git sync --abort".
+      To continue after you have resolved the conflicts, run "git sync --continue".
+      To skip the sync of the 'feature1' branch, run "git sync --skip".
+      """
+    And I end up on the "feature1" branch
+    And I don't have an uncommitted file with name: "uncommitted"
+    And my repo has a merge in progress
+
+
+  Scenario: aborting
+    When I run `git sync --abort`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND           |
+      | feature1 | git merge --abort |
+      | feature1 | git checkout main |
+      | main     | git stash pop     |
+    And I end up on the "main" branch
+    And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE         | FILE NAME        |
+      | main     | local    | main commit     | conflicting_file |
+      | feature1 | local    | feature1 commit | conflicting_file |
+      | feature2 | local    | feature2 commit | feature2_file    |
+
+
+  Scenario: skipping
+    When I run `git sync --skip`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND                  |
+      | feature1 | git merge --abort        |
+      | feature1 | git checkout feature2    |
+      | feature2 | git merge --no-edit main |
+      | feature2 | git checkout main        |
+      | main     | git stash pop            |
+    And I end up on the "main" branch
+    And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE                           | FILE NAME        |
+      | main     | local    | main commit                       | conflicting_file |
+      | feature1 | local    | feature1 commit                   | conflicting_file |
+      | feature2 | local    | feature2 commit                   | feature2_file    |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature2 |                  |
+
+
+  @finishes-with-non-empty-stash
+  Scenario: continuing without resolving the conflicts
+    When I run `git sync --continue`
+    Then it runs no Git commands
+    And I get the error "You must resolve the conflicts before continuing the git sync"
+    And I am still on the "feature1" branch
+    And I don't have an uncommitted file with name: "uncommitted"
+    And my repo still has a merge in progress
+
+
+  Scenario: continuing after resolving the conflicts
+    Given I resolve the conflict in "conflicting_file"
+    And I run `git sync --continue`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND                  |
+      | feature1 | git commit --no-edit     |
+      | feature1 | git checkout feature2    |
+      | feature2 | git merge --no-edit main |
+      | feature2 | git checkout main        |
+      | main     | git stash pop            |
+    And I end up on the "main" branch
+    And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE                           | FILE NAME        |
+      | main     | local    | main commit                       | conflicting_file |
+      | feature1 | local    | feature1 commit                   | conflicting_file |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature1 |                  |
+      | feature2 | local    | feature2 commit                   | feature2_file    |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature2 |                  |
+
+
+  Scenario: continuing after resolving the conflicts and committing
+    Given I resolve the conflict in "conflicting_file"
+    And I run `git commit --no-edit; git sync --continue`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND                  |
+      | feature1 | git checkout feature2    |
+      | feature2 | git merge --no-edit main |
+      | feature2 | git checkout main        |
+      | main     | git stash pop            |
+    And I end up on the "main" branch
+    And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE                           | FILE NAME        |
+      | main     | local    | main commit                       | conflicting_file |
+      | feature1 | local    | feature1 commit                   | conflicting_file |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature1 |                  |
+      | feature2 | local    | feature2 commit                   | feature2_file    |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature2 |                  |

--- a/features/git-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch/first_branch/without_open_changes.feature
+++ b/features/git-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch/first_branch/without_open_changes.feature
@@ -1,0 +1,108 @@
+Feature: git sync --all: handling merge conflicts between feature branch and main branch (without open changes or remote origin)
+
+  Background:
+    Given I have feature branches named "feature1" and "feature2"
+    And my repo does not have a remote origin
+    And the following commits exist in my repository
+      | BRANCH   | LOCATION | MESSAGE         | FILE NAME        | FILE CONTENT     |
+      | main     | local    | main commit     | conflicting_file | main content     |
+      | feature1 | local    | feature1 commit | conflicting_file | feature1 content |
+      | feature2 | local    | feature2 commit | feature2_file    | feature2 content |
+    And I am on the "main" branch
+    When I run `git sync --all`
+
+
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH   | COMMAND                  |
+      | main     | git checkout feature1    |
+      | feature1 | git merge --no-edit main |
+    And I get the error
+      """
+      To abort, run "git sync --abort".
+      To continue after you have resolved the conflicts, run "git sync --continue".
+      To skip the sync of the 'feature1' branch, run "git sync --skip".
+      """
+    And I end up on the "feature1" branch
+    And my repo has a merge in progress
+
+
+  Scenario: aborting
+    When I run `git sync --abort`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND           |
+      | feature1 | git merge --abort |
+      | feature1 | git checkout main |
+    And I end up on the "main" branch
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE         | FILE NAME        |
+      | main     | local    | main commit     | conflicting_file |
+      | feature1 | local    | feature1 commit | conflicting_file |
+      | feature2 | local    | feature2 commit | feature2_file    |
+
+
+  Scenario: skipping
+    When I run `git sync --skip`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND                  |
+      | feature1 | git merge --abort        |
+      | feature1 | git checkout feature2    |
+      | feature2 | git merge --no-edit main |
+      | feature2 | git checkout main        |
+    And I end up on the "main" branch
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE                           | FILE NAME        |
+      | main     | local    | main commit                       | conflicting_file |
+      | feature1 | local    | feature1 commit                   | conflicting_file |
+      | feature2 | local    | feature2 commit                   | feature2_file    |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature2 |                  |
+
+
+  Scenario: continuing without resolving the conflicts
+    When I run `git sync --continue`
+    Then it runs no Git commands
+    And I get the error "You must resolve the conflicts before continuing the git sync"
+    And I am still on the "feature1" branch
+    And my repo still has a merge in progress
+
+
+  Scenario: continuing after resolving the conflicts
+    Given I resolve the conflict in "conflicting_file"
+    And I run `git sync --continue`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND                  |
+      | feature1 | git commit --no-edit     |
+      | feature1 | git checkout feature2    |
+      | feature2 | git merge --no-edit main |
+      | feature2 | git checkout main        |
+    And I end up on the "main" branch
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE                           | FILE NAME        |
+      | main     | local    | main commit                       | conflicting_file |
+      | feature1 | local    | feature1 commit                   | conflicting_file |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature1 |                  |
+      | feature2 | local    | feature2 commit                   | feature2_file    |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature2 |                  |
+
+
+  Scenario: continuing after resolving the conflicts and committing
+    Given I resolve the conflict in "conflicting_file"
+    And I run `git commit --no-edit; git sync --continue`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND                  |
+      | feature1 | git checkout feature2    |
+      | feature2 | git merge --no-edit main |
+      | feature2 | git checkout main        |
+    And I end up on the "main" branch
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE                           | FILE NAME        |
+      | main     | local    | main commit                       | conflicting_file |
+      | feature1 | local    | feature1 commit                   | conflicting_file |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature1 |                  |
+      | feature2 | local    | feature2 commit                   | feature2_file    |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature2 |                  |

--- a/features/git-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch/last_branch/with_open_changes.feature
+++ b/features/git-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch/last_branch/with_open_changes.feature
@@ -1,0 +1,121 @@
+Feature: git sync --all: handling merge conflicts between feature branch and main branch (with open changes and without remote origin)
+
+  Background:
+    Given I have feature branches named "feature1" and "feature2"
+    And my repo does not have a remote origin
+    And the following commits exist in my repository
+      | BRANCH   | LOCATION | MESSAGE         | FILE NAME        | FILE CONTENT     |
+      | main     | local    | main commit     | conflicting_file | main content     |
+      | feature1 | local    | feature1 commit | feature1_file    | feature1 content |
+      | feature2 | local    | feature2 commit | conflicting_file | feature2 content |
+    And I am on the "main" branch
+    And I have an uncommitted file with name: "uncommitted" and content: "stuff"
+    When I run `git sync --all`
+
+
+  @finishes-with-non-empty-stash
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH   | COMMAND                  |
+      | main     | git stash -u             |
+      | main     | git checkout feature1    |
+      | feature1 | git merge --no-edit main |
+      | feature1 | git checkout feature2    |
+      | feature2 | git merge --no-edit main |
+    And I get the error
+      """
+      To abort, run "git sync --abort".
+      To continue after you have resolved the conflicts, run "git sync --continue".
+      To skip the sync of the 'feature2' branch, run "git sync --skip".
+      """
+    And I end up on the "feature2" branch
+    And I don't have an uncommitted file with name: "uncommitted"
+    And my repo has a merge in progress
+
+
+  Scenario: aborting
+    When I run `git sync --abort`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND                                |
+      | feature2 | git merge --abort                      |
+      | feature2 | git checkout feature1                  |
+      | feature1 | git reset --hard [SHA:feature1 commit] |
+      | feature1 | git checkout main                      |
+      | main     | git stash pop                          |
+    And I end up on the "main" branch
+    And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE         | FILE NAME        |
+      | main     | local    | main commit     | conflicting_file |
+      | feature1 | local    | feature1 commit | feature1_file    |
+      | feature2 | local    | feature2 commit | conflicting_file |
+
+
+  Scenario: skipping
+    When I run `git sync --skip`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND           |
+      | feature2 | git merge --abort |
+      | feature2 | git checkout main |
+      | main     | git stash pop     |
+    And I end up on the "main" branch
+    And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE                           | FILE NAME        |
+      | main     | local    | main commit                       | conflicting_file |
+      | feature1 | local    | feature1 commit                   | feature1_file    |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature1 |                  |
+      | feature2 | local    | feature2 commit                   | conflicting_file |
+
+
+  @finishes-with-non-empty-stash
+  Scenario: continuing without resolving the conflicts
+    When I run `git sync --continue`
+    Then it runs no Git commands
+    And I get the error "You must resolve the conflicts before continuing the git sync"
+    And I am still on the "feature2" branch
+    And I don't have an uncommitted file with name: "uncommitted"
+    And my repo still has a merge in progress
+
+
+  Scenario: continuing after resolving the conflicts
+    Given I resolve the conflict in "conflicting_file"
+    And I run `git sync --continue`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND              |
+      | feature2 | git commit --no-edit |
+      | feature2 | git checkout main    |
+      | main     | git stash pop        |
+    And I end up on the "main" branch
+    And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE                           | FILE NAME        |
+      | main     | local    | main commit                       | conflicting_file |
+      | feature1 | local    | feature1 commit                   | feature1_file    |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature1 |                  |
+      | feature2 | local    | feature2 commit                   | conflicting_file |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature2 |                  |
+
+
+
+  Scenario: continuing after resolving the conflicts and committing
+    Given I resolve the conflict in "conflicting_file"
+    And I run `git commit --no-edit; git sync --continue`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND           |
+      | feature2 | git checkout main |
+      | main     | git stash pop     |
+    And I end up on the "main" branch
+    And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE                           | FILE NAME        |
+      | main     | local    | main commit                       | conflicting_file |
+      | feature1 | local    | feature1 commit                   | feature1_file    |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature1 |                  |
+      | feature2 | local    | feature2 commit                   | conflicting_file |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature2 |                  |

--- a/features/git-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch/last_branch/without_open_changes.feature
+++ b/features/git-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch/last_branch/without_open_changes.feature
@@ -1,0 +1,106 @@
+Feature: git sync --all: handling merge conflicts between feature branch and main branch (without open changes or remote origin)
+
+  Background:
+    Given I have feature branches named "feature1" and "feature2"
+    And my repo does not have a remote origin
+    And the following commits exist in my repository
+      | BRANCH   | LOCATION | MESSAGE         | FILE NAME        | FILE CONTENT     |
+      | main     | local    | main commit     | conflicting_file | main content     |
+      | feature1 | local    | feature1 commit | feature1_file    | feature1 content |
+      | feature2 | local    | feature2 commit | conflicting_file | feature2 content |
+    And I am on the "main" branch
+    When I run `git sync --all`
+
+
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH   | COMMAND                  |
+      | main     | git checkout feature1    |
+      | feature1 | git merge --no-edit main |
+      | feature1 | git checkout feature2    |
+      | feature2 | git merge --no-edit main |
+    And I get the error
+      """
+      To abort, run "git sync --abort".
+      To continue after you have resolved the conflicts, run "git sync --continue".
+      To skip the sync of the 'feature2' branch, run "git sync --skip".
+      """
+    And I end up on the "feature2" branch
+    And my repo has a merge in progress
+
+
+  Scenario: aborting
+    When I run `git sync --abort`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND                                |
+      | feature2 | git merge --abort                      |
+      | feature2 | git checkout feature1                  |
+      | feature1 | git reset --hard [SHA:feature1 commit] |
+      | feature1 | git checkout main                      |
+    And I end up on the "main" branch
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE         | FILE NAME        |
+      | main     | local    | main commit     | conflicting_file |
+      | feature1 | local    | feature1 commit | feature1_file    |
+      | feature2 | local    | feature2 commit | conflicting_file |
+
+
+  Scenario: skipping
+    When I run `git sync --skip`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND           |
+      | feature2 | git merge --abort |
+      | feature2 | git checkout main |
+    And I end up on the "main" branch
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE                           | FILE NAME        |
+      | main     | local    | main commit                       | conflicting_file |
+      | feature1 | local    | feature1 commit                   | feature1_file    |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature1 |                  |
+      | feature2 | local    | feature2 commit                   | conflicting_file |
+
+
+  Scenario: continuing without resolving the conflicts
+    When I run `git sync --continue`
+    Then it runs no Git commands
+    And I get the error "You must resolve the conflicts before continuing the git sync"
+    And I am still on the "feature2" branch
+    And my repo still has a merge in progress
+
+
+  Scenario: continuing after resolving the conflicts
+    Given I resolve the conflict in "conflicting_file"
+    And I run `git sync --continue`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND              |
+      | feature2 | git commit --no-edit |
+      | feature2 | git checkout main    |
+    And I end up on the "main" branch
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE                           | FILE NAME        |
+      | main     | local    | main commit                       | conflicting_file |
+      | feature1 | local    | feature1 commit                   | feature1_file    |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature1 |                  |
+      | feature2 | local    | feature2 commit                   | conflicting_file |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature2 |                  |
+
+
+  Scenario: continuing after resolving the conflicts and committing
+    Given I resolve the conflict in "conflicting_file"
+    And I run `git commit --no-edit; git sync --continue`
+    Then it runs the Git commands
+      | BRANCH   | COMMAND           |
+      | feature2 | git checkout main |
+    And I end up on the "main" branch
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE                           | FILE NAME        |
+      | main     | local    | main commit                       | conflicting_file |
+      | feature1 | local    | feature1 commit                   | feature1_file    |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature1 |                  |
+      | feature2 | local    | feature2 commit                   | conflicting_file |
+      |          |          | main commit                       | conflicting_file |
+      |          |          | Merge branch 'main' into feature2 |                  |

--- a/features/git-sync/all_branches/no_conflict/feature_branches/without_remote_origin.feature
+++ b/features/git-sync/all_branches/no_conflict/feature_branches/without_remote_origin.feature
@@ -1,0 +1,31 @@
+Feature: git sync --all: syncs all feature branches (without open changes or remote origin)
+
+  Background:
+    Given I have feature branches named "feature1" and "feature2"
+    And my repo does not have a remote origin
+    And the following commits exist in my repository
+      | BRANCH   | LOCATION | MESSAGE         | FILE NAME     |
+      | main     | local    | main commit     | main_file     |
+      | feature1 | local    | feature1 commit | feature1_file |
+      | feature2 | local    | feature2 commit | feature2_file |
+    And I am on the "feature1" branch
+    When I run `git sync --all`
+
+
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH   | COMMAND                  |
+      | feature1 | git merge --no-edit main |
+      | feature1 | git checkout feature2    |
+      | feature2 | git merge --no-edit main |
+      | feature2 | git checkout feature1    |
+    And I am still on the "feature1" branch
+    And I have the following commits
+      | BRANCH   | LOCATION | MESSAGE                           | FILE NAME     |
+      | main     | local    | main commit                       | main_file     |
+      | feature1 | local    | feature1 commit                   | feature1_file |
+      |          |          | main commit                       | main_file     |
+      |          |          | Merge branch 'main' into feature1 |               |
+      | feature2 | local    | feature2 commit                   | feature2_file |
+      |          |          | main commit                       | main_file     |
+      |          |          | Merge branch 'main' into feature2 |               |

--- a/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_tracking_branch/with_open_changes.feature
+++ b/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_tracking_branch/with_open_changes.feature
@@ -1,0 +1,95 @@
+Feature: git sync: resolving conflicts between the current feature branch and the main branch (with open changes and without remote origin)
+
+  Background:
+    Given I have a feature branch named "feature"
+    And my repo does not have a remote origin
+    And the following commits exist in my repository
+      | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
+      | main    | local    | conflicting main commit    | conflicting_file | main content    |
+      | feature | local    | conflicting feature commit | conflicting_file | feature content |
+    And I am on the "feature" branch
+    And I have an uncommitted file with name: "uncommitted" and content: "stuff"
+    When I run `git sync`
+
+
+  @finishes-with-non-empty-stash
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH  | COMMAND                  |
+      | feature | git stash -u             |
+      | feature | git merge --no-edit main |
+    And I get the error
+      """
+      To abort, run "git sync --abort".
+      To continue after you have resolved the conflicts, run "git sync --continue".
+      To skip the sync of the 'feature' branch, run "git sync --skip".
+      """
+    And I am still on the "feature" branch
+    And I don't have an uncommitted file with name: "uncommitted"
+    And my repo has a merge in progress
+
+
+  Scenario: aborting
+    When I run `git sync --abort`
+    Then it runs the Git commands
+      | BRANCH  | COMMAND           |
+      | feature | git merge --abort |
+      | feature | git stash pop     |
+    And I am still on the "feature" branch
+    And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
+    And there is no merge in progress
+    And I still have the following commits
+      | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
+      | main    | local    | conflicting main commit    | conflicting_file | main content    |
+      | feature | local    | conflicting feature commit | conflicting_file | feature content |
+
+
+  @finishes-with-non-empty-stash
+  Scenario: continuing without resolving the conflicts
+    When I run `git sync --continue`
+    Then it runs no Git commands
+    And I get the error "You must resolve the conflicts before continuing the git sync"
+    And I am still on the "feature" branch
+    And I don't have an uncommitted file with name: "uncommitted"
+    And my repo still has a merge in progress
+
+
+  Scenario: continuing after resolving the conflicts
+    Given I resolve the conflict in "conflicting_file"
+    When I run `git sync --continue`
+    Then it runs the Git commands
+      | BRANCH  | COMMAND              |
+      | feature | git commit --no-edit |
+      | feature | git stash pop        |
+    And I am still on the "feature" branch
+    And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
+    And I still have the following commits
+      | BRANCH  | LOCATION | MESSAGE                          | FILE NAME        |
+      | main    | local    | conflicting main commit          | conflicting_file |
+      | feature | local    | conflicting feature commit       | conflicting_file |
+      |         |          | conflicting main commit          | conflicting_file |
+      |         |          | Merge branch 'main' into feature |                  |
+    And I still have the following committed files
+      | BRANCH  | FILES            | CONTENT          |
+      | main    | conflicting_file | main content     |
+      | feature | conflicting_file | resolved content |
+
+
+  Scenario: continuing after resolving the conflicts and comitting
+    Given I resolve the conflict in "conflicting_file"
+    When I run `git commit --no-edit; git sync --continue`
+    Then it runs the Git commands
+      | BRANCH  | COMMAND       |
+      | feature | git stash pop |
+    And I am still on the "feature" branch
+    And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
+    And I still have the following commits
+      | BRANCH  | LOCATION | MESSAGE                          | FILE NAME        |
+      | main    | local    | conflicting main commit          | conflicting_file |
+      | feature | local    | conflicting feature commit       | conflicting_file |
+      |         |          | conflicting main commit          | conflicting_file |
+      |         |          | Merge branch 'main' into feature |                  |
+    And I still have the following committed files
+      | BRANCH  | FILES            | CONTENT          |
+      | main    | conflicting_file | main content     |
+      | feature | conflicting_file | resolved content |

--- a/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_tracking_branch/without_open_changes.feature
+++ b/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_tracking_branch/without_open_changes.feature
@@ -1,0 +1,81 @@
+Feature: git sync: resolving conflicts between the current feature branch and the main branch (without open changes or remote origin)
+
+  Background:
+    Given I have a feature branch named "feature"
+    And my repo does not have a remote origin
+    And the following commits exist in my repository
+      | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
+      | main    | local    | conflicting main commit    | conflicting_file | main content    |
+      | feature | local    | conflicting feature commit | conflicting_file | feature content |
+    And I am on the "feature" branch
+    When I run `git sync`
+
+
+  Scenario: result
+    Then it runs the Git commands
+      | BRANCH  | COMMAND                  |
+      | feature | git merge --no-edit main |
+    And I get the error
+      """
+      To abort, run "git sync --abort".
+      To continue after you have resolved the conflicts, run "git sync --continue".
+      To skip the sync of the 'feature' branch, run "git sync --skip".
+      """
+    And I am still on the "feature" branch
+    And my repo has a merge in progress
+
+
+  Scenario: aborting
+    When I run `git sync --abort`
+    Then it runs the Git commands
+      | BRANCH  | COMMAND           |
+      | feature | git merge --abort |
+    And I am still on the "feature" branch
+    And there is no merge in progress
+    And I still have the following commits
+      | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
+      | main    | local    | conflicting main commit    | conflicting_file | main content    |
+      | feature | local    | conflicting feature commit | conflicting_file | feature content |
+
+
+  Scenario: continuing without resolving the conflicts
+    When I run `git sync --continue`
+    Then it runs no Git commands
+    And I get the error "You must resolve the conflicts before continuing the git sync"
+    And I am still on the "feature" branch
+    And my repo still has a merge in progress
+
+
+  Scenario: continuing after resolving the conflicts
+    Given I resolve the conflict in "conflicting_file"
+    When I run `git sync --continue`
+    Then it runs the Git commands
+      | BRANCH  | COMMAND              |
+      | feature | git commit --no-edit |
+    And I am still on the "feature" branch
+    And I still have the following commits
+      | BRANCH  | LOCATION | MESSAGE                          | FILE NAME        |
+      | main    | local    | conflicting main commit          | conflicting_file |
+      | feature | local    | conflicting feature commit       | conflicting_file |
+      |         |          | conflicting main commit          | conflicting_file |
+      |         |          | Merge branch 'main' into feature |                  |
+    And I still have the following committed files
+      | BRANCH  | FILES            | CONTENT          |
+      | main    | conflicting_file | main content     |
+      | feature | conflicting_file | resolved content |
+
+
+  Scenario: continuing after resolving the conflicts and comitting
+    Given I resolve the conflict in "conflicting_file"
+    When I run `git commit --no-edit; git sync --continue`
+    And I am still on the "feature" branch
+    And I still have the following commits
+      | BRANCH  | LOCATION | MESSAGE                          | FILE NAME        |
+      | main    | local    | conflicting main commit          | conflicting_file |
+      | feature | local    | conflicting feature commit       | conflicting_file |
+      |         |          | conflicting main commit          | conflicting_file |
+      |         |          | Merge branch 'main' into feature |                  |
+    And I still have the following committed files
+      | BRANCH  | FILES            | CONTENT          |
+      | main    | conflicting_file | main content     |
+      | feature | conflicting_file | resolved content |

--- a/features/git-sync/current_branch/feature_branch/no_conflict/without_remote_origin.feature
+++ b/features/git-sync/current_branch/feature_branch/no_conflict/without_remote_origin.feature
@@ -1,0 +1,45 @@
+Feature: git sync: syncing the current feature branch (without a tracking branch or remote origin)
+
+  (see ./with_a_tracking_branch.feature)
+
+
+  Background:
+    Given I have a local feature branch named "feature"
+    And my repo does not have a remote origin
+    And the following commits exist in my repository
+      | BRANCH  | LOCATION | MESSAGE              | FILE NAME          |
+      | main    | local    | local main commit    | local_main_file    |
+      | feature | local    | local feature commit | local_feature_file |
+    And I am on the "feature" branch
+
+
+  Scenario: with open changes
+    Given I have an uncommitted file with name: "uncommitted" and content: "stuff"
+    When I run `git sync`
+    Then it runs the Git commands
+      | BRANCH  | COMMAND                  |
+      | feature | git stash -u             |
+      | feature | git merge --no-edit main |
+      | feature | git stash pop            |
+    And I am still on the "feature" branch
+    And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
+    And I have the following commits
+      | BRANCH  | LOCATION | MESSAGE                          | FILE NAME          |
+      | main    | local    | local main commit                | local_main_file    |
+      | feature | local    | local feature commit             | local_feature_file |
+      |         |          | local main commit                | local_main_file    |
+      |         |          | Merge branch 'main' into feature |                    |
+
+
+  Scenario: without open changes
+    When I run `git sync`
+    Then it runs the Git commands
+      | BRANCH  | COMMAND                  |
+      | feature | git merge --no-edit main |
+    And I am still on the "feature" branch
+    And I have the following commits
+      | BRANCH  | LOCATION | MESSAGE                          | FILE NAME          |
+      | main    | local    | local main commit                | local_main_file    |
+      | feature | local    | local feature commit             | local_feature_file |
+      |         |          | local main commit                | local_main_file    |
+      |         |          | Merge branch 'main' into feature |                    |

--- a/src/git-kill
+++ b/src/git-kill
@@ -15,7 +15,11 @@ function preconditions {
   target_branch=$(branch_to_kill "$@")
 
   ensure_is_feature_branch "$target_branch" "You can only kill feature branches."
-  fetch
+
+  if [ "$(has_remote_url)" = true ]; then
+      fetch
+  fi
+
   if [ "$target_branch" != "$initial_branch_name" ]; then
     ensure_has_branch "$target_branch"
   fi
@@ -24,15 +28,12 @@ function preconditions {
 
 function steps {
   if [ "$target_branch" = "$initial_branch_name" ]; then
-    if [ "$initial_open_changes" = true ]; then
-      echo "commit_open_changes"
-    fi
+    echo_if_true "commit_open_changes" "$initial_open_changes"
     echo "checkout_main_branch"
   fi
 
-  if [ "$(has_tracking_branch "$target_branch")" = true ]; then
-    echo "delete_remote_branch $target_branch"
-  fi
+  echo_if_true "delete_remote_branch $target_branch" \
+      "$(has_tracking_branch "$target_branch")"
 
   echo "delete_local_branch $target_branch force"
 }

--- a/src/git-sync
+++ b/src/git-sync
@@ -16,7 +16,9 @@ function branches_to_sync {
 
 
 function preconditions {
-  fetch
+  if [ "$(has_remote_url)" = true ]; then
+      fetch
+  fi
 
   should_push_tags=false
   sync_all=false
@@ -44,32 +46,37 @@ function skippable {
 
 
 function steps {
-  if [ "$initial_open_changes" = true ]; then
-    echo "stash_open_changes"
-  fi
+  local has_remote="$(has_remote_url)"
+
+  echo_if_true "stash_open_changes" "$initial_open_changes"
 
   branches_to_sync | while read branch_name; do
-    echo "checkout $branch_name"
+    local is_feature="$(is_feature_branch "$branch_name")"
 
-    if [ "$(is_feature_branch "$branch_name")" = true ]; then
-      echo "merge_tracking_branch"
-      echo "merge $main_branch_name"
-    else
-      echo "rebase_tracking_branch"
+    # If there is a remote origin, then checkout and sync all branches because
+    # there may be changes to non-feature branches, otherwise only sync feature
+    # branches because non-feature branches will not need syncing
+    if [ "$has_remote" = true ] || [ "$is_feature" = true ]; then
+      echo "checkout $branch_name"
+
+      if [ "$is_feature" = true ]; then
+        echo "merge_tracking_branch"
+        echo "merge $main_branch_name"
+      else
+        echo "rebase_tracking_branch"
+      fi
+
+      echo_if_true "push" "$has_remote"
     fi
-
-    echo "push"
   done
 
-  if [ "$should_push_tags" = true ]; then
+  if [ "$has_remote" = true ] && [ "$should_push_tags" = true ]; then
     echo "push_tags"
   fi
 
   echo "checkout $initial_branch_name"
 
-  if [ "$initial_open_changes" = true ]; then
-    echo "restore_open_changes"
-  fi
+  echo_if_true "restore_open_changes" "$initial_open_changes"
 }
 
 

--- a/src/helpers/script_helpers.sh
+++ b/src/helpers/script_helpers.sh
@@ -83,6 +83,17 @@ function preconditions {
 }
 
 
+# Echos command if condition is true
+function echo_if_true {
+  local git_command="$1"
+  local condition="$2"
+
+  if [ "$condition" = true ]; then
+    echo "$git_command"
+  fi
+}
+
+
 function remove_step_files {
   if [ "$(has_file "$steps_file")" = true ]; then
     rm "$steps_file"


### PR DESCRIPTION
If the repo has a remote url, then do as before, otherwise skip any remote operations.

git-extract still left to support without remote.