### PR TITLE
Use quote character for debug output

### DIFF
--- a/features/support/run_helpers.rb
+++ b/features/support/run_helpers.rb
@@ -56,7 +56,7 @@ end
 def print_result result
   puts ''
   puts %(#{result.location}$ #{result.command}
-         #{result.out}).gsub(/^/, '@ ')
+         #{result.out}).gsub(/^/, '> ')
   puts ''
 end
 


### PR DESCRIPTION
@allewun @charlierudolph @ricmatsui 

I'm not sure why we picked `@` to quote debug output. This PR changes that to the "official" quote character. 

Before:
```
@ debug
@ output
@ here
```

Now:
```
> debug
> output
> here
```