### PR TITLE
Use Mortadella to represent actually performed Git operations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
     json (1.8.2)
     kappamaki (0.0.3)
     minitest (5.5.1)
-    mortadella (0.0.1)
+    mortadella (0.0.2)
     multi_json (1.10.1)
     multi_test (0.1.2)
     open4 (1.3.4)

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -64,7 +64,7 @@ Then(/^it runs the Git commands$/) do |expected_commands|
     ERB.new(command).result
   end
 
-  expected_commands.diff! commands_of_last_run
+  expected_commands.diff! commands_of_last_run.table
 end
 
 

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -64,7 +64,7 @@ Then(/^it runs the Git commands$/) do |expected_commands|
     ERB.new(command).result
   end
 
-  expected_commands.diff! commands_of_last_run.unshift(expected_commands.headers)
+  expected_commands.diff! commands_of_last_run
 end
 
 

--- a/features/support/run_helpers.rb
+++ b/features/support/run_helpers.rb
@@ -15,18 +15,24 @@ def commands_of_last_run_outside_git
 end
 
 
-# Returns an array of the Git commands that were run in the last invocation of "run"
-# with the form [<branch_name>, <command>]
+# This regex parses Git commands out of console output.
+# It is used in commands_of_last_run
+GIT_COMMAND_REGEX = /
+  \[1m          # bold text
+  \[(.*?)\]     # branch name in square brackets
+  \s            # space between branch name and Git command
+  (.+?)         # the Git command
+  \s*           # any extra whitespace
+  \n            # newline at the end
+/x
+
+
+# Returns the Git commands run in the last invocation of "run"
+# as a Cucumber-compatible table.
 def commands_of_last_run
-  command_regex = /
-    \[1m          # bold text
-    \[(.*?)\]     # branch name in square brackets
-    \s            # space between branch name and Git command
-    (.+?)         # the Git command
-    \s*           # any extra whitespace
-    \n            # newline at the end
-  /x
-  @last_run_result.out.scan command_regex
+  result = Mortadella.new headers: %w(BRANCH COMMAND)
+  @last_run_result.out.scan(GIT_COMMAND_REGEX).each { |command| result << command }
+  result.table
 end
 
 

--- a/features/support/run_helpers.rb
+++ b/features/support/run_helpers.rb
@@ -27,12 +27,12 @@ GIT_COMMAND_REGEX = /
 /x
 
 
-# Returns the Git commands run in the last invocation of "run"
-# as a Cucumber-compatible table.
+# Returns a Mortadella instance containing the Git commands run
+# in the last invocation of "run".
 def commands_of_last_run
   result = Mortadella.new headers: %w(BRANCH COMMAND)
   @last_run_result.out.scan(GIT_COMMAND_REGEX).each { |command| result << command }
-  result.table
+  result
 end
 
 


### PR DESCRIPTION
@charlierudolph @allewun 

This change replaces the manual building of the data table to verify the Git commands run with using Mortadella. This is not only safer, because it verifies the headers, it also sets the foundation for #430.