### PR TITLE
Add verification of files for git-extract

### DIFF
--- a/features/git-extract/cherry_pick_conflict/with_remote_origin/with_open_changes.feature
+++ b/features/git-extract/cherry_pick_conflict/with_remote_origin/with_open_changes.feature
@@ -74,12 +74,12 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
     And I end up on the "refactor" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE         | FILE NAME        |
-      | main     | local and remote | main commit     | conflicting_file |
-      | feature  | local            | feature commit  | feature_file     |
-      |          |                  | refactor commit | conflicting_file |
-      | refactor | local and remote | main commit     | conflicting_file |
-      |          |                  | refactor commit | conflicting_file |
+      | BRANCH   | LOCATION         | MESSAGE         |
+      | main     | local and remote | main commit     |
+      | feature  | local            | feature commit  |
+      |          |                  | refactor commit |
+      | refactor | local and remote | main commit     |
+      |          |                  | refactor commit |
     And now I have the following committed files
       | BRANCH   | NAME             | CONTENT          |
       | main     | conflicting_file | main content     |
@@ -99,12 +99,12 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
     And I end up on the "refactor" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE         | FILE NAME        |
-      | main     | local and remote | main commit     | conflicting_file |
-      | feature  | local            | feature commit  | feature_file     |
-      |          |                  | refactor commit | conflicting_file |
-      | refactor | local and remote | main commit     | conflicting_file |
-      |          |                  | refactor commit | conflicting_file |
+      | BRANCH   | LOCATION         | MESSAGE         |
+      | main     | local and remote | main commit     |
+      | feature  | local            | feature commit  |
+      |          |                  | refactor commit |
+      | refactor | local and remote | main commit     |
+      |          |                  | refactor commit |
     And now I have the following committed files
       | BRANCH   | NAME             | CONTENT          |
       | main     | conflicting_file | main content     |

--- a/features/git-extract/cherry_pick_conflict/with_remote_origin/with_open_changes.feature
+++ b/features/git-extract/cherry_pick_conflict/with_remote_origin/with_open_changes.feature
@@ -8,10 +8,10 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
   Background:
     Given I have a feature branch named "feature"
     And the following commits exist in my repository
-      | BRANCH  | LOCATION | MESSAGE         | FILE NAME        | FILE CONTENT     |
-      | main    | local    | main commit     | conflicting_file | main content     |
-      | feature | local    | feature commit  | feature_file     |                  |
-      |         |          | refactor commit | conflicting_file | refactor content |
+      | BRANCH  | LOCATION         | MESSAGE         | FILE NAME        | FILE CONTENT     |
+      | main    | local and remote | main commit     | conflicting_file | main content     |
+      | feature | local            | feature commit  | feature_file     |                  |
+      |         |                  | refactor commit | conflicting_file | refactor content |
     And I am on the "feature" branch
     And I have an uncommitted file with name: "uncommitted" and content: "stuff"
     When I run `git extract refactor` with the last commit sha
@@ -25,7 +25,6 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       |          | git stash -u                                 |
       |          | git checkout main                            |
       | main     | git rebase origin/main                       |
-      |          | git push                                     |
       |          | git checkout -b refactor main                |
       | refactor | git cherry-pick <%= sha 'refactor commit' %> |
     And I get the error
@@ -50,11 +49,7 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
     And I end up on the "feature" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And there is no "refactor" branch
-    And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE         | FILE NAME        |
-      | main    | local and remote | main commit     | conflicting_file |
-      | feature | local            | feature commit  | feature_file     |
-      |         |                  | refactor commit | conflicting_file |
+    And I am left with my original commits
     And my repo has no cherry-pick in progress
 
 
@@ -85,6 +80,13 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       |          |                  | refactor commit | conflicting_file |
       | refactor | local and remote | main commit     | conflicting_file |
       |          |                  | refactor commit | conflicting_file |
+    And now I have the following committed files
+      | BRANCH   | NAME             | CONTENT          |
+      | main     | conflicting_file | main content     |
+      | feature  | conflicting_file | refactor content |
+      | feature  | feature_file     |                  |
+      | refactor | conflicting_file | resolved content |
+
 
 
   Scenario: continuing after resolving the conflicts and committing
@@ -103,3 +105,9 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       |          |                  | refactor commit | conflicting_file |
       | refactor | local and remote | main commit     | conflicting_file |
       |          |                  | refactor commit | conflicting_file |
+    And now I have the following committed files
+      | BRANCH   | NAME             | CONTENT          |
+      | main     | conflicting_file | main content     |
+      | feature  | conflicting_file | refactor content |
+      | feature  | feature_file     |                  |
+      | refactor | conflicting_file | resolved content |

--- a/features/git-extract/cherry_pick_conflict/with_remote_origin/without_open_changes.feature
+++ b/features/git-extract/cherry_pick_conflict/with_remote_origin/without_open_changes.feature
@@ -62,12 +62,12 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       |          | git push -u origin refactor |
     And I end up on the "refactor" branch
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE         | FILE NAME        |
-      | main     | local and remote | main commit     | conflicting_file |
-      | feature  | local            | feature commit  | feature_file     |
-      |          |                  | refactor commit | conflicting_file |
-      | refactor | local and remote | main commit     | conflicting_file |
-      |          |                  | refactor commit | conflicting_file |
+      | BRANCH   | LOCATION         | MESSAGE         |
+      | main     | local and remote | main commit     |
+      | feature  | local            | feature commit  |
+      |          |                  | refactor commit |
+      | refactor | local and remote | main commit     |
+      |          |                  | refactor commit |
     And now I have the following committed files
       | BRANCH   | NAME             | CONTENT          |
       | main     | conflicting_file | main content     |
