### PR TITLE
git sync --all: fix parent branch prompt

### DIFF
--- a/features/shared/prompting_for_parent_branch.feature
+++ b/features/shared/prompting_for_parent_branch.feature
@@ -32,16 +32,21 @@ Feature: Prompt for parent branch when unknown
 
 
   Scenario: prompting for parent branch when running git sync --all
-    Given I have a feature branch named "feature" with no parent
+    Given I have a feature branch named "feature-1" with no parent
+    And I have a feature branch named "feature-2" with no parent
     And the following commits exist in my repository
-      | BRANCH  | LOCATION         | MESSAGE        |
-      | main    | local and remote | main commit    |
-      | feature | local and remote | feature commit |
+      | BRANCH    | LOCATION         | MESSAGE          |
+      | main      | local and remote | main commit      |
+      | feature-1 | local and remote | feature-1 commit |
+      | feature-2 | local and remote | feature-2 commit |
     And I am on the "main" branch
-    When I run `git sync --all` and press ENTER
+    When I run `git sync --all` and press ENTER twice
     Then I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE                          |
-      | main    | local and remote | main commit                      |
-      | feature | local and remote | feature commit                   |
-      |         |                  | main commit                      |
-      |         |                  | Merge branch 'main' into feature |
+      | BRANCH    | LOCATION         | MESSAGE                            |
+      | main      | local and remote | main commit                        |
+      | feature-1 | local and remote | feature-1 commit                   |
+      |           |                  | main commit                        |
+      |           |                  | Merge branch 'main' into feature-1 |
+      | feature-2 | local and remote | feature-2 commit                   |
+      |           |                  | main commit                        |
+      |           |                  | Merge branch 'main' into feature-2 |

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -38,8 +38,10 @@ When(/^I run `(.+?)` and enter main branch name "(.+?)"(?: and perennial branch 
 end
 
 
-When(/^I run `(.+?)` and press ENTER$/) do |command|
-  step "I run `#{command}` and enter \"\""
+When(/^I run `(.+?)` and press ENTER( twice)?$/) do |command, twice|
+  inputs = ["\n"]
+  inputs += inputs if twice
+  @result = run command, inputs: inputs
 end
 
 

--- a/src/git-sync
+++ b/src/git-sync
@@ -29,7 +29,8 @@ function preconditions {
 
   if [ "$1" = "--all" ]; then
     sync_target="all branches"
-    local_branches_without_main | while read branch_name; do
+    local branches="$(local_branches_without_main | tr '\n' ' ')"
+    for branch_name in $branches; do
       if [ "$(is_feature_branch "$branch_name")" = true ]; then
         ensure_knows_parent_branches "$branch_name"
       fi


### PR DESCRIPTION
@kevgo @allewun 

Current implementation wasn't working because we are reading while branch names are being piped in, thus the parent branches are being automatically set as other branches.