### PR TITLE
update documentation

### DIFF
--- a/documentation/commands/git-extract.md
+++ b/documentation/commands/git-extract.md
@@ -6,7 +6,7 @@ git-extract - copy selected commits from the current branch into their own branc
 #### SYNOPSIS
 
 ```
-git extract <branchname> [<commit>...]
+git extract <branch_name> [<commit>...]
 git extract (--abort | --continue)
 ```
 
@@ -23,7 +23,7 @@ If no commits are provided, prompts the user to select from a list of commits un
 #### OPTIONS
 
 ```
-<branchname>
+<branch_name>
     The name of the branch to create.
 
 <commit>

--- a/documentation/commands/git-hack.md
+++ b/documentation/commands/git-hack.md
@@ -6,7 +6,7 @@ git-hack - create a new feature branch
 #### SYNOPSIS
 
 ```
-git hack <branchname> [<parent branch name>]
+git hack <branch_name> [<parent_branch_name>]
 git hack (--abort | --continue)
 ```
 
@@ -21,10 +21,10 @@ and brings over all uncommitted changes to the new feature branch.
 #### OPTIONS
 
 ```
-<branchname>
+<branch_name>
     The name of the branch to create.
 
-[parent branch name]
+<parent_branch_name>
     If provided, cuts the new branch off the given existing feature branch.
     Providing '.' here uses the current branch as the parent branch.
     If omitted, uses the main branch as the parent.

--- a/documentation/commands/git-kill.md
+++ b/documentation/commands/git-kill.md
@@ -6,14 +6,14 @@ git-kill - remove an obsolete feature branch
 #### SYNOPSIS
 
 ```
-git kill [<branchname>]
+git kill [<branch_name>]
 git kill --undo
 ```
 
 
 #### DESCRIPTION
 
-Deletes the current branch, or `<branchname>` if given,
+Deletes the current branch, or `<branch_name>` if given,
 from the local and remote repositories.
 
 Does not delete perennial branches nor the main branch.
@@ -23,7 +23,7 @@ Does not delete perennial branches nor the main branch.
 #### OPTIONS
 
 ```
-<branchname>
+<branch_name>
     The branch to remove.
     If not provided, uses the current branch.
 

--- a/documentation/commands/git-rename-branch.md
+++ b/documentation/commands/git-rename-branch.md
@@ -6,7 +6,7 @@ git-rename-branch - rename a branch both locally and remotely
 #### SYNOPSIS
 
 ```
-git rename-branch <branchname> <newbranchname> [-f]
+git rename-branch <old_branch_name> <new_branch_name> [-f]
 ```
 
 
@@ -34,10 +34,10 @@ When run on a perennial branch
 #### OPTIONS
 
 ```
-<branchname>
+<old_branch_name>
     The name of the branch to rename.
 
-<newbranchname>
+<new_branch_name>
     The new name of the branch.
 
 -f

--- a/documentation/commands/git-ship.md
+++ b/documentation/commands/git-ship.md
@@ -6,22 +6,22 @@ git-ship - deliver a completed feature branch
 #### SYNOPSIS
 
 ```
-git ship [<branchname>] [<commit-options>]
+git ship [<branch_name>] [<commit_options>]
 git ship (--abort | --continue)
 ```
 
 
 #### DESCRIPTION
 
-Squash-merges the current branch, or `<branchname>` if given,
+Squash-merges the current branch, or `<branch_name>` if given,
 into the main branch, leading to linear history on the main branch.
 
 * syncs the main branch
-* pulls remote updates for `<branchname>`
-* merges the main branch into `<branchname>`
-* squash-merges `<branchname>` into the main branch
+* pulls remote updates for `<branch_name>`
+* merges the main branch into `<branch_name>`
+* squash-merges `<branch_name>` into the main branch
 * pushes the main branch to the remote repository
-* deletes `<branchname>` from the local and remote repositories
+* deletes `<branch_name>` from the local and remote repositories
 
 Only shipping of direct children of the main branch is allowed.
 To ship a nested child branch, all ancestor branches have to be shipped or killed.
@@ -30,11 +30,11 @@ To ship a nested child branch, all ancestor branches have to be shipped or kille
 #### OPTIONS
 
 ```
-<branchname>
+<branch_name>
     The branch to ship.
     If not provided, uses the current branch.
 
-<commit-options>
+<commit_options>
     Options to pass to 'git commit' when commiting the squash-merge.
 
 --abort

--- a/documentation/commands/git-town.md
+++ b/documentation/commands/git-town.md
@@ -10,8 +10,8 @@ git town
 git town config [--reset | --setup]
 git town help
 git town install-fish-autocompletion
-git town main-branch [<branchname>]
-git town perennial-branches [(--add | --remove) <branchname>]
+git town main-branch [<branch_name>]
+git town perennial-branches [(--add | --remove) <branch_name>]
 git town version
 ```
 
