### PR TITLE
Display output on error

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -73,10 +73,8 @@ end
 
 After do
   if @last_run_result && !@error_expected
-    if @last_run_result.error
-      puts unformatted_last_run_output
-      expect(@last_run_result.error).to be_falsy, 'Expected no runtime error'
-    end
+    puts unformatted_last_run_output if @last_run_result.error
+    expect(@last_run_result.error).to be_falsy, 'Expected no runtime error'
   end
   unless @non_empty_stash_expected
     expect(stash_size).to eql(0), 'Finished with non empty stash'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -73,7 +73,10 @@ end
 
 After do
   if @last_run_result && !@error_expected
-    expect(@last_run_result.error).to be_falsy, 'Expected no runtime error'
+    if @last_run_result.error
+      puts unformatted_last_run_output
+      expect(@last_run_result.error).to be_falsy, 'Expected no runtime error'
+    end
   end
   unless @non_empty_stash_expected
     expect(stash_size).to eql(0), 'Finished with non empty stash'


### PR DESCRIPTION
@charlierudolph @allewun @ricmatsui 

Displays the full command output in case a command unexpectedly produces an error in the tests