### PR TITLE
move related code closer

### DIFF
--- a/src/git-ship
+++ b/src/git-ship
@@ -5,8 +5,8 @@ source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/helpers/helpers.sh"
 function ensure_has_no_unshipped_ancestors {
   local branch_name=$1
 
-  local parent_branch_name ; parent_branch_name=$(parent_branch "$branch_name")
-  if [ "$parent_branch_name" != "$MAIN_BRANCH_NAME" ]; then
+  ensure_knows_parent_branches "$branch_name"
+  if [ "$(parent_branch "$branch_name")" != "$MAIN_BRANCH_NAME" ]; then
     echo_error_header
     echo_error "Shipping this branch would ship $(ancestor_branches "$branch_name") as well."
     echo_error "Please ship '$(oldest_ancestor_branch "$branch_name")' first."
@@ -39,7 +39,6 @@ function preconditions {
   fi
 
   ensure_is_feature_branch "$target_branch_name" "Only feature branches can be shipped."
-  ensure_knows_parent_branches "$target_branch_name"
   ensure_has_no_unshipped_ancestors "$target_branch_name"
   commit_options=$(parameters_as_string "$@")
 }


### PR DESCRIPTION
@kevgo @allewun 

`ensure_knows_parent_branches` needs to be called only before a call to `parent_branch` or `parent_branches`. Move the check closer to the usage, and remove an unneeded variable