@@ -33,7 +33,7 @@ git town version
 * *main-branch*
 > Displays the name of the main development branch.
 >
-> With an optional branch name `<branchname>`, specify a branch to assign as the main branch.
+> With an optional branch name `<branch_name>`, specify a branch to assign as the main branch.
 > ```bash
 > # Set "master" as the main branch
 > git town main-branch master

--- a/features/git-town/configuration/perennial_branches/add_branch.feature
+++ b/features/git-town/configuration/perennial_branches/add_branch.feature
@@ -37,5 +37,5 @@ Feature: add a branch to the perennial branches configuration
     Then I get the error
       """
       error: missing branch name
-      usage: git town perennial-branches (--add | --remove) <branchname>
+      usage: git town perennial-branches (--add | --remove) <branch_name>
       """

--- a/features/git-town/configuration/perennial_branches/invalid_option.feature
+++ b/features/git-town/configuration/perennial_branches/invalid_option.feature
@@ -10,5 +10,5 @@ Feature: passing an invalid option to the perennial branch configuration
     Then I get the error
       """
       error: unsupported option '--invalid-option'
-      usage: git town perennial-branches (--add | --remove) <branchname>
+      usage: git town perennial-branches (--add | --remove) <branch_name>
       """

--- a/features/git-town/configuration/perennial_branches/remove_branch.feature
+++ b/features/git-town/configuration/perennial_branches/remove_branch.feature
@@ -27,5 +27,5 @@ Feature: remove a branch from the perennial branches configuration
     Then I get the error
       """
       error: missing branch name
-      usage: git town perennial-branches (--add | --remove) <branchname>
+      usage: git town perennial-branches (--add | --remove) <branch_name>
       """

--- a/features/git-town/town.feature
+++ b/features/git-town/town.feature
@@ -9,7 +9,7 @@ Feature: Show correct git town usage
          or: git town config [--reset | --setup]
          or: git town help
          or: git town install-fish-autocompletion
-         or: git town main-branch [<branchname>]
-         or: git town perennial-branches [(--add | --remove) <branchname>]
+         or: git town main-branch [<branch_name>]
+         or: git town perennial-branches [(--add | --remove) <branch_name>]
          or: git town version
       """

--- a/man/man1/git-extract.1
+++ b/man/man1/git-extract.1
@@ -5,7 +5,7 @@ git extract \- copy selected commits from the current branch into their own bran
 
 
 .SH "SYNOPSIS"
-\fIgit extract\fR <branchname> [<commit>...]
+\fIgit extract\fR <branch_name> [<commit>...]
 .br
 \fIgit extract\fR (--abort | --continue)
 
@@ -21,7 +21,7 @@ If no commits are provided, prompts the user to select from a list of commits un
 
 
 .SH "OPTIONS"
-.IP "<branchname>" 4
+.IP "<branch_name>" 4
 The name of the branch to create.
 
 .IP "<commit>" 4

--- a/man/man1/git-hack.1
+++ b/man/man1/git-hack.1
@@ -5,7 +5,7 @@ git hack \- create a new feature branch
 
 
 .SH "SYNOPSIS"
-\fIgit hack\fR <branchname> [<parent branch name>]
+\fIgit hack\fR <branch_name> [<parent_branch_name>]
 .br
 \fIgit hack\fR (--abort | --continue)
 
@@ -19,10 +19,10 @@ and brings over all uncommitted changes to the new feature branch.
 
 
 .SH "OPTIONS"
-.IP "<branchname>" 4
+.IP "<branch_name>" 4
 The name of the branch to create.
 
-.IP "[parent branch name]" 4
+.IP "<parent_branch_name>" 4
 If provided, cuts the new branch off the given existing feature branch.
 .br
 Providing '.' here uses the current branch as the parent branch.

--- a/man/man1/git-kill.1
+++ b/man/man1/git-kill.1
@@ -5,20 +5,20 @@ git kill \- remove an obsolete feature branch
 
 
 .SH "SYNOPSIS"
-\fIgit kill\fR [<branchname>]
+\fIgit kill\fR [<branch_name>]
 .br
 \fIgit kill\fR --undo
 
 
 .SH "DESCRIPTION"
-Deletes the current branch, or <branchname> if given,
+Deletes the current branch, or <branch_name> if given,
 from the local and remote repositories.
 .br
 Does not delete perennial branches nor the main branch.
 
 
 .SH "OPTIONS"
-.IP "<branchname>" 4
+.IP "<branch_name>" 4
 The name of the branch to remove.
 .br
 If not provided, removes the current branch.

--- a/man/man1/git-rename-branch.1
+++ b/man/man1/git-rename-branch.1
@@ -5,7 +5,7 @@ git-rename-branch \- rename a branch both locally and remotely
 
 
 .SH "SYNOPSIS"
-\fIgit rename-branch\fR <branchname> <newbranchname> [-f]
+\fIgit rename-branch\fR <old_branch_name> <new_branch_name> [-f]
 
 
 .SH "DESCRIPTION"
@@ -37,10 +37,10 @@ When run on a perennial branch
 
 
 .SH "OPTIONS"
-.IP "<branchname>" 4
+.IP "<old_branch_name>" 4
 The name of the branch to rename.
 
-.IP "<newbranchname>" 4
+.IP "<new_branch_name>" 4
 The new name of the branch.
 
 .IP "-f" 4

--- a/man/man1/git-ship.1
+++ b/man/man1/git-ship.1
@@ -5,26 +5,26 @@ git ship \- deliver a completed feature branch
 
 
 .SH "SYNOPSIS"
-\fIgit ship\fR [<branchname>] [<commit-options>]
+\fIgit ship\fR [<branch_name>] [<commit_options>]
 .br
 \fIgit ship\fR (--abort | --continue)
 
 
 .SH "DESCRIPTION"
-Squash merges the current branch, or <branchname> if given,
+Squash merges the current branch, or <branch_name> if given,
 into the main branch, leading to linear history on the main branch.
 .PP
 * syncs the main branch
 .br
-* pulls remote updates for <branchname>
+* pulls remote updates for <branch_name>
 .br
-* merges the main branch into <branchname>
+* merges the main branch into <branch_name>
 .br
-* squash-merges <branchname> into the main branch
+* squash-merges <branch_name> into the main branch
 .br
 * pushes the main branch to the remote repository
 .br
-* deletes <branchname> from the local and remote repositories
+* deletes <branch_name> from the local and remote repositories
 
 Only shipping of direct children of the main branch is allowed.
 .br
@@ -32,12 +32,12 @@ To ship a nested child branch, all ancestor branches have to be shipped or kille
 
 
 .SH "OPTIONS"
-.IP "<branchname>" 4
+.IP "<branch_name>" 4
 The branch to ship.
 .br
 If not provided, uses the current branch.
 
-.IP "<commit-options>" 4
+.IP "<commit_options>" 4
 Options to pass to 'git commit' when commiting the squash merge.
 
 .IP "--abort" 4

--- a/man/man1/git-town.1
+++ b/man/man1/git-town.1
@@ -7,9 +7,9 @@
 .br
 \fIgit town\fR install-fish-autocompletion
 .br
-\fIgit town\fR main-branch [<branchname>]
+\fIgit town\fR main-branch [<branch_name>]
 .br
-\fIgit town\fR perennial-branches [(--add | --remove) <branchname>]
+\fIgit town\fR perennial-branches [(--add | --remove) <branch_name>]
 .br
 \fIgit town\fR version
 
@@ -63,14 +63,14 @@ Installs the autocompletion definition for Fish shell
 .IP "git town main-branch" 4
 Displays your main branch
 
-.IP "git town main-branch <branchname>" 4
-Set your main branch to <branchname>
+.IP "git town main-branch <branch_name>" 4
+Set your main branch to <branch_name>
 
 .IP "git town perennial-branches" 4
 Displays your perennial branches
 
-.IP "git town perennial-branches --add <branchname>" 4
+.IP "git town perennial-branches --add <branch_name>" 4
 Add a new perennial branch
 
-.IP "git town perennial-branches --remove <branchname>" 4
+.IP "git town perennial-branches --remove <branch_name>" 4
 Remove branch from perennial branches

--- a/src/git-town
+++ b/src/git-town
@@ -64,8 +64,8 @@ elif [ -n "$1" ]; then
   echo_inline_usage_or "git town config [--reset | --setup]"
   echo_inline_usage_or "git town help"
   echo_inline_usage_or "git town install-fish-autocompletion"
-  echo_inline_usage_or "git town main-branch [<branchname>]"
-  echo_inline_usage_or "git town perennial-branches [(--add | --remove) <branchname>]"
+  echo_inline_usage_or "git town main-branch [<branch_name>]"
+  echo_inline_usage_or "git town perennial-branches [(--add | --remove) <branch_name>]"
   echo_inline_usage_or "git town version"
   exit_with_error newline
 fi

--- a/src/helpers/configuration_helpers.sh
+++ b/src/helpers/configuration_helpers.sh
@@ -44,7 +44,7 @@ function add_or_remove_perennial_branches {
 
 
 function echo_perennial_branch_usage {
-  echo_inline_usage 'git town perennial-branches (--add | --remove) <branchname>'
+  echo_inline_usage 'git town perennial-branches (--add | --remove) <branch_name>'
 }
 
 


### PR DESCRIPTION
@kevgo @allewun @ricmatsui 

Big change is
`<branchname>` -> `<branch_name>`
plus a little other cleanup around parent branch name

We originally used `<branchname>` as the documentation of git branch has that but some other git commands use `_` for separation and I'd prefer that.