@@ -84,12 +84,12 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       | refactor | git push -u origin refactor |
     And I end up on the "refactor" branch
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE         | FILE NAME        |
-      | main     | local and remote | main commit     | conflicting_file |
-      | feature  | local            | feature commit  | feature_file     |
-      |          |                  | refactor commit | conflicting_file |
-      | refactor | local and remote | main commit     | conflicting_file |
-      |          |                  | refactor commit | conflicting_file |
+      | BRANCH   | LOCATION         | MESSAGE         |
+      | main     | local and remote | main commit     |
+      | feature  | local            | feature commit  |
+      |          |                  | refactor commit |
+      | refactor | local and remote | main commit     |
+      |          |                  | refactor commit |
     And now I have the following committed files
       | BRANCH   | NAME             | CONTENT          |
       | main     | conflicting_file | main content     |

--- a/features/git-extract/cherry_pick_conflict/with_remote_origin/without_open_changes.feature
+++ b/features/git-extract/cherry_pick_conflict/with_remote_origin/without_open_changes.feature
@@ -6,10 +6,10 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
   Background:
     Given I have a feature branch named "feature"
     And the following commits exist in my repository
-      | BRANCH  | LOCATION | MESSAGE         | FILE NAME        | FILE CONTENT     |
-      | main    | local    | main commit     | conflicting_file | main content     |
-      | feature | local    | feature commit  | feature_file     |                  |
-      |         |          | refactor commit | conflicting_file | refactor content |
+      | BRANCH  | LOCATION         | MESSAGE         | FILE NAME        | FILE CONTENT     |
+      | main    | local and remote | main commit     | conflicting_file | main content     |
+      | feature | local            | feature commit  | feature_file     |                  |
+      |         |                  | refactor commit | conflicting_file | refactor content |
     And I am on the "feature" branch
     When I run `git extract refactor` with the last commit sha
 
@@ -20,7 +20,6 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       | feature  | git fetch --prune                            |
       |          | git checkout main                            |
       | main     | git rebase origin/main                       |
-      |          | git push                                     |
       |          | git checkout -b refactor main                |
       | refactor | git cherry-pick <%= sha 'refactor commit' %> |
     And I get the error
@@ -42,11 +41,7 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       |          | git checkout feature    |
     And I end up on the "feature" branch
     And there is no "refactor" branch
-    And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE         | FILE NAME        |
-      | main    | local and remote | main commit     | conflicting_file |
-      | feature | local            | feature commit  | feature_file     |
-      |         |                  | refactor commit | conflicting_file |
+    And I am left with my original commits
     And my repo has no cherry-pick in progress
 
 
@@ -73,6 +68,12 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       |          |                  | refactor commit | conflicting_file |
       | refactor | local and remote | main commit     | conflicting_file |
       |          |                  | refactor commit | conflicting_file |
+    And now I have the following committed files
+      | BRANCH   | NAME             | CONTENT          |
+      | main     | conflicting_file | main content     |
+      | feature  | conflicting_file | refactor content |
+      | feature  | feature_file     |                  |
+      | refactor | conflicting_file | resolved content |
 
 
   Scenario: continuing after resolving the conflicts and committing
@@ -89,3 +90,9 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       |          |                  | refactor commit | conflicting_file |
       | refactor | local and remote | main commit     | conflicting_file |
       |          |                  | refactor commit | conflicting_file |
+    And now I have the following committed files
+      | BRANCH   | NAME             | CONTENT          |
+      | main     | conflicting_file | main content     |
+      | feature  | conflicting_file | refactor content |
+      | feature  | feature_file     |                  |
+      | refactor | conflicting_file | resolved content |

--- a/features/git-extract/cherry_pick_conflict/without_remote_origin/with_open_changes.feature
+++ b/features/git-extract/cherry_pick_conflict/without_remote_origin/with_open_changes.feature
@@ -76,6 +76,12 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       |          |          | refactor commit | conflicting_file |
       | refactor | local    | main commit     | conflicting_file |
       |          |          | refactor commit | conflicting_file |
+    And now I have the following committed files
+      | BRANCH   | NAME             | CONTENT          |
+      | main     | conflicting_file | main content     |
+      | feature  | conflicting_file | refactor content |
+      | feature  | feature_file     |                  |
+      | refactor | conflicting_file | resolved content |
 
 
   Scenario: continuing after resolving the conflicts and committing
@@ -93,3 +99,9 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       |          |          | refactor commit | conflicting_file |
       | refactor | local    | main commit     | conflicting_file |
       |          |          | refactor commit | conflicting_file |
+    And now I have the following committed files
+      | BRANCH   | NAME             | CONTENT          |
+      | main     | conflicting_file | main content     |
+      | feature  | conflicting_file | refactor content |
+      | feature  | feature_file     |                  |
+      | refactor | conflicting_file | resolved content |

--- a/features/git-extract/cherry_pick_conflict/without_remote_origin/with_open_changes.feature
+++ b/features/git-extract/cherry_pick_conflict/without_remote_origin/with_open_changes.feature
@@ -70,12 +70,12 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
     And I end up on the "refactor" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH   | LOCATION | MESSAGE         | FILE NAME        |
