### PR TITLE
Debugging through tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,14 +63,15 @@ about problems.
 
 ## Debugging
 
-To see the output of the Git commands run in tests, you can either
-* set the `DEBUG_COMMANDS` environment variable while running your specs:
+To see the output of the Git commands run in tests, you can either set the
+`DEBUG_COMMANDS` environment variable while running your specs:
 
-  ```bash
-  $ DEBUG_COMMANDS=true cucumber <filename>[:<lineno>]
-  ```
+```bash
+$ DEBUG_COMMANDS=true cucumber <filename>[:<lineno>]
+```
 
-* add a `@debug-commands` flag to the respective Cucumber spec
+Alternatively, you can also add a `@debug-commands` flag to the respective
+Cucumber spec:
 
   ```cucumber
   @debug-commands

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ To see the output of the Git commands run in tests, you can either
 * set the `DEBUG_COMMANDS` environment variable while running your specs:
 
   ```bash
-  DEBUG_COMMANDS=true cucumber <filename>[:<lineno>]
+  $ DEBUG_COMMANDS=true cucumber <filename>[:<lineno>]
   ```
 
 * add a `@debug-commands` flag to the respective Cucumber spec

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,6 @@ rake test    # runs the feature tests
 cucumber <filename>[:<lineno>]
 cucumber -n '<scenario/feature name>'
 
-# running individual scenarios/features while showing the application output
-DEBUG_COMMANDS=true cucumber <filename>[:<lineno>]
-
 # running several features in parallel
 bin/cuke [cucumber parameters]
 
@@ -62,6 +59,27 @@ Git Town's [CI server](https://circleci.com/gh/Originate/git-town)
 automatically tests all commits and pull requests,
 and notifies you via email and through status badges in pull requests
 about problems.
+
+
+## Debugging
+
+To see the output of the Git commands run in tests, you can either
+* set the `DEBUG_COMMANDS` environment variable while running your specs:
+
+  ```bash
+  DEBUG_COMMANDS=true cucumber <filename>[:<lineno>]
+  ```
+
+* add a `@debug-commands` flag to the respective Cucumber spec
+
+  ```cucumber
+  @debug-commands
+  Scenario: foo bar baz
+    Given ...
+  ```
+
+For even more detailed output, you can use the `DEBUG` variable or tag
+in a similar fashion.
 
 
 ## Pull Requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ about problems.
 
 ## Debugging
 
-To see the output of the Git commands run in tests, you can either set the
+To see the output of the Git commands run in tests, you can set the
 `DEBUG_COMMANDS` environment variable while running your specs:
 
 ```bash
@@ -81,6 +81,9 @@ Cucumber spec:
 
 For even more detailed output, you can use the `DEBUG` variable or tag
 in a similar fashion.
+If set, Git Town prints every shell command executed during the tests
+(includes setup, inspection of the Git status, and the Git commands),
+and the respective console output.
 
 
 ## Pull Requests

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -16,6 +16,11 @@ TOOLS_INSTALLED_FILENAME = "#{REPOSITORY_BASE}/tools_installed.txt"
 
 FISH_AUTOCOMPLETIONS_PATH = File.expand_path '~/.config/fish/completions/git.fish'
 
+DEBUG = {
+  all: ENV['DEBUG'],                      # Prints debug info for all activities
+  commands_only: ENV['DEBUG_COMMANDS']    # Prints debug info only for the Git commands run
+}
+
 
 # load memoized environment by copying contents
 # of MEMOIZED_REPOSITORY_BASE to REPOSITORY_BASE
@@ -70,6 +75,24 @@ end
 
 After '~@finishes-with-non-empty-stash' do
   expect(stash_size).to eql(0), 'Finished with non empty stash'
+end
+
+
+Before '@debug' do
+  DEBUG[:all] = true
+end
+
+After '@debug' do
+  DEBUG[:all] = ENV['DEBUG']
+end
+
+
+Before '@debug-commands' do
+  DEBUG[:commands_only] = true
+end
+
+After '@debug-commands' do
+  DEBUG[:commands_only] = ENV['DEBUG_COMMANDS']
 end
 
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,8 +17,12 @@ TOOLS_INSTALLED_FILENAME = "#{REPOSITORY_BASE}/tools_installed.txt"
 FISH_AUTOCOMPLETIONS_PATH = File.expand_path '~/.config/fish/completions/git.fish'
 
 DEBUG = {
-  all: ENV['DEBUG'],                      # Prints debug info for all activities
-  commands_only: ENV['DEBUG_COMMANDS']    # Prints debug info only for the Git commands run
+
+  # Prints debug info for all activities
+  all: ENV['DEBUG'],
+
+  # Prints debug info only for the Git commands run
+  commands_only: ENV['DEBUG_COMMANDS']
 }
 
 

--- a/features/support/run_helpers.rb
+++ b/features/support/run_helpers.rb
@@ -61,12 +61,12 @@ def print_result result
 end
 
 
-def run command, debug: false, inputs: []
+def run command, inputs: []
   result = run_shell_command command, inputs
   is_git_town_command = git_town_command? command
   raise_error = (!is_git_town_command && result.error) || result_has_shell_error?(result)
 
-  print_result(result) if raise_error || should_print_command_output?(command, debug)
+  print_result(result) if raise_error || should_print_command_output?(command)
   fail 'Command not successful!' if raise_error
 
   @last_run_result = result if is_git_town_command
@@ -102,8 +102,8 @@ def shell_overrides
 end
 
 
-def should_print_command_output? command, debug
-  debug || ENV['DEBUG'] || (ENV['DEBUG_COMMANDS'] && git_town_command?(command))
+def should_print_command_output? command
+  DEBUG[:all] || (DEBUG[:commands_only] && git_town_command?(command))
 end
 
 


### PR DESCRIPTION
@charlierudolph @allewun @ricmatsui 

Debugging through an environment variable is often cumbersome, not only because I use Fish shell, but also because I have to change the command called when debugging.

Adding a tag to the Cucumber specs is often easier, so this PR adds support for that, and also cleans up some no longer needed infrastructure for handling the debug flags.