### PR TITLE
Specify leading dot position in Ruby source code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,11 @@ Metrics/ParameterLists:
   Max: 6
 
 
+Style/DotPosition:
+  EnforcedStyle: leading
+  Enabled: true
+
+
 Style/EmptyLines:
   Enabled: false
 


### PR DESCRIPTION
@charlierudolph @allewun @ricmatsui 

Activate enforcement of this continuation style in Ruby:

```ruby
foo
  .bar
  .baz
```

over

```ruby
foo.
  bar.
  baz
```

This matches CoffeeScript/JavaScript style, and is better readable.