-      | main     | local    | main commit     | conflicting_file |
-      | feature  | local    | feature commit  | feature_file     |
-      |          |          | refactor commit | conflicting_file |
-      | refactor | local    | main commit     | conflicting_file |
-      |          |          | refactor commit | conflicting_file |
+      | BRANCH   | LOCATION | MESSAGE         |
+      | main     | local    | main commit     |
+      | feature  | local    | feature commit  |
+      |          |          | refactor commit |
+      | refactor | local    | main commit     |
+      |          |          | refactor commit |
     And now I have the following committed files
       | BRANCH   | NAME             | CONTENT          |
       | main     | conflicting_file | main content     |
@@ -93,12 +93,12 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
     And I end up on the "refactor" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH   | LOCATION | MESSAGE         | FILE NAME        |
-      | main     | local    | main commit     | conflicting_file |
-      | feature  | local    | feature commit  | feature_file     |
-      |          |          | refactor commit | conflicting_file |
-      | refactor | local    | main commit     | conflicting_file |
-      |          |          | refactor commit | conflicting_file |
+      | BRANCH   | LOCATION | MESSAGE         |
+      | main     | local    | main commit     |
+      | feature  | local    | feature commit  |
+      |          |          | refactor commit |
+      | refactor | local    | main commit     |
+      |          |          | refactor commit |
     And now I have the following committed files
       | BRANCH   | NAME             | CONTENT          |
       | main     | conflicting_file | main content     |

--- a/features/git-extract/cherry_pick_conflict/without_remote_origin/without_open_changes.feature
+++ b/features/git-extract/cherry_pick_conflict/without_remote_origin/without_open_changes.feature
@@ -60,12 +60,12 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       | refactor | git commit --no-edit |
     And I end up on the "refactor" branch
     And now I have the following commits
-      | BRANCH   | LOCATION | MESSAGE         | FILE NAME        |
-      | main     | local    | main commit     | conflicting_file |
-      | feature  | local    | feature commit  | feature_file     |
-      |          |          | refactor commit | conflicting_file |
-      | refactor | local    | main commit     | conflicting_file |
-      |          |          | refactor commit | conflicting_file |
+      | BRANCH   | LOCATION | MESSAGE         |
+      | main     | local    | main commit     |
+      | feature  | local    | feature commit  |
+      |          |          | refactor commit |
+      | refactor | local    | main commit     |
+      |          |          | refactor commit |
     And now I have the following committed files
       | BRANCH   | NAME             | CONTENT          |
       | main     | conflicting_file | main content     |
@@ -79,12 +79,12 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
     When I run `git commit --no-edit; git extract --continue`
     Then I end up on the "refactor" branch
     And now I have the following commits
-      | BRANCH   | LOCATION | MESSAGE         | FILE NAME        |
-      | main     | local    | main commit     | conflicting_file |
-      | feature  | local    | feature commit  | feature_file     |
-      |          |          | refactor commit | conflicting_file |
-      | refactor | local    | main commit     | conflicting_file |
-      |          |          | refactor commit | conflicting_file |
+      | BRANCH   | LOCATION | MESSAGE         |
+      | main     | local    | main commit     |
+      | feature  | local    | feature commit  |
+      |          |          | refactor commit |
+      | refactor | local    | main commit     |
+      |          |          | refactor commit |
     And now I have the following committed files
       | BRANCH   | NAME             | CONTENT          |
       | main     | conflicting_file | main content     |

--- a/features/git-extract/cherry_pick_conflict/without_remote_origin/without_open_changes.feature
+++ b/features/git-extract/cherry_pick_conflict/without_remote_origin/without_open_changes.feature
@@ -66,6 +66,12 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       |          |          | refactor commit | conflicting_file |
       | refactor | local    | main commit     | conflicting_file |
       |          |          | refactor commit | conflicting_file |
+    And now I have the following committed files
+      | BRANCH   | NAME             | CONTENT          |
+      | main     | conflicting_file | main content     |
+      | feature  | conflicting_file | refactor content |
+      | feature  | feature_file     |                  |
+      | refactor | conflicting_file | resolved content |
 
 
   Scenario: continuing after resolving the conflicts and committing
@@ -79,3 +85,9 @@ Feature: git extract: resolving conflicts between main branch and extracted comm
       |          |          | refactor commit | conflicting_file |
       | refactor | local    | main commit     | conflicting_file |
       |          |          | refactor commit | conflicting_file |
+    And now I have the following committed files
+      | BRANCH   | NAME             | CONTENT          |
+      | main     | conflicting_file | main content     |
+      | feature  | conflicting_file | refactor content |
+      | feature  | feature_file     |                  |
+      | refactor | conflicting_file | resolved content |

--- a/features/git-extract/main_branch_rebase_tracking_branch_conflict/with_open_changes.feature
+++ b/features/git-extract/main_branch_rebase_tracking_branch_conflict/with_open_changes.feature
@@ -72,14 +72,14 @@ Feature: git extract: resolving conflicts between main branch and its tracking b
     And I end up on the "refactor" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE                   | FILE NAME        |
