### PR TITLE
Nesting support for git-new-pull-request

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ Metrics/CyclomaticComplexity:
 
 
 Metrics/LineLength:
-  Max: 120
+  Enabled: false
 
 
 Metrics/ParameterLists:

--- a/features/git-new-pull-request/github.feature
+++ b/features/git-new-pull-request/github.feature
@@ -5,10 +5,12 @@ Feature: git-new-pull-request when origin is on GitHub
   So that I have more time for coding the next feature instead of wasting it with process boilerplate.
 
 
+  Background:
+    Given I have "open" installed
+
   Scenario Outline: creating pull-requests
     Given I have a feature branch named "feature"
     And my remote origin is <ORIGIN>
-    And I have "open" installed
     And I am on the "feature" branch
     When I run `git new-pull-request`
     Then I see a new GitHub pull request for the "feature" branch in the "<REPOSITORY>" repo in my browser
@@ -27,3 +29,29 @@ Feature: git-new-pull-request when origin is on GitHub
       | https://github.com/Originate/originate.github.com     | Originate/originate.github.com |
       | git@github.com:Originate/originate.github.com.git     | Originate/originate.github.com |
       | git@github.com:Originate/originate.github.com         | Originate/originate.github.com |
+
+
+  Scenario: nested feature branch with known parent
+    Given I have a feature branch named "parent-feature"
+    And I have a feature branch named "child-feature" as a child of "parent-feature"
+    And my remote origin is git@github.com:Originate/git-town.git
+    And I am on the "child-feature" branch
+    When I run `git new-pull-request`
+    Then I see a new GitHub pull request for the "child-feature" branch against the "parent-feature" branch in the "Originate/git-town" repo in my browser
+
+
+  Scenario: nested feature branch with unknown parent (entering the parent name)
+    Given I have a feature branch named "feature"
+    And Git Town has no branch hierarchy information for "feature"
+    And my remote origin is git@github.com:Originate/git-town.git
+    And I am on the "feature" branch
+    When I run `git new-pull-request` and enter "main"
+    Then I see a new GitHub pull request for the "feature" branch against the "main" branch in the "Originate/git-town" repo in my browser
+
+  Scenario: nested feature branch with unknown parent (accepting default choice)
+    Given I have a feature branch named "feature"
+    And Git Town has no branch hierarchy information for "feature"
+    And my remote origin is git@github.com:Originate/git-town.git
+    And I am on the "feature" branch
+    When I run `git new-pull-request` and enter ""
+    Then I see a new GitHub pull request for the "feature" branch against the "main" branch in the "Originate/git-town" repo in my browser

--- a/features/git-new-pull-request/github.feature
+++ b/features/git-new-pull-request/github.feature
@@ -8,6 +8,7 @@ Feature: git-new-pull-request when origin is on GitHub
   Background:
     Given I have "open" installed
 
+
   Scenario Outline: creating pull-requests
     Given I have a feature branch named "feature"
     And my remote origin is <ORIGIN>
@@ -47,6 +48,7 @@ Feature: git-new-pull-request when origin is on GitHub
     And I am on the "feature" branch
     When I run `git new-pull-request` and enter "main"
     Then I see a new GitHub pull request for the "feature" branch against the "main" branch in the "Originate/git-town" repo in my browser
+
 
   Scenario: nested feature branch with unknown parent (accepting default choice)
     Given I have a feature branch named "feature"

--- a/features/step_definitions/browser_steps.rb
+++ b/features/step_definitions/browser_steps.rb
@@ -1,5 +1,12 @@
-Then(/^I see a new (.+?) pull request for the "(.+?)" branch in the "(.+?)" repo in my browser$/) do |domain, branch, repo|
-  expect(@last_run_result.out.strip).to eql "#{@tool} called with: #{pull_request_url domain, branch, repo}"
+Then(/^I see a new (.+?) pull request for the "([^"]+)" branch in the "(.+?)" repo in my browser$/) do |domain, branch, repo|
+  url = pull_request_url domain: domain, branch: branch, parent_branch: 'main', repo: repo
+  expect(@last_run_result.out.strip).to eql "#{@tool} called with: #{url}"
+end
+
+
+Then(/^I see a new (.+?) pull request for the "([^"]+)" branch against the "(.+?)" branch in the "(.+?)" repo in my browser$/) do |domain, child_branch, parent_branch, repo|
+  url = pull_request_url domain: domain, branch: child_branch, parent_branch: parent_branch, repo: repo
+  expect(@last_run_result.out.strip).to include "#{@tool} called with: #{url}"
 end
 
 

--- a/features/support/remote_helpers.rb
+++ b/features/support/remote_helpers.rb
@@ -11,17 +11,26 @@ def base_url domain
 end
 
 
