### PR TITLE
Verify files through Cucumber tables

### DIFF
--- a/features/git-hack/main_branch_rebase_tracking_branch_conflict/with_open_changes.feature
+++ b/features/git-hack/main_branch_rebase_tracking_branch_conflict/with_open_changes.feature
@@ -72,7 +72,7 @@ Feature: git hack: resolving conflicts between main branch and its tracking bran
       | new_feature | local            | conflicting remote commit | conflicting_file |
       |             |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH      | FILES            | CONTENT          |
+      | BRANCH      | NAME             | CONTENT          |
       | main        | conflicting_file | resolved content |
       | new_feature | conflicting_file | resolved content |
 
@@ -94,6 +94,6 @@ Feature: git hack: resolving conflicts between main branch and its tracking bran
       | new_feature | local            | conflicting remote commit | conflicting_file |
       |             |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH      | FILES            | CONTENT          |
+      | BRANCH      | NAME             | CONTENT          |
       | main        | conflicting_file | resolved content |
       | new_feature | conflicting_file | resolved content |

--- a/features/git-hack/main_branch_rebase_tracking_branch_conflict/without_open_changes.feature
+++ b/features/git-hack/main_branch_rebase_tracking_branch_conflict/without_open_changes.feature
@@ -60,7 +60,7 @@ Feature: git hack: resolving conflicts between main branch and its tracking bran
       | new_feature | local            | conflicting remote commit | conflicting_file |
       |             |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH      | FILES            | CONTENT          |
+      | BRANCH      | NAME             | CONTENT          |
       | main        | conflicting_file | resolved content |
       | new_feature | conflicting_file | resolved content |
 
@@ -80,6 +80,6 @@ Feature: git hack: resolving conflicts between main branch and its tracking bran
       | new_feature | local            | conflicting remote commit | conflicting_file |
       |             |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH      | FILES            | CONTENT          |
+      | BRANCH      | NAME             | CONTENT          |
       | main        | conflicting_file | resolved content |
       | new_feature | conflicting_file | resolved content |

--- a/features/git-sync-fork/main_branch/rebase_upstream_conflict_with_open_changes.feature
+++ b/features/git-sync-fork/main_branch/rebase_upstream_conflict_with_open_changes.feature
@@ -54,7 +54,7 @@ Feature: git-sync-fork: handling rebase conflicts between main branch and its re
       | main   | local, remote, and upstream | upstream commit | conflicting_file |
       | main   | local, remote               | local commit    | conflicting_file |
     And now I have the following committed files
-      | BRANCH | FILES            | CONTENT          |
+      | BRANCH | NAME             | CONTENT          |
       | main   | conflicting_file | resolved content |
 
 
@@ -72,5 +72,5 @@ Feature: git-sync-fork: handling rebase conflicts between main branch and its re
       | main   | local, remote, and upstream | upstream commit | conflicting_file |
       | main   | local, remote               | local commit    | conflicting_file |
     And now I have the following committed files
-      | BRANCH | FILES            | CONTENT          |
+      | BRANCH | NAME             | CONTENT          |
       | main   | conflicting_file | resolved content |

--- a/features/git-sync-fork/main_branch/rebase_upstream_conflict_without_open_changes.feature
+++ b/features/git-sync-fork/main_branch/rebase_upstream_conflict_without_open_changes.feature
@@ -46,7 +46,7 @@ Feature: git-sync-fork: handling rebase conflicts between main branch and its re
       | main   | local, remote, and upstream | upstream commit | conflicting_file |
       | main   | local, remote               | local commit    | conflicting_file |
     And now I have the following committed files
-      | BRANCH | FILES            | CONTENT          |
+      | BRANCH | NAME             | CONTENT          |
       | main   | conflicting_file | resolved content |
 
 
@@ -62,5 +62,5 @@ Feature: git-sync-fork: handling rebase conflicts between main branch and its re
       | main   | local, remote, and upstream | upstream commit | conflicting_file |
       | main   | local, remote               | local commit    | conflicting_file |
     And now I have the following committed files
-      | BRANCH | FILES            | CONTENT          |
+      | BRANCH | NAME             | CONTENT          |
       | main   | conflicting_file | resolved content |

--- a/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/with_open_changes.feature
+++ b/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/with_open_changes.feature
@@ -107,7 +107,7 @@ Feature: git sync: resolving conflicts between the current feature branch and th
       |         |                  | conflicting main commit                                    | conflicting_file |
       |         |                  | Merge branch 'main' into feature                           |                  |
     And I still have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
       | feature | feature_file     | feature content  |

