### PR TITLE
rename debugging environment variables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,13 +64,13 @@ about problems.
 ## Debugging
 
 To see the output of the Git commands run in tests, you can set the
-`DEBUG_COMMANDS` environment variable while running your specs:
+`GIT_TOWN_DEBUG_COMMANDS` environment variable while running your specs:
 
 ```bash
-$ DEBUG_COMMANDS=true cucumber <filename>[:<lineno>]
+$ GIT_TOWN_DEBUG_COMMANDS=true cucumber <filename>[:<lineno>]
 ```
 
-Alternatively, you can also add a `@debug-commands` flag to the respective
+Alternatively, you can also add a `@debug-commands` tag to the respective
 Cucumber spec:
 
   ```cucumber
@@ -79,7 +79,7 @@ Cucumber spec:
     Given ...
   ```
 
-For even more detailed output, you can use the `DEBUG` variable or tag
+For even more detailed output, you can use the `GIT_TOWN_DEBUG` variable or `@debug` tag
 in a similar fashion.
 If set, Git Town prints every shell command executed during the tests
 (includes setup, inspection of the Git status, and the Git commands),

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -19,10 +19,10 @@ FISH_AUTOCOMPLETIONS_PATH = File.expand_path '~/.config/fish/completions/git.fis
 DEBUG = {
 
   # Prints debug info for all activities
-  all: ENV['DEBUG'],
+  all: ENV['GIT_TOWN_DEBUG'],
 
   # Prints debug info only for the Git commands run
-  commands_only: ENV['DEBUG_COMMANDS']
+  commands_only: ENV['GIT_TOWN_DEBUG_COMMANDS']
 }
 
 
@@ -86,7 +86,7 @@ Before '@debug' do
 end
 
 After '@debug' do
-  DEBUG[:all] = ENV['DEBUG']
+  DEBUG[:all] = ENV['GIT_TOWN_DEBUG']
 end
 
 
@@ -95,7 +95,7 @@ Before '@debug-commands' do
 end
 
 After '@debug-commands' do
-  DEBUG[:commands_only] = ENV['DEBUG_COMMANDS']
+  DEBUG[:commands_only] = ENV['GIT_TOWN_DEBUG_COMMANDS']
 end
 
 


### PR DESCRIPTION
I think these variables should be namespaced. I just went ahead and made the PR since it's so small rather than create an issue first.

* `DEBUG_COMMANDS` → `GIT_TOWN_DEBUG_COMMANDS`
* `DEBUG` → `GIT_TOWN_DEBUG`

@kevgo @charlierudolph @ricmatsui 