### PR TITLE
Initial driver architecture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ Implements #123
 
 ## Architecture
 
-*The following refers to all commands except `git-new-pull-request`, `git-repo`, and `git-town`.*
+_The following refers to all commands except `git-town`._
 
 Each Git Town command begins by inspecting the current state of the Git repository
 (which branch you are on, whether you have open changes).
@@ -124,6 +124,26 @@ This list is then executed one by one.
 For discussion around this architecture see
 [#199](https://github.com/Originate/git-town/issues/199),
 where it was proposed.
+
+
+### Drivers
+
+_Drivers_ implement third-party specific functionality in a standardized way.
+For example, the [GitHub driver](./src/drivers/code_hosting/github.sh)
+implements GitHub-related operations like creating a pull request there.
+
+There is also an analogous
+[Bitbucket driver](./src/drivers/code_hosting/bitbucket.sh)
+that does the same things on Bitbucket.
+Both drivers are part of the [code hosting](./src/drivers/code_hosting) _driver family_.
+
+The functions that a driver needs to implement are described in the
+documentation for the respective driver family.
+
+In order to use a driver, a script simply needs to activate the respective
+driver family.
+The driver family's activation script then automatically determines
+the appropriate driver for the current environment and runs it.
 
 
 ## Documentation

--- a/features/git-new-pull-request/github.feature
+++ b/features/git-new-pull-request/github.feature
@@ -5,7 +5,7 @@ Feature: git-new-pull-request when origin is on GitHub
   So that I have more time for coding the next feature instead of wasting it with process boilerplate.
 
 
-  Scenario Outline: result
+  Scenario Outline: creating pull-requests
     Given I have a feature branch named "feature"
     And my remote origin is <ORIGIN>
     And I have "open" installed

--- a/features/git-new-pull-request/unsupported_hosting_service.feature
+++ b/features/git-new-pull-request/unsupported_hosting_service.feature
@@ -13,4 +13,4 @@ Feature: git-new-pull-request: when origin is unsupported
 
   Scenario: result
     Then I get the error "Unsupported hosting service"
-    And I get the error "Pull requests can only be created on Bitbucket and GitHub"
+    And I get the error "This command requires hosting on GitHub or Bitbucket"

--- a/features/git-new-pull-request/unsupported_hosting_service.feature
+++ b/features/git-new-pull-request/unsupported_hosting_service.feature
@@ -12,4 +12,5 @@ Feature: git-new-pull-request: when origin is unsupported
 
 
   Scenario: result
-    Then I get the error "Unsupported hosting service. Pull requests can only be created on Bitbucket and GitHub"
+    Then I get the error "Unsupported hosting service"
+    And I get the error "Pull requests can only be created on Bitbucket and GitHub"

--- a/features/git-repo/unsupported_hosting_service.feature
+++ b/features/git-repo/unsupported_hosting_service.feature
@@ -6,4 +6,4 @@ Feature: git-repo when origin is unsupported
 
   Scenario: result
     Then I get the error "Unsupported hosting service"
-    And I get the error "Repositories can only be viewed on Bitbucket and GitHub"
+    And I get the error "This command requires hosting on GitHub or Bitbucket"

--- a/features/git-repo/unsupported_hosting_service.feature
+++ b/features/git-repo/unsupported_hosting_service.feature
@@ -5,4 +5,5 @@ Feature: git-repo when origin is unsupported
 
 
   Scenario: result
-    Then I get the error "Unsupported hosting service. Repositories can only be viewed on Bitbucket and GitHub"
+    Then I get the error "Unsupported hosting service"
+    And I get the error "Repositories can only be viewed on Bitbucket and GitHub"

--- a/features/step_definitions/browser_steps.rb
+++ b/features/step_definitions/browser_steps.rb
@@ -1,8 +1,8 @@
 Then(/^I see a new (.+?) pull request for the "(.+?)" branch in the "(.+?)" repo in my browser$/) do |domain, branch, repo|
-  expect(@last_run_result.out).to eql "#{@tool} called with: #{pull_request_url domain, branch, repo}\n"
+  expect(@last_run_result.out.strip).to eql "#{@tool} called with: #{pull_request_url domain, branch, repo}"
 end
 
 
 Then(/^I see the (Bitbucket|GitHub) homepage of the "(.+?)" repository in my browser$/) do |domain, repository|
-  expect(@last_run_result.out).to eql "#{@tool} called with: #{repository_homepage_url domain, repository}\n"
+  expect(@last_run_result.out.strip).to eql "#{@tool} called with: #{repository_homepage_url domain, repository}"
 end

--- a/src/drivers/code_hosting/README.md
+++ b/src/drivers/code_hosting/README.md
@@ -1,0 +1,39 @@
+This _code hosting_ interface makes functionality on
+third-party source code hosting services like [GitHub](http://github.com)
+or [Bitbucket](http://bitbucket.org) available.
+
+The particular driver to be used is automatically determined by analyzing
+the `origin` remote in the Git repo that the command is run.
+
+
+## Interface
+
+<table>
+  <thead>
+    <tr></tr>
+    <tr>
+      <th width="345px">function</th>
+      <th>description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>create_pull_request &lt;repository&gt; &lt;branch&gt;</code>
+      </td>
+      <td>
+        opens a browser window that allows to create a pull request
+        for the given branch in the given repository against the main branch
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>show_repo &lt;repository&gt;</code>
+      </td>
+      <td>
+        opens a browser window showing the home page of the given repository
+        on its hosting platform
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/drivers/code_hosting/activate.sh
+++ b/src/drivers/code_hosting/activate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# This is the activation script for the "code hosting" driver family.
+#
+# It is called when this family is activated.
+# It automatically determines the right driver for the current environment
+# and loads it.
+
+
+# Loads the code-hosting driver that works with the given hostname
+function activate_driver_for_code_hosting {
+  local origin_hostname="$(remote_domain)"
+  if [ "$origin_hostname" == 'github.com' ]; then
+    activate_driver 'code_hosting' 'github'
+  elif [ "$origin_hostname" == 'bitbucket.org' ]; then
+    activate_driver 'code_hosting' 'bitbucket'
+  else
+    echo_error_header
+    echo_usage "Unsupported hosting service."
+    echo_usage 'This command requires hosting on GitHub or Bitbucket.'
+    exit_with_error newline
+  fi
+}

--- a/src/drivers/code_hosting/bitbucket.sh
+++ b/src/drivers/code_hosting/bitbucket.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+
+# Returns the source for a new Bitbucket pull request
+function bitbucket_source {
+  local repository=$1
+  local branch=$2
+
+  local sha=$(git log --format="%H" -1 | cut -c-12)
+  echo "$repository:$sha:$branch" | sed 's/\//%2F/g' | sed 's/\:/%3A/g'
+}
+
+
+function create_pull_request {
+  local repository=$1
+  local branch=$2
+
+  open_browser "https://bitbucket.org/$repository/pull-request/new?source=$(bitbucket_source "$repository" "$branch")"
+}
+
+
+function show_repo {
+  local repository=$1
+
+  open_browser "https://bitbucket.org/$repository"
+}

--- a/src/drivers/code_hosting/github.sh
+++ b/src/drivers/code_hosting/github.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+
+function create_pull_request {
+  local repository=$1
+  local branch=$2
+
+  open_browser "https://github.com/$repository/compare/$branch?expand=1"
+}
+
+
+function show_repo {
+  local repository=$1
+
+  open_browser "https://github.com/$repository"
+}

--- a/src/git-new-pull-request
+++ b/src/git-new-pull-request
@@ -2,25 +2,14 @@
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/helpers/helpers.sh"
 
 
-# Returns the source for a new Bitbucket pull request
-function bitbucket_source {
-  sha=$(git log --format="%H" -1 | cut -c-12)
-  echo "$repository:$sha:$branch" | sed 's/\//%2F/g' | sed 's/\:/%3A/g'
+function preconditions {
+  activate_driver_family 'code_hosting'
 }
 
 
-branch=$INITIAL_BRANCH_NAME
-domain=$(remote_domain)
-repository=$(remote_repository_name)
+function steps {
+  echo "create_pull_request $(remote_repository_name) $INITIAL_BRANCH_NAME"
+}
 
-if [ "$domain" == github.com ]; then
-  pr_path="compare/$branch?expand=1"
-elif [ "$domain" == bitbucket.org ]; then
-  pr_path="pull-request/new?source=$(bitbucket_source)"
-else
-  echo_error_header
-  echo_usage "Unsupported hosting service. Pull requests can only be created on Bitbucket and GitHub"
-  exit_with_error newline
-fi
 
-open_browser "https://$domain/$repository/$pr_path"
+run "$@"

--- a/src/git-repo
+++ b/src/git-repo
@@ -2,13 +2,14 @@
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/helpers/helpers.sh"
 
 
-domain=$(remote_domain)
-repository=$(remote_repository_name)
+function preconditions {
+  activate_driver_family 'code_hosting'
+}
 
-if [ "$domain" != github.com ] && [ "$domain" != bitbucket.org ]; then
-  echo_error_header
-  echo_usage "Unsupported hosting service. Repositories can only be viewed on Bitbucket and GitHub"
-  exit_with_error newline
-fi
 
-open_browser "https://$domain/$repository"
+function steps {
+  echo "show_repo $(remote_repository_name)"
+}
+
+
+run "$@"

--- a/src/helpers/driver_helpers.sh
+++ b/src/helpers/driver_helpers.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Helper methods around drivers
+
+
+# Loads and activates the given driver
+function activate_driver {
+  local driver_family_name=$1
+  local driver_name=$2
+
+  source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../drivers/$driver_family_name/$driver_name.sh"
+}
+
+
+# Activates the given driver family,
+# and lets the driver family activation script determine on its own
+# which particular driver to load.
+function activate_driver_family {
+  local driver_family_name=$1
+
+  source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../drivers/$driver_family_name/activate.sh"
+  shift
+  activate_driver_for_"$driver_family_name" "$@"
+}

--- a/src/helpers/helpers.sh
+++ b/src/helpers/helpers.sh
@@ -25,6 +25,7 @@ source "$current_dir/git_helpers/tracking_branch_helpers.sh"
 
 source "$current_dir/browser_helpers.sh"
 source "$current_dir/configuration_helpers.sh"
+source "$current_dir/driver_helpers.sh"
 source "$current_dir/file_helpers.sh"
 source "$current_dir/folder_helpers.sh"
 source "$current_dir/script_helpers.sh"


### PR DESCRIPTION
@charlierudolph @allewun @ricmatsui 

This is a first attempt at separating third-party specific functionality into "drivers" for those third-party APIs, as a parts of #477. The first driver family created here is around code hosting (GitHub, Bitbucket), with another driver family around CI coming soon (CircleCI, Travis, etc).

The motivation for this change is that this makes it much easier to add support for additional third-party systems.

The right patterns to use here is certainly a topic for great debates, and I have gone back and forth (in my head) on the various solutions. On the simple side we have a simple driver infrastructure like in this PR. On the complex side is a full extension system that can define its own Git commands, integration tests, and helpers, which can depend on each other, and be loaded through our own package manager. Following KISS and YAGNI as principles that have always served me very well, this PR contains the simplest possible approach, as a start. I'm happy to add more complexity when it is really needed and makes things simpler. In Bash one doesn't want to over-engineer things!

I don't want to explain the changes too much myself here. The architecture should be documented sufficiently in the developer documentation changes in this PR. If it leaves anything unclear, please let me know, and I'll add more details there, so that they are around for everybody to understand.

What do you think?