-      | main     | local and remote | conflicting remote commit | conflicting_file |
-      |          |                  | conflicting local commit  | conflicting_file |
-      | feature  | local            | feature commit            | feature_file     |
-      |          |                  | refactor commit           | refactor_file    |
-      | refactor | local and remote | conflicting remote commit | conflicting_file |
-      |          |                  | conflicting local commit  | conflicting_file |
-      |          |                  | refactor commit           | refactor_file    |
+      | BRANCH   | LOCATION         | MESSAGE                   |
+      | main     | local and remote | conflicting remote commit |
+      |          |                  | conflicting local commit  |
+      | feature  | local            | feature commit            |
+      |          |                  | refactor commit           |
+      | refactor | local and remote | conflicting remote commit |
+      |          |                  | conflicting local commit  |
+      |          |                  | refactor commit           |
     And now I have the following committed files
       | BRANCH   | NAME             | CONTENT          |
       | main     | conflicting_file | resolved content |
@@ -102,14 +102,14 @@ Feature: git extract: resolving conflicts between main branch and its tracking b
     And I end up on the "refactor" branch
     And I again have an uncommitted file with name: "uncommitted" and content: "stuff"
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE                   | FILE NAME        |
-      | main     | local and remote | conflicting remote commit | conflicting_file |
-      |          |                  | conflicting local commit  | conflicting_file |
-      | feature  | local            | feature commit            | feature_file     |
-      |          |                  | refactor commit           | refactor_file    |
-      | refactor | local and remote | conflicting remote commit | conflicting_file |
-      |          |                  | conflicting local commit  | conflicting_file |
-      |          |                  | refactor commit           | refactor_file    |
+      | BRANCH   | LOCATION         | MESSAGE                   |
+      | main     | local and remote | conflicting remote commit |
+      |          |                  | conflicting local commit  |
+      | feature  | local            | feature commit            |
+      |          |                  | refactor commit           |
+      | refactor | local and remote | conflicting remote commit |
+      |          |                  | conflicting local commit  |
+      |          |                  | refactor commit           |
     And now I have the following committed files
       | BRANCH   | NAME             | CONTENT          |
       | main     | conflicting_file | resolved content |

--- a/features/git-extract/main_branch_rebase_tracking_branch_conflict/with_open_changes.feature
+++ b/features/git-extract/main_branch_rebase_tracking_branch_conflict/with_open_changes.feature
@@ -80,6 +80,13 @@ Feature: git extract: resolving conflicts between main branch and its tracking b
       | refactor | local and remote | conflicting remote commit | conflicting_file |
       |          |                  | conflicting local commit  | conflicting_file |
       |          |                  | refactor commit           | refactor_file    |
+    And now I have the following committed files
+      | BRANCH   | NAME             | CONTENT          |
+      | main     | conflicting_file | resolved content |
+      | feature  | feature_file     |                  |
+      | feature  | refactor_file    |                  |
+      | refactor | conflicting_file | resolved content |
+      | refactor | refactor_file    |                  |
 
 
   Scenario: continuing after resolving the conflicts and continuing the rebase
@@ -103,3 +110,10 @@ Feature: git extract: resolving conflicts between main branch and its tracking b
       | refactor | local and remote | conflicting remote commit | conflicting_file |
       |          |                  | conflicting local commit  | conflicting_file |
       |          |                  | refactor commit           | refactor_file    |
+    And now I have the following committed files
+      | BRANCH   | NAME             | CONTENT          |
+      | main     | conflicting_file | resolved content |
+      | feature  | feature_file     |                  |
+      | feature  | refactor_file    |                  |
+      | refactor | conflicting_file | resolved content |
+      | refactor | refactor_file    |                  |

--- a/features/git-extract/main_branch_rebase_tracking_branch_conflict/without_open_changes.feature
+++ b/features/git-extract/main_branch_rebase_tracking_branch_conflict/without_open_changes.feature
@@ -60,14 +60,14 @@ Feature: git extract: resolving conflicts between main branch and its tracking b
       |          | git push -u origin refactor                  |
     And I end up on the "refactor" branch
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE                   | FILE NAME        |
-      | main     | local and remote | conflicting remote commit | conflicting_file |
-      |          |                  | conflicting local commit  | conflicting_file |
-      | feature  | local            | feature commit            | feature_file     |
-      |          |                  | refactor commit           | refactor_file    |
-      | refactor | local and remote | conflicting remote commit | conflicting_file |
-      |          |                  | conflicting local commit  | conflicting_file |
-      |          |                  | refactor commit           | refactor_file    |
+      | BRANCH   | LOCATION         | MESSAGE                   |
+      | main     | local and remote | conflicting remote commit |
+      |          |                  | conflicting local commit  |
+      | feature  | local            | feature commit            |
+      |          |                  | refactor commit           |
+      | refactor | local and remote | conflicting remote commit |
+      |          |                  | conflicting local commit  |
+      |          |                  | refactor commit           |
     And now I have the following committed files
       | BRANCH   | NAME             | CONTENT          |
       | main     | conflicting_file | resolved content |
@@ -88,14 +88,14 @@ Feature: git extract: resolving conflicts between main branch and its tracking b
       |          | git push -u origin refactor                  |
     And I end up on the "refactor" branch
     And now I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE                   | FILE NAME        |
