### PR TITLE
Fix spec structure issue

### DIFF
--- a/features/git-rename-branch/branch_does_not_exist.feature
+++ b/features/git-rename-branch/branch_does_not_exist.feature
@@ -10,11 +10,11 @@ Feature: git rename-branch: errors if the feature branch does not exist
       | BRANCH | LOCATION         | MESSAGE     |
       | main   | local and remote | main commit |
     And I am on the "main" branch
+    And I have an uncommitted file
+    When I run `git rename-branch non-existing-feature renamed-feature`
 
 
   Scenario: result
-    And I have an uncommitted file
-    When I run `git rename-branch non-existing-feature renamed-feature`
     Then I get the error "There is no branch named 'non-existing-feature'"
     And I end up on the "main" branch
     And I still have my uncommitted file

--- a/features/git-rename-branch/destination_branch_exists_locally.feature
+++ b/features/git-rename-branch/destination_branch_exists_locally.feature
@@ -12,11 +12,11 @@ Feature: git rename-branch: errors when the destination branch exists locally
       | current-feature  | local and remote | current-feature commit  |
       | existing-feature | local and remote | existing-feature commit |
     And I am on the "current-feature" branch
+    And I have an uncommitted file
+    When I run `git rename-branch current-feature existing-feature`
 
 
   Scenario: result
-    And I have an uncommitted file
-    When I run `git rename-branch current-feature existing-feature`
     Then it runs the Git commands
       | BRANCH          | COMMAND           |
       | current-feature | git fetch --prune |

--- a/features/git-rename-branch/destination_branch_exists_remotely.feature
+++ b/features/git-rename-branch/destination_branch_exists_remotely.feature
@@ -11,11 +11,11 @@ Feature: git rename-branch: errors when the destination branch exists remotely
       | current-feature  | local and remote | current-feature commit  |
       | existing-feature | remote           | existing-feature commit |
     And I am on the "current-feature" branch
+    And I have an uncommitted file
+    When I run `git rename-branch current-feature existing-feature`
 
 
   Scenario: result
-    And I have an uncommitted file
-    When I run `git rename-branch current-feature existing-feature`
     Then it runs the Git commands
       | BRANCH          | COMMAND           |
       | current-feature | git fetch --prune |

--- a/features/git-rename-branch/feature_branch/branch_and_destination_same.feature
+++ b/features/git-rename-branch/feature_branch/branch_and_destination_same.feature
@@ -11,11 +11,11 @@ Feature: git rename-branch: does nothing if renaming a feature branch onto itsel
       | BRANCH          | LOCATION         | MESSAGE                |
       | current-feature | local and remote | current-feature commit |
     And I am on the "current-feature" branch
+    And I have an uncommitted file
+    When I run `git rename-branch current-feature current-feature`
 
 
   Scenario: result
-    When I run `git rename-branch current-feature current-feature`
-    Given I have an uncommitted file
     Then I see "Renaming branch to same name, nothing needed."
     And I end up on the "current-feature" branch
     And I still have my uncommitted file

--- a/features/git-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
+++ b/features/git-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
@@ -13,11 +13,11 @@ Feature: git rename-branch: errors if renaming a feature branch that has unpulle
       | current-feature | local and remote | feature commit        |
       |                 | remote           | remote feature commit |
     And I am on the "current-feature" branch
+    And I have an uncommitted file
+    When I run `git rename-branch current-feature renamed-feature`
 
 
   Scenario: result
-    And I have an uncommitted file
-    When I run `git rename-branch current-feature renamed-feature`
     Then I get the error "The branch is not in sync with its tracking branch."
     And I get the error "Run 'git sync current-feature' to sync the branch."
     And I end up on the "current-feature" branch

--- a/features/git-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
+++ b/features/git-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
@@ -13,11 +13,11 @@ Feature: git rename-branch: errors if renaming a feature branch that has unpushe
       | current-feature | local and remote | feature commit       |
       |                 | local            | local feature commit |
     And I am on the "current-feature" branch
+    And I have an uncommitted file
+    When I run `git rename-branch current-feature renamed-feature`
 
 
   Scenario: result
-    And I have an uncommitted file
-    When I run `git rename-branch current-feature renamed-feature`
     Then I get the error "The branch is not in sync with its tracking branch."
     And I get the error "Run 'git sync current-feature' to sync the branch."
     And I end up on the "current-feature" branch

--- a/features/git-rename-branch/non_feature_branch/branch_and_destination_same.feature
+++ b/features/git-rename-branch/non_feature_branch/branch_and_destination_same.feature
@@ -12,11 +12,11 @@ Feature: git rename-branch: does nothing if renaming a non-feature branch onto i
       | BRANCH     | LOCATION         | MESSAGE           |
       | production | local and remote | production commit |
     And I am on the "production" branch
+    And I have an uncommitted file
+    When I run `git rename-branch production production -f`
 
 
   Scenario: result
-    When I run `git rename-branch production production -f`
-    Given I have an uncommitted file
     Then I see "Renaming branch to same name, nothing needed."
     And I end up on the "production" branch
     And I still have my uncommitted file

--- a/features/git-rename-branch/non_feature_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
+++ b/features/git-rename-branch/non_feature_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
@@ -14,11 +14,11 @@ Feature: git rename-branch: errors if renaming a non-feature branch that has unp
       | production | local and remote | production commit        |
       |            | remote           | remote production commit |
     And I am on the "production" branch
+    And I have an uncommitted file
+    When I run `git rename-branch production renamed-production -f`
 
 
   Scenario: result
-    And I have an uncommitted file
-    When I run `git rename-branch production renamed-production -f`
     Then I get the error "The branch is not in sync with its tracking branch."
     And I get the error "Run 'git sync production' to sync the branch."
     And I end up on the "production" branch

--- a/features/git-rename-branch/non_feature_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
+++ b/features/git-rename-branch/non_feature_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
@@ -14,11 +14,11 @@ Feature: git rename-branch: errors if renaming a non-feature branch that has unp
       | production | local and remote | production commit        |
       |            | local            | remote production commit |
     And I am on the "production" branch
+    And I have an uncommitted file
+    When I run `git rename-branch production renamed-production -f`
 
 
   Scenario: result
-    And I have an uncommitted file
-    When I run `git rename-branch production renamed-production -f`
     Then I get the error "The branch is not in sync with its tracking branch."
     And I get the error "Run 'git sync production' to sync the branch."
     And I end up on the "production" branch


### PR DESCRIPTION
@charlierudolph @allewun @ricmatsui 

Some of the git-rename-branch specs had setup code in the `result` scenario.