### PR TITLE
Cache Ruby dependencies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,8 +13,8 @@ dependencies:
   # Cache ShellCheck for subsequent builds
   cache_directories:
     - "~/.cabal"
-    - "~/git-town/vendor/bundle"
     - "~/.rvm"
+    - "~/git-town/vendor/bundle"
 
   post:
     - bin/circleci-install-shellcheck

--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,6 @@ machine:
     # but 8 processors yields the fastest results
     PARALLEL_TEST_PROCESSORS: 8
 
-    PATH: $HOME/.cabal/bin/:$PATH
-
 
 dependencies:
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,11 +10,6 @@ machine:
 
 dependencies:
 
-  # Cache ShellCheck for subsequent builds
-  cache_directories:
-    - "~/.cabal"
-    - "~/git-town/vendor/bundle"
-
   post:
     - bin/circleci-install-shellcheck
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,7 @@ dependencies:
   cache_directories:
     - "~/.cabal"
     - "~/git-town/vendor/bundle"
+    - "~/.rvm"
 
   post:
     - bin/circleci-install-shellcheck

--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,7 @@ dependencies:
   # Cache ShellCheck for subsequent builds
   cache_directories:
     - "~/.cabal"
+    - "~/vendor/bundle"
 
   post:
     - bin/circleci-install-shellcheck

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,6 @@ dependencies:
   # Cache ShellCheck for subsequent builds
   cache_directories:
     - "~/.cabal"
-    - "~/.rvm"
     - "~/git-town/vendor/bundle"
 
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ dependencies:
   # Cache ShellCheck for subsequent builds
   cache_directories:
     - "~/.cabal"
-    - "~/vendor/bundle"
+    - "~/git-town/vendor/bundle"
 
   post:
     - bin/circleci-install-shellcheck


### PR DESCRIPTION
@charlierudolph @allewun @ricmatsui 

This caches the installed Ruby gems, thereby saving some time on Circle. It still installs Ruby. Caching the installed Ruby is also possible, but takes 3.5 minutes to restore, so I'm not doing it.