-      | main     | local and remote | conflicting remote commit | conflicting_file |
-      |          |                  | conflicting local commit  | conflicting_file |
-      | feature  | local            | feature commit            | feature_file     |
-      |          |                  | refactor commit           | refactor_file    |
-      | refactor | local and remote | conflicting remote commit | conflicting_file |
-      |          |                  | conflicting local commit  | conflicting_file |
-      |          |                  | refactor commit           | refactor_file    |
+      | BRANCH   | LOCATION         | MESSAGE                   |
+      | main     | local and remote | conflicting remote commit |
+      |          |                  | conflicting local commit  |
+      | feature  | local            | feature commit            |
+      |          |                  | refactor commit           |
+      | refactor | local and remote | conflicting remote commit |
+      |          |                  | conflicting local commit  |
+      |          |                  | refactor commit           |
     And now I have the following committed files
       | BRANCH   | NAME             | CONTENT          |
       | main     | conflicting_file | resolved content |

--- a/features/git-extract/main_branch_rebase_tracking_branch_conflict/without_open_changes.feature
+++ b/features/git-extract/main_branch_rebase_tracking_branch_conflict/without_open_changes.feature
@@ -68,6 +68,13 @@ Feature: git extract: resolving conflicts between main branch and its tracking b
       | refactor | local and remote | conflicting remote commit | conflicting_file |
       |          |                  | conflicting local commit  | conflicting_file |
       |          |                  | refactor commit           | refactor_file    |
+    And now I have the following committed files
+      | BRANCH   | NAME             | CONTENT          |
+      | main     | conflicting_file | resolved content |
+      | feature  | feature_file     |                  |
+      | feature  | refactor_file    |                  |
+      | refactor | conflicting_file | resolved content |
+      | refactor | refactor_file    |                  |
 
 
   Scenario: continuing after resolving the conflicts and continuing the rebase
@@ -89,3 +96,10 @@ Feature: git extract: resolving conflicts between main branch and its tracking b
       | refactor | local and remote | conflicting remote commit | conflicting_file |
       |          |                  | conflicting local commit  | conflicting_file |
       |          |                  | refactor commit           | refactor_file    |
+    And now I have the following committed files
+      | BRANCH   | NAME             | CONTENT          |
+      | main     | conflicting_file | resolved content |
+      | feature  | feature_file     |                  |
+      | feature  | refactor_file    |                  |
+      | refactor | conflicting_file | resolved content |
+      | refactor | refactor_file    |                  |

--- a/features/git-extract/multiple_commits/with_remote_origin/with_open_changes.feature
+++ b/features/git-extract/multiple_commits/with_remote_origin/with_open_changes.feature
@@ -40,3 +40,12 @@ Feature: git extract: extracting multiple commits (with open changes)
       | refactor | local and remote | remote main commit | remote_main_file |
       |          |                  | refactor1 commit   | refactor1_file   |
       |          |                  | refactor2 commit   | refactor2_file   |
+    And now I have the following committed files
+      | BRANCH   | NAME             |
+      | main     | remote_main_file |
+      | feature  | feature_file     |
+      | feature  | refactor1_file   |
+      | feature  | refactor2_file   |
+      | refactor | refactor1_file   |
+      | refactor | refactor2_file   |
+      | refactor | remote_main_file |

--- a/features/git-extract/multiple_commits/with_remote_origin/with_open_changes.feature
+++ b/features/git-extract/multiple_commits/with_remote_origin/with_open_changes.feature
@@ -32,14 +32,14 @@ Feature: git extract: extracting multiple commits (with open changes)
     And I end up on the "refactor" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE            | FILE NAME        |
-      | main     | local and remote | remote main commit | remote_main_file |
-      | feature  | local            | feature commit     | feature_file     |
-      |          |                  | refactor1 commit   | refactor1_file   |
-      |          |                  | refactor2 commit   | refactor2_file   |
-      | refactor | local and remote | remote main commit | remote_main_file |
-      |          |                  | refactor1 commit   | refactor1_file   |
-      |          |                  | refactor2 commit   | refactor2_file   |
+      | BRANCH   | LOCATION         | MESSAGE            |
+      | main     | local and remote | remote main commit |
+      | feature  | local            | feature commit     |
+      |          |                  | refactor1 commit   |
+      |          |                  | refactor2 commit   |
+      | refactor | local and remote | remote main commit |
+      |          |                  | refactor1 commit   |
+      |          |                  | refactor2 commit   |
     And now I have the following committed files
       | BRANCH   | NAME             |
       | main     | remote_main_file |

--- a/features/git-extract/multiple_commits/with_remote_origin/without_open_changes.feature
+++ b/features/git-extract/multiple_commits/with_remote_origin/without_open_changes.feature
@@ -34,3 +34,12 @@ Feature: git extract: extracting multiple commits (without open changes)
       | refactor | local and remote | remote main commit | remote_main_file |
       |          |                  | refactor1 commit   | refactor1_file   |
       |          |                  | refactor2 commit   | refactor2_file   |
+    And now I have the following committed files
+      | BRANCH   | NAME             |
+      | main     | remote_main_file |
+      | feature  | feature_file     |
+      | feature  | refactor1_file   |
+      | feature  | refactor2_file   |
+      | refactor | refactor1_file   |
+      | refactor | refactor2_file   |
+      | refactor | remote_main_file |

--- a/features/git-extract/multiple_commits/with_remote_origin/without_open_changes.feature
+++ b/features/git-extract/multiple_commits/with_remote_origin/without_open_changes.feature
@@ -26,14 +26,14 @@ Feature: git extract: extracting multiple commits (without open changes)
       |          | git push -u origin refactor                                                 |
     And  I end up on the "refactor" branch
     And I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE            | FILE NAME        |