+# Returns the URL for making pull requests on Bitbucket
+def bitbucket_pull_request_url branch:, parent_branch:, repo:
+  sha = recent_commit_shas(1).join('')[0, 12] # TODO: update to have the branch as an argument
+  source = CGI.escape "#{repo}:#{sha}:#{branch}"
+  dest = CGI.escape "#{repo}::#{parent_branch}"
+  "https://bitbucket.org/#{repo}/pull-request/new?source=#{source}&dest=#{dest}"
+end
+
+
+# Returns the URL for making pull requests on GitHub
+def github_pull_request_url branch:, parent_branch:, repo:
+  "https://github.com/#{repo}/compare/#{parent_branch}...#{branch}?expand=1"
+end
+
+
 # Returns the remote URL for a new pull request for the given domain and branch
-def pull_request_url domain, branch_name, repo
-  case domain
-  when 'Bitbucket'
-    sha = recent_commit_shas(1).join('')[0, 12]
-    "https://bitbucket.org/#{repo}/pull-request/new?source=#{CGI.escape repo}%3A#{sha}%3A#{branch_name}"
-  when 'GitHub'
-    "https://github.com/#{repo}/compare/#{branch_name}?expand=1"
-  else
-    fail "Unknown domain: #{domain}"
-  end
+def pull_request_url domain:, branch:, parent_branch:, repo:
+  send "#{domain.downcase}_pull_request_url", branch: branch,
+                                              parent_branch: parent_branch,
+                                              repo: repo
 end
 
 

--- a/features/support/remote_helpers.rb
+++ b/features/support/remote_helpers.rb
@@ -28,9 +28,8 @@ end
 
 # Returns the remote URL for a new pull request for the given domain and branch
 def pull_request_url domain:, branch:, parent_branch:, repo:
-  send "#{domain.downcase}_pull_request_url", branch: branch,
-                                              parent_branch: parent_branch,
-                                              repo: repo
+  send "#{domain.downcase}_pull_request_url",
+       branch: branch, parent_branch: parent_branch, repo: repo
 end
 
 

--- a/src/drivers/code_hosting/bitbucket.sh
+++ b/src/drivers/code_hosting/bitbucket.sh
@@ -12,7 +12,7 @@ function bitbucket_source {
 
 
 # Returns the parent for a new Bitbucket pull request
-function bitbucket_parent {
+function bitbucket_destination {
   local repository=$1
   local branch=$2
 
@@ -26,8 +26,8 @@ function create_pull_request {
   local parent_branch=$3
 
   src=$(bitbucket_source "$repository" "$branch")
-  parent=$(bitbucket_parent "$repository" "$parent_branch")
-  open_browser "https://bitbucket.org/$repository/pull-request/new?source=$src\&dest=$parent"
+  dest=$(bitbucket_destination "$repository" "$parent_branch")
+  open_browser "https://bitbucket.org/$repository/pull-request/new?source=$src\&dest=$dest"
 }
 
 

--- a/src/drivers/code_hosting/bitbucket.sh
+++ b/src/drivers/code_hosting/bitbucket.sh
@@ -6,16 +6,28 @@ function bitbucket_source {
   local repository=$1
   local branch=$2
 
-  local sha=$(git log --format="%H" -1 | cut -c-12)
+  local sha ; sha=$(git log --format="%H" -1 | cut -c-12)
   echo "$repository:$sha:$branch" | sed 's/\//%2F/g' | sed 's/\:/%3A/g'
+}
+
+
+# Returns the parent for a new Bitbucket pull request
+function bitbucket_parent {
+  local repository=$1
+  local branch=$2
+
+  echo "$repository::$branch" | sed 's/\//%2F/g' | sed 's/\:/%3A/g'
 }
 
 
 function create_pull_request {
   local repository=$1
   local branch=$2
+  local parent_branch=$3
 
-  open_browser "https://bitbucket.org/$repository/pull-request/new?source=$(bitbucket_source "$repository" "$branch")"
+  src=$(bitbucket_source "$repository" "$branch")
+  parent=$(bitbucket_parent "$repository" "$parent_branch")
+  open_browser "https://bitbucket.org/$repository/pull-request/new?source=$src\&dest=$parent"
 }
 
 

--- a/src/drivers/code_hosting/github.sh
+++ b/src/drivers/code_hosting/github.sh
@@ -4,8 +4,9 @@
 function create_pull_request {
   local repository=$1
   local branch=$2
+  local parent_branch=$3
 
-  open_browser "https://github.com/$repository/compare/$branch?expand=1"
+  open_browser "https://github.com/$repository/compare/$parent_branch...$branch?expand=1"
 }
 
 

--- a/src/git-new-pull-request
+++ b/src/git-new-pull-request
@@ -4,11 +4,12 @@ source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/helpers/helpers.sh"
 
 function preconditions {
   activate_driver_family 'code_hosting'
+  ensure_knows_parent_branches "$INITIAL_BRANCH_NAME"
 }
 
 
 function steps {
-  echo "create_pull_request $(remote_repository_name) $INITIAL_BRANCH_NAME"
+  echo "create_pull_request $(remote_repository_name) $INITIAL_BRANCH_NAME $(parent_branch "$INITIAL_BRANCH_NAME")"
 }
 
 


### PR DESCRIPTION
@charlierudolph @allewun @ricmatsui 

Makes git-new-pull-request able to handle nested branches

implements parts of #529 