### PR TITLE
Git ship: use sync-branch-steps

### DIFF
--- a/features/git-hack/nested_branches/current_branch_as_parent.feature
+++ b/features/git-hack/nested_branches/current_branch_as_parent.feature
@@ -8,8 +8,8 @@ Feature: Creating nested feature branches
   Background:
     Given I have a feature branch named "parent-feature"
     And Git Town is aware of this branch hierarchy
-      | BRANCH         | PARENT         |
-      | parent-feature | main           |
+      | BRANCH         | PARENT |
+      | parent-feature | main   |
     Given the following commits exist in my repository
       | BRANCH         | LOCATION | MESSAGE        | FILE NAME    |
       | main           | remote   | main_commit    | main_file    |

--- a/features/git-ship/current_branch/on_coworker_feature_branch.feature
+++ b/features/git-ship/current_branch/on_coworker_feature_branch.feature
@@ -18,9 +18,9 @@ Feature: git ship: shipping a coworker's feature branch
   Scenario: result
     Then it runs the Git commands
       | BRANCH  | COMMAND                                                                 |
-      | feature | git checkout main                                                       |
-      | main    | git fetch --prune                                                       |
-      |         | git rebase origin/main                                                  |
+      | feature | git fetch --prune                                                       |
+      |         | git checkout main                                                       |
+      | main    | git rebase origin/main                                                  |
       |         | git checkout feature                                                    |
       | feature | git merge --no-edit origin/feature                                      |
       |         | git merge --no-edit main                                                |

--- a/features/git-ship/current_branch/on_feature_branch/commit_messsage_containing_double_quotes.feature
+++ b/features/git-ship/current_branch/on_feature_branch/commit_messsage_containing_double_quotes.feature
@@ -17,9 +17,9 @@ Feature: git ship: shipping the current feature branch
   Scenario: result
     Then it runs the Git commands
       | BRANCH  | COMMAND                                                |
-      | feature | git checkout main                                      |
-      | main    | git fetch --prune                                      |
-      |         | git rebase origin/main                                 |
+      | feature | git fetch --prune                                      |
+      |         | git checkout main                                      |
+      | main    | git rebase origin/main                                 |
       |         | git checkout feature                                   |
       | feature | git merge --no-edit origin/feature                     |
       |         | git merge --no-edit main                               |

--- a/features/git-ship/current_branch/on_feature_branch/empty_commit_message.feature
+++ b/features/git-ship/current_branch/on_feature_branch/empty_commit_message.feature
@@ -17,9 +17,9 @@ Feature: git ship: aborting the ship of the current feature branch by entering a
   Scenario: result
     Then it runs the Git commands
       | BRANCH  | COMMAND                            |
-      | feature | git checkout main                  |
-      | main    | git fetch --prune                  |
-      |         | git rebase origin/main             |
+      | feature | git fetch --prune                  |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
       |         | git checkout feature               |
       | feature | git merge --no-edit origin/feature |
       |         | git merge --no-edit main           |

--- a/features/git-ship/current_branch/on_feature_branch/feature_branch_merge_main_branch_conflict.feature
+++ b/features/git-ship/current_branch/on_feature_branch/feature_branch_merge_main_branch_conflict.feature
@@ -18,9 +18,9 @@ Feature: git ship: resolving conflicts between the current feature branch and th
   Scenario: result
     Then it runs the Git commands
       | BRANCH  | COMMAND                            |
-      | feature | git checkout main                  |
-      | main    | git fetch --prune                  |
-      |         | git rebase origin/main             |
+      | feature | git fetch --prune                  |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
       |         | git push                           |
       |         | git checkout feature               |
       | feature | git merge --no-edit origin/feature |

--- a/features/git-ship/current_branch/on_feature_branch/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-ship/current_branch/on_feature_branch/feature_branch_merge_tracking_branch_conflict.feature
@@ -18,9 +18,9 @@ Feature: git ship: resolving conflicts between the current feature branch and it
   Scenario: result
     Then it runs the Git commands
       | BRANCH  | COMMAND                            |
-      | feature | git checkout main                  |
-      | main    | git fetch --prune                  |
-      |         | git rebase origin/main             |
+      | feature | git fetch --prune                  |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
       |         | git checkout feature               |
       | feature | git merge --no-edit origin/feature |
     And I get the error

