### PR TITLE
No longer install Cabal on CircleCI

### DIFF
--- a/bin/circleci-install-shellcheck
+++ b/bin/circleci-install-shellcheck
@@ -4,8 +4,6 @@
 set -e
 
 if [ ! -f ~/.cabal/bin/shellcheck ]; then
-  sudo apt-get install cabal-install
-  cabal update --verbose=0
   cabal install --verbose=0 shellcheck-0.3.6
 else
   echo "Using cached shellcheck"

--- a/bin/circleci-install-shellcheck
+++ b/bin/circleci-install-shellcheck
@@ -4,6 +4,7 @@
 set -e
 
 if [ ! -f ~/.cabal/bin/shellcheck ]; then
+  cabal update --verbose=0
   cabal install --verbose=0 shellcheck-0.3.6
 else
   echo "Using cached shellcheck"


### PR DESCRIPTION
@charlierudolph @allewun @ricmatsui 

Its preinstalled now. I have tested it manually by running Circle without cache.

Implements #496 