-      | main     | local and remote | remote main commit | remote_main_file |
-      | feature  | local            | feature commit     | feature_file     |
-      |          |                  | refactor1 commit   | refactor1_file   |
-      |          |                  | refactor2 commit   | refactor2_file   |
-      | refactor | local and remote | remote main commit | remote_main_file |
-      |          |                  | refactor1 commit   | refactor1_file   |
-      |          |                  | refactor2 commit   | refactor2_file   |
+      | BRANCH   | LOCATION         | MESSAGE            |
+      | main     | local and remote | remote main commit |
+      | feature  | local            | feature commit     |
+      |          |                  | refactor1 commit   |
+      |          |                  | refactor2 commit   |
+      | refactor | local and remote | remote main commit |
+      |          |                  | refactor1 commit   |
+      |          |                  | refactor2 commit   |
     And now I have the following committed files
       | BRANCH   | NAME             |
       | main     | remote_main_file |

--- a/features/git-extract/multiple_commits/without_remote_origin/with_open_changes.feature
+++ b/features/git-extract/multiple_commits/without_remote_origin/with_open_changes.feature
@@ -28,14 +28,14 @@ Feature: git extract: extracting multiple commits (with open changes and without
     And I end up on the "refactor" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I have the following commits
-      | BRANCH   | LOCATION | MESSAGE          | FILE NAME      |
-      | main     | local    | main commit      | main_file      |
-      | feature  | local    | feature commit   | feature_file   |
-      |          |          | refactor1 commit | refactor1_file |
-      |          |          | refactor2 commit | refactor2_file |
-      | refactor | local    | main commit      | main_file      |
-      |          |          | refactor1 commit | refactor1_file |
-      |          |          | refactor2 commit | refactor2_file |
+      | BRANCH   | LOCATION | MESSAGE          |
+      | main     | local    | main commit      |
+      | feature  | local    | feature commit   |
+      |          |          | refactor1 commit |
+      |          |          | refactor2 commit |
+      | refactor | local    | main commit      |
+      |          |          | refactor1 commit |
+      |          |          | refactor2 commit |
     And now I have the following committed files
       | BRANCH   | NAME           |
       | main     | main_file      |

--- a/features/git-extract/multiple_commits/without_remote_origin/with_open_changes.feature
+++ b/features/git-extract/multiple_commits/without_remote_origin/with_open_changes.feature
@@ -36,3 +36,12 @@ Feature: git extract: extracting multiple commits (with open changes and without
       | refactor | local    | main commit      | main_file      |
       |          |          | refactor1 commit | refactor1_file |
       |          |          | refactor2 commit | refactor2_file |
+    And now I have the following committed files
+      | BRANCH   | NAME           |
+      | main     | main_file      |
+      | feature  | feature_file   |
+      | feature  | refactor1_file |
+      | feature  | refactor2_file |
+      | refactor | main_file      |
+      | refactor | refactor1_file |
+      | refactor | refactor2_file |

--- a/features/git-extract/multiple_commits/without_remote_origin/without_open_changes.feature
+++ b/features/git-extract/multiple_commits/without_remote_origin/without_open_changes.feature
@@ -32,3 +32,12 @@ Feature: git extract: extracting multiple commits (without open changes or remot
       | refactor | local    | main commit      | main_file      |
       |          |          | refactor1 commit | refactor1_file |
       |          |          | refactor2 commit | refactor2_file |
+    And now I have the following committed files
+      | BRANCH   | NAME           |
+      | main     | main_file      |
+      | feature  | feature_file   |
+      | feature  | refactor1_file |
+      | feature  | refactor2_file |
+      | refactor | main_file      |
+      | refactor | refactor1_file |
+      | refactor | refactor2_file |

--- a/features/git-extract/multiple_commits/without_remote_origin/without_open_changes.feature
+++ b/features/git-extract/multiple_commits/without_remote_origin/without_open_changes.feature
@@ -24,14 +24,14 @@ Feature: git extract: extracting multiple commits (without open changes or remot
       | refactor | git cherry-pick <%= sha 'refactor1 commit' %> <%= sha 'refactor2 commit' %> |
     And  I end up on the "refactor" branch
     And I have the following commits
-      | BRANCH   | LOCATION | MESSAGE          | FILE NAME      |
-      | main     | local    | main commit      | main_file      |
-      | feature  | local    | feature commit   | feature_file   |
-      |          |          | refactor1 commit | refactor1_file |
-      |          |          | refactor2 commit | refactor2_file |
-      | refactor | local    | main commit      | main_file      |
-      |          |          | refactor1 commit | refactor1_file |
-      |          |          | refactor2 commit | refactor2_file |
+      | BRANCH   | LOCATION | MESSAGE          |
+      | main     | local    | main commit      |
+      | feature  | local    | feature commit   |
+      |          |          | refactor1 commit |
+      |          |          | refactor2 commit |
+      | refactor | local    | main commit      |
+      |          |          | refactor1 commit |
+      |          |          | refactor2 commit |
     And now I have the following committed files
       | BRANCH   | NAME           |
       | main     | main_file      |

--- a/features/git-extract/single_commit/with_remote_origin/with_open_changes.feature
+++ b/features/git-extract/single_commit/with_remote_origin/with_open_changes.feature
@@ -29,12 +29,12 @@ Feature: git extract: extracting a single commit (with open changes)
     And I end up on the "refactor" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE            | FILE NAME        |
-      | main     | local and remote | remote main commit | remote_main_file |
-      | feature  | local            | feature commit     | feature_file     |
-      |          |                  | refactor commit    | refactor_file    |
-      | refactor | local and remote | remote main commit | remote_main_file |
-      |          |                  | refactor commit    | refactor_file    |
+      | BRANCH   | LOCATION         | MESSAGE            |
+      | main     | local and remote | remote main commit |
+      | feature  | local            | feature commit     |
+      |          |                  | refactor commit    |
+      | refactor | local and remote | remote main commit |
+      |          |                  | refactor commit    |
     And now I have the following committed files
       | BRANCH   | NAME             |
       | main     | remote_main_file |

--- a/features/git-extract/single_commit/with_remote_origin/with_open_changes.feature
+++ b/features/git-extract/single_commit/with_remote_origin/with_open_changes.feature
@@ -35,3 +35,10 @@ Feature: git extract: extracting a single commit (with open changes)
       |          |                  | refactor commit    | refactor_file    |
       | refactor | local and remote | remote main commit | remote_main_file |
       |          |                  | refactor commit    | refactor_file    |
+    And now I have the following committed files
+      | BRANCH   | NAME             |
+      | main     | remote_main_file |
+      | feature  | feature_file     |
+      | feature  | refactor_file    |
+      | refactor | refactor_file    |
+      | refactor | remote_main_file |

--- a/features/git-extract/single_commit/with_remote_origin/without_open_changes.feature
+++ b/features/git-extract/single_commit/with_remote_origin/without_open_changes.feature
@@ -31,3 +31,10 @@ Feature: git extract: extracting a single commit (without open changes)
       |          |                  | refactor commit    | refactor_file    |
       | refactor | local and remote | remote main commit | remote_main_file |
       |          |                  | refactor commit    | refactor_file    |
+    And now I have the following committed files
+      | BRANCH   | NAME             |
+      | main     | remote_main_file |
+      | feature  | feature_file     |
+      | feature  | refactor_file    |
+      | refactor | refactor_file    |
+      | refactor | remote_main_file |

--- a/features/git-extract/single_commit/with_remote_origin/without_open_changes.feature
+++ b/features/git-extract/single_commit/with_remote_origin/without_open_changes.feature
@@ -25,12 +25,12 @@ Feature: git extract: extracting a single commit (without open changes)
       |          | git push -u origin refactor                  |
     And I end up on the "refactor" branch
     And I have the following commits
-      | BRANCH   | LOCATION         | MESSAGE            | FILE NAME        |
-      | main     | local and remote | remote main commit | remote_main_file |
-      | feature  | local            | feature commit     | feature_file     |
-      |          |                  | refactor commit    | refactor_file    |
-      | refactor | local and remote | remote main commit | remote_main_file |
-      |          |                  | refactor commit    | refactor_file    |
+      | BRANCH   | LOCATION         | MESSAGE            |
+      | main     | local and remote | remote main commit |
+      | feature  | local            | feature commit     |
+      |          |                  | refactor commit    |
+      | refactor | local and remote | remote main commit |
+      |          |                  | refactor commit    |
     And now I have the following committed files
       | BRANCH   | NAME             |
       | main     | remote_main_file |

--- a/features/git-extract/single_commit/without_remote_origin/with_open_changes.feature
+++ b/features/git-extract/single_commit/without_remote_origin/with_open_changes.feature
@@ -27,12 +27,12 @@ Feature: git extract: extracting a single commit (with open changes and without 
     And I end up on the "refactor" branch
     And I still have an uncommitted file with name: "uncommitted" and content: "stuff"
     And I have the following commits
-      | BRANCH   | LOCATION | MESSAGE         | FILE NAME     |
-      | main     | local    | main commit     | main_file     |
-      | feature  | local    | feature commit  | feature_file  |
-      |          |          | refactor commit | refactor_file |
-      | refactor | local    | main commit     | main_file     |
-      |          |          | refactor commit | refactor_file |
+      | BRANCH   | LOCATION | MESSAGE         |
+      | main     | local    | main commit     |
+      | feature  | local    | feature commit  |
+      |          |          | refactor commit |
+      | refactor | local    | main commit     |
+      |          |          | refactor commit |
     And now I have the following committed files
       | BRANCH   | NAME          |
       | main     | main_file     |

--- a/features/git-extract/single_commit/without_remote_origin/with_open_changes.feature
+++ b/features/git-extract/single_commit/without_remote_origin/with_open_changes.feature
@@ -33,3 +33,10 @@ Feature: git extract: extracting a single commit (with open changes and without 
       |          |          | refactor commit | refactor_file |
       | refactor | local    | main commit     | main_file     |
       |          |          | refactor commit | refactor_file |
+    And now I have the following committed files
+      | BRANCH   | NAME          |
+      | main     | main_file     |
+      | feature  | feature_file  |
+      | feature  | refactor_file |
+      | refactor | main_file     |
+      | refactor | refactor_file |

--- a/features/git-extract/single_commit/without_remote_origin/without_open_changes.feature
+++ b/features/git-extract/single_commit/without_remote_origin/without_open_changes.feature
@@ -23,12 +23,12 @@ Feature: git extract: extracting a single commit (without open changes or remote
       | refactor | git cherry-pick <%= sha 'refactor commit' %> |
     And I end up on the "refactor" branch
     And I have the following commits
-      | BRANCH   | LOCATION | MESSAGE         | FILE NAME     |
-      | main     | local    | main commit     | main_file     |
-      | feature  | local    | feature commit  | feature_file  |
-      |          |          | refactor commit | refactor_file |
-      | refactor | local    | main commit     | main_file     |
-      |          |          | refactor commit | refactor_file |
+      | BRANCH   | LOCATION | MESSAGE         |
+      | main     | local    | main commit     |
+      | feature  | local    | feature commit  |
+      |          |          | refactor commit |
+      | refactor | local    | main commit     |
+      |          |          | refactor commit |
     And now I have the following committed files
       | BRANCH   | NAME          |
       | main     | main_file     |

--- a/features/git-extract/single_commit/without_remote_origin/without_open_changes.feature
+++ b/features/git-extract/single_commit/without_remote_origin/without_open_changes.feature
@@ -29,3 +29,10 @@ Feature: git extract: extracting a single commit (without open changes or remote
       |          |          | refactor commit | refactor_file |
       | refactor | local    | main commit     | main_file     |
       |          |          | refactor commit | refactor_file |
+    And now I have the following committed files
+      | BRANCH   | NAME          |
+      | main     | main_file     |
+      | feature  | feature_file  |
+      | feature  | refactor_file |
+      | refactor | main_file     |
+      | refactor | refactor_file |

--- a/features/step_definitions/commit_steps.rb
+++ b/features/step_definitions/commit_steps.rb
@@ -4,6 +4,7 @@ Given(/^the following commits? exists? in (my|my coworker's) repository$/) do |w
   @initial_commits_table = commits_table.clone
   in_repository user do
     create_commits commits_table.hashes
+    @original_files = files_in_branches
   end
 end
 

--- a/features/step_definitions/files_steps.rb
+++ b/features/step_definitions/files_steps.rb
@@ -10,6 +10,10 @@ end
 
 
 
+Then(/^I am left with my original files$/) do
+  expect(files_in_branches).to match_array @original_files
+end
+
 
 Then(/^(?:now I|I still) have the following committed files$/) do |files_data|
   files_data.diff! files_in_branches

--- a/features/support/commit_helpers.rb
+++ b/features/support/commit_helpers.rb
@@ -81,7 +81,7 @@ end
 # Returns a commit_data structure consisting of
 # the given commit_data structure with default values added
 def add_default_commit_data commit_data
-  file_name = "default file name #{SecureRandom.urlsafe_base64}"
+  file_name = "default_file_name_#{SecureRandom.urlsafe_base64}"
   commit_data.clone.reverse_merge(
     file_name: file_name,
     message: 'default commit message',

--- a/features/support/commit_helpers.rb
+++ b/features/support/commit_helpers.rb
@@ -67,20 +67,28 @@ def create_commits commits_array
   commits_array = [commits_array] if commits_array.is_a? Hash
   normalize_commit_data commits_array
   commits_array.each do |commit_data|
-    commit_data.reverse_merge!(default_commit_attributes)
-    create_commit commit_data
+    create_commit add_default_commit_data(commit_data)
   end
 end
 
 
-def default_commit_attributes
-  {
-    file_name: "default file name #{SecureRandom.urlsafe_base64}",
-    file_content: 'default file content',
+# Returns a commit_data structure consisting of
+# the given commit_data structure with default values added
+def add_default_commit_data commit_data
+  file_name = "default file name #{SecureRandom.urlsafe_base64}"
+  commit_data.clone.reverse_merge(
+    file_name: file_name,
     message: 'default commit message',
     location: 'local and remote',
-    branch: current_branch_name
-  }
+    branch: current_branch_name,
+    file_content: default_file_content_for(commit_data[:file_name] || file_name)
+  )
+end
+
+
+# Returns the file content that is used if no file content is provided by the user
+def default_file_content_for file_name
+  "#{file_name} content"
 end
 
 

--- a/features/support/files_helpers.rb
+++ b/features/support/files_helpers.rb
@@ -1,6 +1,8 @@
 # Returns the content of the file with the given name on the given branch
 def content_of file:, for_sha:
-  output_of "git show #{for_sha}:#{file}"
+  result = output_of "git show #{for_sha}:#{file}"
+  result = '' if result == default_file_content_for(file)
+  result
 end
 
 
@@ -13,13 +15,13 @@ end
 # Returns a table of all files in all branches.
 # This is for comparing against expected files in a Cucumber table.
 def files_in_branches
-  result = [%w(BRANCH NAME CONTENT)]
+  result = Mortadella.new headers: %w(BRANCH NAME CONTENT)
   existing_local_branches(order: :main_first).each do |branch|
     files_in(branch: branch).each do |file|
       result << [branch, file, content_of(file: file, for_sha: branch)]
     end
   end
-  result
+  result.table
 end
 
 


### PR DESCRIPTION
@charlierudolph @allewun @ricmatsui 

Implements parts of #420 

* explicitely specifies which files are in which branch after the operation is done
* except for cases where this is very obvious from the commits. In this case the file verification is inlined with the commit verification
* if no file content is given, uses a default file content (file name + " content")
* dries up existing file content verification tables thanks to using Mortadella now
* sorts file tables by 
  * branch name: main first, then alphabetically
  * file name

What do you think?