--- a/features/git-ship/current_branch/on_feature_branch/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-ship/current_branch/on_feature_branch/main_branch_rebase_tracking_branch_conflict.feature
@@ -19,9 +19,9 @@ Feature: git ship: resolving conflicts between the main branch and its tracking 
   Scenario: result
     Then it runs the Git commands
       | BRANCH  | COMMAND                |
-      | feature | git checkout main      |
-      | main    | git fetch --prune      |
-      |         | git rebase origin/main |
+      | feature | git fetch --prune      |
+      |         | git checkout main      |
+      | main    | git rebase origin/main |
     And I get the error
       """
       To abort, run "git ship --abort".

--- a/features/git-ship/current_branch/on_feature_branch/no_diff.feature
+++ b/features/git-ship/current_branch/on_feature_branch/no_diff.feature
@@ -18,9 +18,9 @@ Feature: git ship: errors when trying to ship the current feature branch that ha
   Scenario: result
     Then it runs the Git commands
       | BRANCH        | COMMAND                                      |
-      | empty-feature | git checkout main                            |
-      | main          | git fetch --prune                            |
-      |               | git rebase origin/main                       |
+      | empty-feature | git fetch --prune                            |
+      |               | git checkout main                            |
+      | main          | git rebase origin/main                       |
       |               | git checkout empty-feature                   |
       | empty-feature | git merge --no-edit origin/empty-feature     |
       |               | git merge --no-edit main                     |

--- a/features/git-ship/current_branch/on_feature_branch/with_tracking_branch.feature
+++ b/features/git-ship/current_branch/on_feature_branch/with_tracking_branch.feature
@@ -17,9 +17,9 @@ Feature: git ship: shipping the current feature branch with a tracking branch
   Scenario: result
     Then it runs the Git commands
       | BRANCH  | COMMAND                            |
-      | feature | git checkout main                  |
-      | main    | git fetch --prune                  |
-      |         | git rebase origin/main             |
+      | feature | git fetch --prune                  |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
       |         | git checkout feature               |
       | feature | git merge --no-edit origin/feature |
       |         | git merge --no-edit main           |

--- a/features/git-ship/current_branch/on_feature_branch/without_tracking_branch.feature
+++ b/features/git-ship/current_branch/on_feature_branch/without_tracking_branch.feature
@@ -15,9 +15,9 @@ Feature: git ship: shipping the current feature branch without a tracking branch
   Scenario: result
     Then it runs the Git commands
       | BRANCH  | COMMAND                      |
-      | feature | git checkout main            |
-      | main    | git fetch --prune            |
-      |         | git rebase origin/main       |
+      | feature | git fetch --prune            |
+      |         | git checkout main            |
+      | main    | git rebase origin/main       |
       |         | git checkout feature         |
       | feature | git merge --no-edit main     |
       |         | git checkout main            |

--- a/features/git-ship/supplied_branch/feature_branch/empty_commit_message.feature
+++ b/features/git-ship/supplied_branch/feature_branch/empty_commit_message.feature
@@ -18,9 +18,9 @@ Feature: git ship: aborting the ship of the supplied feature branch by entering 
     Then it runs the Git commands
       | BRANCH        | COMMAND                                      |
       | other_feature | git stash -u                                 |
+      |               | git fetch --prune                            |
       |               | git checkout main                            |
-      | main          | git fetch --prune                            |
-      |               | git rebase origin/main                       |
+      | main          | git rebase origin/main                       |
       |               | git checkout feature                         |
       | feature       | git merge --no-edit origin/feature           |
       |               | git merge --no-edit main                     |

--- a/features/git-ship/supplied_branch/feature_branch/feature_branch_merge_main_branch_conflict.feature
+++ b/features/git-ship/supplied_branch/feature_branch/feature_branch_merge_main_branch_conflict.feature
@@ -18,9 +18,9 @@ Feature: git ship: resolving conflicts between the supplied feature branch and t
     Then it runs the Git commands
       | BRANCH        | COMMAND                            |
       | other_feature | git stash -u                       |
+      |               | git fetch --prune                  |
       |               | git checkout main                  |
-      | main          | git fetch --prune                  |
-      |               | git rebase origin/main             |
+      | main          | git rebase origin/main             |
       |               | git push                           |
       |               | git checkout feature               |
       | feature       | git merge --no-edit origin/feature |

--- a/features/git-ship/supplied_branch/feature_branch/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-ship/supplied_branch/feature_branch/feature_branch_merge_tracking_branch_conflict.feature
@@ -18,9 +18,9 @@ Feature: git ship: resolving conflicts between the supplied feature branch and i
     Then it runs the Git commands
       | BRANCH        | COMMAND                            |
       | other_feature | git stash -u                       |
+      |               | git fetch --prune                  |
       |               | git checkout main                  |
-      | main          | git fetch --prune                  |
-      |               | git rebase origin/main             |
+      | main          | git rebase origin/main             |
       |               | git checkout feature               |
       | feature       | git merge --no-edit origin/feature |
     And I get the error

--- a/features/git-ship/supplied_branch/feature_branch/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-ship/supplied_branch/feature_branch/main_branch_rebase_tracking_branch_conflict.feature
@@ -19,9 +19,9 @@ Feature: git ship: resolving conflicts between the main branch and its tracking 
     Then it runs the Git commands
       | BRANCH        | COMMAND                |
       | other_feature | git stash -u           |
+      |               | git fetch --prune      |
       |               | git checkout main      |
-      | main          | git fetch --prune      |
-      |               | git rebase origin/main |
+      | main          | git rebase origin/main |
     And I get the error
       """
       To abort, run "git ship --abort".