--- a/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/with_open_changes.feature
+++ b/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/with_open_changes.feature
@@ -83,7 +83,7 @@ Feature: git sync: resolving conflicts between the current feature branch and th
       |         |                  | conflicting main commit                                    | conflicting_file |
       |         |                  | Merge branch 'main' into feature                           |                  |
     And I still have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
       | feature | feature_file     | feature content  |

--- a/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/without_open_changes.feature
+++ b/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/without_open_changes.feature
@@ -73,7 +73,7 @@ Feature: git sync: resolving conflicts between the current feature branch and th
       |         |                  | conflicting main commit                                    | conflicting_file |
       |         |                  | Merge branch 'main' into feature                           |                  |
     And I still have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
       | feature | feature_file     | feature content  |
@@ -95,7 +95,7 @@ Feature: git sync: resolving conflicts between the current feature branch and th
       |         |                  | conflicting main commit                                    | conflicting_file |
       |         |                  | Merge branch 'main' into feature                           |                  |
     And I still have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
       | feature | feature_file     | feature content  |

--- a/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/with_open_changes.feature
+++ b/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/with_open_changes.feature
@@ -78,7 +78,7 @@ Feature: git sync: resolving conflicts between the current feature branch and th
       |         |                  | conflicting main commit          | conflicting_file |
       |         |                  | Merge branch 'main' into feature |                  |
     And I still have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
 
@@ -99,6 +99,6 @@ Feature: git sync: resolving conflicts between the current feature branch and th
       |         |                  | conflicting main commit          | conflicting_file |
       |         |                  | Merge branch 'main' into feature |                  |
     And I still have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |

--- a/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/without_open_changes.feature
+++ b/features/git-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/without_open_changes.feature
@@ -68,7 +68,7 @@ Feature: git sync: resolving conflicts between the current feature branch and th
       |         |                  | conflicting main commit          | conflicting_file |
       |         |                  | Merge branch 'main' into feature |                  |
     And I still have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
 
@@ -87,6 +87,6 @@ Feature: git sync: resolving conflicts between the current feature branch and th
       |         |                  | conflicting main commit          | conflicting_file |
       |         |                  | Merge branch 'main' into feature |                  |
     And I still have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |

--- a/features/git-sync/current_branch/feature_branch/feature_branch_merge_tracking_branch_conflict/with_open_changes.feature
+++ b/features/git-sync/current_branch/feature_branch/feature_branch_merge_tracking_branch_conflict/with_open_changes.feature
@@ -77,7 +77,7 @@ Feature: git sync: resolving conflicts between the current feature branch and it
       |         |                  | remote conflicting commit                                  | conflicting_file |
       |         |                  | Merge remote-tracking branch 'origin/feature' into feature |                  |
     And now I have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | feature | conflicting_file | resolved content |
 
 
@@ -97,5 +97,5 @@ Feature: git sync: resolving conflicts between the current feature branch and it
       |         |                  | remote conflicting commit                                  | conflicting_file |
       |         |                  | Merge remote-tracking branch 'origin/feature' into feature |                  |
     And now I have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | feature | conflicting_file | resolved content |

--- a/features/git-sync/current_branch/feature_branch/feature_branch_merge_tracking_branch_conflict/without_open_changes.feature
+++ b/features/git-sync/current_branch/feature_branch/feature_branch_merge_tracking_branch_conflict/without_open_changes.feature
@@ -65,7 +65,7 @@ Feature: git sync: resolving conflicts between the current feature branch and it
       |         |                  | remote conflicting commit                                  | conflicting_file |
       |         |                  | Merge remote-tracking branch 'origin/feature' into feature |                  |
     And now I have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | feature | conflicting_file | resolved content |
 
 
@@ -83,5 +83,5 @@ Feature: git sync: resolving conflicts between the current feature branch and it
       |         |                  | remote conflicting commit                                  | conflicting_file |
       |         |                  | Merge remote-tracking branch 'origin/feature' into feature |                  |
     And now I have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | feature | conflicting_file | resolved content |

--- a/features/git-sync/current_branch/feature_branch/main_branch_rebase_tracking_branch_conflict/with_open_changes.feature
+++ b/features/git-sync/current_branch/feature_branch/main_branch_rebase_tracking_branch_conflict/with_open_changes.feature
@@ -75,7 +75,7 @@ Feature: git sync: resolving conflicts between the main branch and its tracking 
       | feature | local and remote | conflicting remote commit | conflicting_file |
       |         |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |
       | feature | conflicting_file | resolved content |
 
@@ -100,6 +100,6 @@ Feature: git sync: resolving conflicts between the main branch and its tracking 
       | feature | local and remote | conflicting remote commit | conflicting_file |
       |         |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |
       | feature | conflicting_file | resolved content |

