### PR TITLE
Lock down shellcheck version

### DIFF
--- a/bin/circleci-install-shellcheck
+++ b/bin/circleci-install-shellcheck
@@ -6,7 +6,7 @@ set -e
 if [ ! -f ~/.cabal/bin/shellcheck ]; then
   sudo apt-get install cabal-install
   cabal update --verbose=0
-  cabal install --verbose=0 shellcheck
+  cabal install --verbose=0 shellcheck-0.3.5
 else
   echo "Using cached shellcheck"
 fi


### PR DESCRIPTION
@charlierudolph @allewun @ricmatsui

Shellcheck just updated and found a ton of new issues. While I take them on separately, this PR locks down the ShellCheck version to the last working version (0.3.5).