--- a/features/git-ship/supplied_branch/feature_branch/no_diff.feature
+++ b/features/git-ship/supplied_branch/feature_branch/no_diff.feature
@@ -18,9 +18,9 @@ Feature: git ship: errors when trying to ship the supplied feature branch that h
     Then it runs the Git commands
       | BRANCH        | COMMAND                                      |
       | other_feature | git stash -u                                 |
+      |               | git fetch --prune                            |
       |               | git checkout main                            |
-      | main          | git fetch --prune                            |
-      |               | git rebase origin/main                       |
+      | main          | git rebase origin/main                       |
       |               | git checkout empty-feature                   |
       | empty-feature | git merge --no-edit origin/empty-feature     |
       |               | git merge --no-edit main                     |

--- a/features/git-ship/supplied_branch/feature_branch/with_tracking_branch.feature
+++ b/features/git-ship/supplied_branch/feature_branch/with_tracking_branch.feature
@@ -17,9 +17,9 @@ Feature: git ship: shipping the supplied feature branch with a tracking branch
     Then it runs the Git commands
       | BRANCH        | COMMAND                            |
       | other_feature | git stash -u                       |
+      |               | git fetch --prune                  |
       |               | git checkout main                  |
-      | main          | git fetch --prune                  |
-      |               | git rebase origin/main             |
+      | main          | git rebase origin/main             |
       |               | git checkout feature               |
       | feature       | git merge --no-edit origin/feature |
       |               | git merge --no-edit main           |

--- a/features/git-ship/supplied_branch/feature_branch/without_tracking_branch.feature
+++ b/features/git-ship/supplied_branch/feature_branch/without_tracking_branch.feature
@@ -17,9 +17,9 @@ Feature: git ship: shipping the supplied feature branch without a tracking branc
     Then it runs the Git commands
       | BRANCH        | COMMAND                            |
       | other_feature | git stash -u                       |
+      |               | git fetch --prune                  |
       |               | git checkout main                  |
-      | main          | git fetch --prune                  |
-      |               | git rebase origin/main             |
+      | main          | git rebase origin/main             |
       |               | git checkout feature               |
       | feature       | git merge --no-edit origin/feature |
       |               | git merge --no-edit main           |

--- a/src/git-ship
+++ b/src/git-ship
@@ -32,10 +32,8 @@ function steps {
   fi
 
   if [ "$HAS_REMOTE" = true ]; then
-    echo "checkout_main_branch"
     echo "fetch"
-    echo "rebase_tracking_branch"
-    echo "push"
+    sync_branch_steps "$MAIN_BRANCH_NAME"
   fi
 
   echo "checkout $target_branch_name"


### PR DESCRIPTION
@charlierudolph @allewun @ricmatsui 

Dries up git-ship by using the extracted sync_branch_steps helper

implements parts of #529 