--- a/features/git-sync/current_branch/feature_branch/main_branch_rebase_tracking_branch_conflict/without_open_changes.feature
+++ b/features/git-sync/current_branch/feature_branch/main_branch_rebase_tracking_branch_conflict/without_open_changes.feature
@@ -64,7 +64,7 @@ Feature: git sync: resolving conflicts between the main branch and its tracking 
       | feature | local and remote | conflicting remote commit | conflicting_file |
       |         |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |
       | feature | conflicting_file | resolved content |
 
@@ -87,6 +87,6 @@ Feature: git sync: resolving conflicts between the main branch and its tracking 
       | feature | local and remote | conflicting remote commit | conflicting_file |
       |         |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH  | FILES            | CONTENT          |
+      | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |
       | feature | conflicting_file | resolved content |

--- a/features/git-sync/current_branch/main_branch/rebase_tracking_branch_conflict/with_open_changes.feature
+++ b/features/git-sync/current_branch/main_branch/rebase_tracking_branch_conflict/with_open_changes.feature
@@ -68,7 +68,7 @@ Feature: git sync: resolving conflicts between the main branch and its tracking 
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH | FILES            | CONTENT          |
+      | BRANCH | NAME             | CONTENT          |
       | main   | conflicting_file | resolved content |
 
 
@@ -87,5 +87,5 @@ Feature: git sync: resolving conflicts between the main branch and its tracking 
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH | FILES            | CONTENT          |
+      | BRANCH | NAME             | CONTENT          |
       | main   | conflicting_file | resolved content |

--- a/features/git-sync/current_branch/main_branch/rebase_tracking_branch_conflict/without_open_changes.feature
+++ b/features/git-sync/current_branch/main_branch/rebase_tracking_branch_conflict/without_open_changes.feature
@@ -58,7 +58,7 @@ Feature: git sync: resolving conflicts between the main branch and its tracking 
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH | FILES            | CONTENT          |
+      | BRANCH | NAME             | CONTENT          |
       | main   | conflicting_file | resolved content |
 
 
@@ -75,5 +75,5 @@ Feature: git sync: resolving conflicts between the main branch and its tracking 
       | main   | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH | FILES            | CONTENT          |
+      | BRANCH | NAME             | CONTENT          |
       | main   | conflicting_file | resolved content |

--- a/features/git-sync/current_branch/non_feature_branch/rebase_tracking_branch_conflict/with_open_changes.feature
+++ b/features/git-sync/current_branch/non_feature_branch/rebase_tracking_branch_conflict/with_open_changes.feature
@@ -71,7 +71,7 @@ Feature: git sync: resolving conflicts between the current non-feature branch an
       | qa     | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH | FILES            | CONTENT          |
+      | BRANCH | NAME             | CONTENT          |
       | qa     | conflicting_file | resolved content |
 
 
@@ -90,5 +90,5 @@ Feature: git sync: resolving conflicts between the current non-feature branch an
       | qa     | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH | FILES            | CONTENT          |
+      | BRANCH | NAME             | CONTENT          |
       | qa     | conflicting_file | resolved content |

--- a/features/git-sync/current_branch/non_feature_branch/rebase_tracking_branch_conflict/without_open_changes.feature
+++ b/features/git-sync/current_branch/non_feature_branch/rebase_tracking_branch_conflict/without_open_changes.feature
@@ -58,7 +58,7 @@ Feature: git sync: resolving conflicts between the current non-feature branch an
       | qa     | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH | FILES            | CONTENT          |
+      | BRANCH | NAME             | CONTENT          |
       | qa     | conflicting_file | resolved content |
 
 
@@ -75,5 +75,5 @@ Feature: git sync: resolving conflicts between the current non-feature branch an
       | qa     | local and remote | conflicting remote commit | conflicting_file |
       |        |                  | conflicting local commit  | conflicting_file |
     And now I have the following committed files
-      | BRANCH | FILES            | CONTENT          |
+      | BRANCH | NAME             | CONTENT          |
       | qa     | conflicting_file | resolved content |

--- a/features/step_definitions/files_steps.rb
+++ b/features/step_definitions/files_steps.rb
@@ -12,7 +12,7 @@ end
 
 
 Then(/^(?:now I|I still) have the following committed files$/) do |files_data|
-  files_data.diff! files_in_branches_array
+  files_data.diff! files_in_branches
 end
 
 

--- a/features/step_definitions/files_steps.rb
+++ b/features/step_definitions/files_steps.rb
@@ -12,8 +12,7 @@ end
 
 
 Then(/^(?:now I|I still) have the following committed files$/) do |files_data|
