### PR TITLE
Remove unnecessary location from shell command result

### DIFF
--- a/features/support/run_helpers.rb
+++ b/features/support/run_helpers.rb
@@ -82,7 +82,7 @@ end
 
 
 def run_shell_command command, inputs
-  result = OpenStruct.new(command: command, location: Pathname.new(Dir.pwd).basename)
+  result = OpenStruct.new command: command
   command = "#{shell_overrides}; #{command} 2>&1"
   kill = inputs.pop if inputs.last == '^C' # command shouldn't error if user aborts it
 


### PR DESCRIPTION
@charlierudolph @allewun @ricmatsui 

We no longer use the location entry in the result set for shell commands, so this change removes it.