-  files_data.map_headers!(&:downcase)
-  verify_files files_data.hashes
+  files_data.diff! files_in_branches_array
 end
 
 

--- a/features/support/branch_helpers.rb
+++ b/features/support/branch_helpers.rb
@@ -40,8 +40,13 @@ end
 
 
 # Returns the names of all existing local branches.
-def existing_local_branches
-  array_output_of "git branch | tr -d '*'"
+def existing_local_branches order: :alphabetically
+  result = array_output_of "git branch | tr -d '*'"
+  if order == :main_first
+    main_branch = result.delete 'main'
+    result = [main_branch].concat result if main_branch
+  end
+  result
 end
 
 

--- a/features/support/files_helpers.rb
+++ b/features/support/files_helpers.rb
@@ -15,7 +15,7 @@ end
 def files_in_branches
   result = [%w(BRANCH NAME CONTENT)]
   existing_local_branches(order: :main_first).each do |branch|
-    files_in(branch: branch).map do |file|
+    files_in(branch: branch).each do |file|
       result << [branch, file, content_of(file: file, for_sha: branch)]
     end
   end

--- a/features/support/files_helpers.rb
+++ b/features/support/files_helpers.rb
@@ -10,18 +10,7 @@ def files_in branch:
 end
 
 
-# Returns a table of all files in all branches.
-# This is for comparing against expected files in a Cucumber table.
 def files_in_branches
-  existing_local_branches.map do |branch|
-    files_in(branch: branch).map do |file|
-      content = content_of file: file, for_sha: branch
-      { branch: branch, name: file, content: content }
-    end
-  end.flatten
-end
-
-def files_in_branches_array
   result = [%w(BRANCH NAME CONTENT)]
   existing_local_branches.each do |branch|
     files_in(branch: branch).map do |file|
@@ -33,22 +22,6 @@ def files_in_branches_array
 end
 
 
-
 def uncommitted_files
   array_output_of "git status --porcelain | awk '{print $2}'"
-end
-
-
-def verify_files files_array
-  expected_files = files_array.map do |file_data|
-    file_data.symbolize_keys_deep!
-    Kappamaki.from_sentence(file_data.delete :files).map do |file|
-      content = content_of file: file, for_sha: file_data[:branch]
-      file_data.clone.reverse_merge name: file, content: content
-    end
-  end.flatten
-
-  actual_files = files_in_branches
-
-  expect(actual_files).to match_array expected_files
 end

--- a/features/support/files_helpers.rb
+++ b/features/support/files_helpers.rb
@@ -10,6 +10,8 @@ def files_in branch:
 end
 
 
+# Returns a table of all files in all branches.
+# This is for comparing against expected files in a Cucumber table.
 def files_in_branches
   result = [%w(BRANCH NAME CONTENT)]
   existing_local_branches.each do |branch|

--- a/features/support/files_helpers.rb
+++ b/features/support/files_helpers.rb
@@ -16,8 +16,7 @@ def files_in_branches
   result = [%w(BRANCH NAME CONTENT)]
   existing_local_branches(order: :main_first).each do |branch|
     files_in(branch: branch).map do |file|
-      content = content_of file: file, for_sha: branch
-      result << [branch, file, content]
+      result << [branch, file, content_of(file: file, for_sha: branch)]
     end
   end
   result

--- a/features/support/files_helpers.rb
+++ b/features/support/files_helpers.rb
@@ -14,7 +14,7 @@ end
 # This is for comparing against expected files in a Cucumber table.
 def files_in_branches
   result = [%w(BRANCH NAME CONTENT)]
-  existing_local_branches.each do |branch|
+  existing_local_branches(order: :main_first).each do |branch|
     files_in(branch: branch).map do |file|
       content = content_of file: file, for_sha: branch
       result << [branch, file, content]

--- a/features/support/files_helpers.rb
+++ b/features/support/files_helpers.rb
@@ -21,6 +21,18 @@ def files_in_branches
   end.flatten
 end
 
+def files_in_branches_array
+  result = [%w(BRANCH NAME CONTENT)]
+  existing_local_branches.each do |branch|
+    files_in(branch: branch).map do |file|
+      content = content_of file: file, for_sha: branch
+      result << [branch, file, content]
+    end
+  end
+  result
+end
+
+
 
 def uncommitted_files
   array_output_of "git status --porcelain | awk '{print $2}'"


### PR DESCRIPTION
@charlierudolph @allewun 

This change has the advantage that the expected files are now verified through a Cucumber table. This means we see much better if there are extra files or missing files as the result of running a Git Town command.
The previous self-made diffing algorithm was very hard to read.

I also renamed the FILES table header to NAME, which is more correct. Besides that there are no breaking changes from this.

implements #422 