### PR TITLE
cleanup: dry up files names in commit tables for git-kill

### DIFF
--- a/features/git-kill/current_branch/on_feature_branch/with_deleted_tracking_branch.feature
+++ b/features/git-kill/current_branch/on_feature_branch/with_deleted_tracking_branch.feature
@@ -8,9 +8,9 @@ Feature: git kill: killing the current feature branch with a deleted tracking br
   Background:
     Given I have feature branches named "current-feature" and "other-feature"
     And the following commits exist in my repository
-      | BRANCH          | LOCATION         | MESSAGE                | FILE NAME            |
-      | current-feature | local and remote | current feature commit | current_feature_file |
-      | other-feature   | local and remote | other feature commit   | other_feature_file   |
+      | BRANCH          | LOCATION         | MESSAGE                |
+      | current-feature | local and remote | current feature commit |
+      | other-feature   | local and remote | other feature commit   |
     And the "current-feature" branch gets deleted on the remote
     And I am on the "current-feature" branch
     And I have an uncommitted file
@@ -32,8 +32,8 @@ Feature: git kill: killing the current feature branch with a deleted tracking br
       | local      | main, other-feature |
       | remote     | main, other-feature |
     And I have the following commits
-      | BRANCH        | LOCATION         | MESSAGE              | FILE NAME          |
-      | other-feature | local and remote | other feature commit | other_feature_file |
+      | BRANCH        | LOCATION         | MESSAGE              |
+      | other-feature | local and remote | other feature commit |
 
 
   Scenario: undoing the kill
@@ -50,6 +50,6 @@ Feature: git kill: killing the current feature branch with a deleted tracking br
       | local      | main, current-feature, other-feature |
       | remote     | main, other-feature                  |
     And I have the following commits
-      | BRANCH          | LOCATION         | MESSAGE                | FILE NAME            |
-      | current-feature | local            | current feature commit | current_feature_file |
-      | other-feature   | local and remote | other feature commit   | other_feature_file   |
+      | BRANCH          | LOCATION         | MESSAGE                |
+      | current-feature | local            | current feature commit |
+      | other-feature   | local and remote | other feature commit   |

--- a/features/git-kill/current_branch/on_feature_branch/with_parent_and_child_branches.feature
+++ b/features/git-kill/current_branch/on_feature_branch/with_parent_and_child_branches.feature
@@ -10,10 +10,10 @@ Feature: git kill: killing the current feature branch with child branches
     And I have a feature branch named "feature-2" as a child of "feature-1"
     And I have a feature branch named "feature-3" as a child of "feature-2"
     And the following commits exist in my repository
-      | BRANCH    | LOCATION         | MESSAGE          | FILE NAME      |
-      | feature-1 | local and remote | feature 1 commit | feature_1_file |
-      | feature-2 | local and remote | feature 2 commit | feature_2_file |
-      | feature-3 | local and remote | feature 3 commit | feature_3_file |
+      | BRANCH    | LOCATION         | MESSAGE          |
+      | feature-1 | local and remote | feature 1 commit |
+      | feature-2 | local and remote | feature 2 commit |
+      | feature-3 | local and remote | feature 3 commit |
     And I am on the "feature-2" branch
     And I have an uncommitted file
     When I run `git kill`
@@ -35,9 +35,9 @@ Feature: git kill: killing the current feature branch with child branches
       | local      | main, feature-1, feature-3 |
       | remote     | main, feature-1, feature-3 |
     And I have the following commits
-      | BRANCH    | LOCATION         | MESSAGE          | FILE NAME      |
-      | feature-1 | local and remote | feature 1 commit | feature_1_file |
-      | feature-3 | local and remote | feature 3 commit | feature_3_file |
+      | BRANCH    | LOCATION         | MESSAGE          |
+      | feature-1 | local and remote | feature 1 commit |
+      | feature-3 | local and remote | feature 3 commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH    | PARENT    |
       | feature-1 | main      |

--- a/features/git-kill/current_branch/on_feature_branch/with_tracking_branch.feature
+++ b/features/git-kill/current_branch/on_feature_branch/with_tracking_branch.feature
@@ -8,9 +8,9 @@ Feature: git kill: killing the current feature branch with a tracking branch
   Background:
     Given I have feature branches named "current-feature" and "other-feature"
     And the following commits exist in my repository
-      | BRANCH          | LOCATION         | MESSAGE                | FILE NAME            |
-      | current-feature | local and remote | current feature commit | current_feature_file |
-      | other-feature   | local and remote | other feature commit   | other_feature_file   |
+      | BRANCH          | LOCATION         | MESSAGE                |
+      | current-feature | local and remote | current feature commit |
+      | other-feature   | local and remote | other feature commit   |
     And I am on the "current-feature" branch
     And I have an uncommitted file
     When I run `git kill`
@@ -32,8 +32,8 @@ Feature: git kill: killing the current feature branch with a tracking branch
       | local      | main, other-feature |
       | remote     | main, other-feature |
     And I have the following commits
-      | BRANCH        | LOCATION         | MESSAGE              | FILE NAME          |
-      | other-feature | local and remote | other feature commit | other_feature_file |
+      | BRANCH        | LOCATION         | MESSAGE              |
+      | other-feature | local and remote | other feature commit |
 
 
   Scenario: undoing the kill
@@ -51,7 +51,4 @@ Feature: git kill: killing the current feature branch with a tracking branch
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
       | remote     | main, current-feature, other-feature |
-    And I have the following commits
-      | BRANCH          | LOCATION         | MESSAGE                | FILE NAME            |
-      | current-feature | local and remote | current feature commit | current_feature_file |
-      | other-feature   | local and remote | other feature commit   | other_feature_file   |
+    And I am left with my original commits

--- a/features/git-kill/current_branch/on_feature_branch/without_remote_origin.feature
+++ b/features/git-kill/current_branch/on_feature_branch/without_remote_origin.feature
@@ -7,9 +7,9 @@ Feature: git kill: killing the current feature branch without a tracking branch 
     Given my repo does not have a remote origin
     And I have local feature branches named "current-feature" and "other-feature"
     And the following commits exist in my repository
-      | BRANCH          | LOCATION | MESSAGE                | FILE NAME            | FILE CONTENT            |
-      | current-feature | local    | current feature commit | current_feature_file | current feature content |
-      | other-feature   | local    | other feature commit   | other_feature_file   | other feature content   |
+      | BRANCH          | LOCATION | MESSAGE                |
+      | current-feature | local    | current feature commit |
+      | other-feature   | local    | other feature commit   |
     And I am on the "current-feature" branch
     And I have an uncommitted file
     When I run `git kill`
@@ -27,8 +27,8 @@ Feature: git kill: killing the current feature branch without a tracking branch 
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
     And now I have the following commits
-      | BRANCH        | LOCATION | MESSAGE              | FILE NAME          | FILE CONTENT          |
-      | other-feature | local    | other feature commit | other_feature_file | other feature content |
+      | BRANCH        | LOCATION | MESSAGE              |
+      | other-feature | local    | other feature commit |
 
 
   Scenario: Undoing a kill of a local feature branch
@@ -43,7 +43,4 @@ Feature: git kill: killing the current feature branch without a tracking branch 
     And the existing branches are
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
-    And now I have the following commits
-      | BRANCH          | LOCATION | MESSAGE                | FILE NAME            | FILE CONTENT            |
-      | current-feature | local    | current feature commit | current_feature_file | current feature content |
-      | other-feature   | local    | other feature commit   | other_feature_file   | other feature content   |
+    And I am left with my original commits

--- a/features/git-kill/current_branch/on_feature_branch/without_tracking_branch.feature
+++ b/features/git-kill/current_branch/on_feature_branch/without_tracking_branch.feature
@@ -9,9 +9,9 @@ Feature: git kill: killing the current feature branch without a tracking branch
     Given I have a feature branch named "other-feature"
     And I have a local feature branch named "current-feature"
     And the following commits exist in my repository
-      | BRANCH          | LOCATION         | MESSAGE                | FILE NAME          |
-      | other-feature   | local and remote | other feature commit   | other_feature_file |
-      | current-feature | local            | current feature commit | unfortunate_file   |
+      | BRANCH          | LOCATION         | MESSAGE                |
+      | current-feature | local            | current feature commit |
+      | other-feature   | local and remote | other feature commit   |
     And I am on the "current-feature" branch
     And I have an uncommitted file
     When I run `git kill`
@@ -31,8 +31,8 @@ Feature: git kill: killing the current feature branch without a tracking branch
       | local      | main, other-feature |
       | remote     | main, other-feature |
     And I have the following commits
-      | BRANCH        | LOCATION         | MESSAGE              | FILE NAME          |
-      | other-feature | local and remote | other feature commit | other_feature_file |
+      | BRANCH        | LOCATION         | MESSAGE              |
+      | other-feature | local and remote | other feature commit |
 
 
   Scenario: Undoing a kill of a local feature branch
@@ -48,7 +48,4 @@ Feature: git kill: killing the current feature branch without a tracking branch
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
       | remote     | main, other-feature                  |
-    And I have the following commits
-      | BRANCH          | LOCATION         | MESSAGE                | FILE NAME          |
-      | current-feature | local            | current feature commit | unfortunate_file   |
-      | other-feature   | local and remote | other feature commit   | other_feature_file |
+    And I am left with my original commits

--- a/features/git-kill/current_branch/on_main_branch.feature
+++ b/features/git-kill/current_branch/on_main_branch.feature
@@ -8,8 +8,8 @@ Feature: git kill: errors when trying to kill the main branch
   Background:
     Given I have a feature branch named "feature"
     And the following commits exist in my repository
-      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
-      | feature | local and remote | good commit | good_file |
+      | BRANCH  | LOCATION         | MESSAGE     |
+      | feature | local and remote | good commit |
     And I am on the "main" branch
 
 
@@ -24,7 +24,5 @@ Feature: git kill: errors when trying to kill the main branch
       | REPOSITORY | BRANCHES      |
       | local      | main, feature |
       | remote     | main, feature |
-    And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
-      | feature | local and remote | good commit | good_file |
+    And I am left with my original commits
 

--- a/features/git-kill/current_branch/on_non_feature_branch.feature
+++ b/features/git-kill/current_branch/on_non_feature_branch.feature
@@ -9,8 +9,8 @@ Feature: git kill: errors when trying to kill a perennial branch
     Given I have a branch named "qa"
     And my perennial branches are configured as "qa"
     And the following commits exist in my repository
-      | BRANCH | LOCATION         | MESSAGE   | FILE NAME |
-      | qa     | local and remote | qa commit | qa_file   |
+      | BRANCH | LOCATION         | MESSAGE   |
+      | qa     | local and remote | qa commit |
     And I am on the "qa" branch
 
 
@@ -25,7 +25,5 @@ Feature: git kill: errors when trying to kill a perennial branch
       | REPOSITORY | BRANCHES |
       | local      | main, qa |
       | remote     | main, qa |
-    And I have the following commits
-      | BRANCH | LOCATION         | MESSAGE   | FILE NAME |
-      | qa     | local and remote | qa commit | qa_file   |
+    And I am left with my original commits
 

--- a/features/git-kill/supplied_branch/feature_branch/with_child_branches.feature
+++ b/features/git-kill/supplied_branch/feature_branch/with_child_branches.feature
@@ -8,10 +8,10 @@ Feature: git kill: killing the given branch with child branches
     And I have a feature branch named "feature-2" as a child of "feature-1"
     And I have a feature branch named "feature-3" as a child of "feature-2"
     And the following commits exist in my repository
-      | BRANCH    | LOCATION         | MESSAGE          | FILE NAME      |
-      | feature-1 | local and remote | feature 1 commit | feature_1_file |
-      | feature-2 | local and remote | feature 2 commit | feature_2_file |
-      | feature-3 | local and remote | feature 3 commit | feature_3_file |
+      | BRANCH    | LOCATION         | MESSAGE          |
+      | feature-1 | local and remote | feature 1 commit |
+      | feature-2 | local and remote | feature 2 commit |
+      | feature-3 | local and remote | feature 3 commit |
     And I am on the "feature-3" branch
     And I have an uncommitted file
     When I run `git kill feature-2`
@@ -30,9 +30,9 @@ Feature: git kill: killing the given branch with child branches
       | local      | main, feature-1, feature-3 |
       | remote     | main, feature-1, feature-3 |
     And I have the following commits
-      | BRANCH    | LOCATION         | MESSAGE          | FILE NAME      |
-      | feature-1 | local and remote | feature 1 commit | feature_1_file |
-      | feature-3 | local and remote | feature 3 commit | feature_3_file |
+      | BRANCH    | LOCATION         | MESSAGE          |
+      | feature-1 | local and remote | feature 1 commit |
+      | feature-3 | local and remote | feature 3 commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH    | PARENT    |
       | feature-1 | main      |

--- a/features/git-kill/supplied_branch/feature_branch/with_tracking_branch.feature
+++ b/features/git-kill/supplied_branch/feature_branch/with_tracking_branch.feature
@@ -8,10 +8,10 @@ Feature: git kill: killing the given feature branch
   Background:
     Given I have feature branches named "good-feature" and "dead-feature"
     And the following commits exist in my repository
-      | BRANCH       | LOCATION         | MESSAGE                              | FILE NAME        | FILE CONTENT |
-      | main         | local and remote | conflicting with uncommitted changes | conflicting_file | main content |
-      | good-feature | local and remote | good commit                          | good_file        |              |
-      | dead-feature | local and remote | dead-end commit                      | unfortunate_file |              |
+      | BRANCH       | LOCATION         | MESSAGE                              | FILE NAME        |
+      | main         | local and remote | conflicting with uncommitted changes | conflicting_file |
+      | dead-feature | local and remote | dead-end commit                      | unfortunate_file |
+      | good-feature | local and remote | good commit                          | good_file        |
     And I am on the "good-feature" branch
     And I have an uncommitted file with name: "conflicting_file" and content: "conflicting content"
     When I run `git kill dead-feature`
@@ -47,8 +47,4 @@ Feature: git kill: killing the given feature branch
       | REPOSITORY | BRANCHES                         |
       | local      | main, dead-feature, good-feature |
       | remote     | main, dead-feature, good-feature |
-    And I have the following commits
-      | BRANCH       | LOCATION         | MESSAGE                              | FILE NAME        |
-      | main         | local and remote | conflicting with uncommitted changes | conflicting_file |
-      | dead-feature | local and remote | dead-end commit                      | unfortunate_file |
-      | good-feature | local and remote | good commit                          | good_file        |
+    And I am left with my original commits

--- a/features/git-kill/supplied_branch/feature_branch/without_remote_origin.feature
+++ b/features/git-kill/supplied_branch/feature_branch/without_remote_origin.feature
@@ -7,10 +7,10 @@ Feature: git kill: killing the given feature branch (without remote repo)
     Given my repo does not have a remote origin
     And I have local feature branches named "current-feature" and "other-feature"
     And the following commits exist in my repository
-      | BRANCH          | LOCATION | MESSAGE                | FILE NAME            | FILE CONTENT            |
-      | main            | local    | main commit            | conflicting_file     | main content            |
-      | current-feature | local    | current feature commit | current_feature_file | current feature content |
-      | other-feature   | local    | other feature commit   | other_feature_file   | other feature content   |
+      | BRANCH          | LOCATION | MESSAGE                | FILE NAME            |
+      | main            | local    | main commit            | conflicting_file     |
+      | current-feature | local    | current feature commit | current_feature_file |
+      | other-feature   | local    | other feature commit   | other_feature_file   |
     And I am on the "current-feature" branch
     And I have an uncommitted file with name: "conflicting_file" and content: "conflicting content"
     When I run `git kill other-feature`
@@ -26,9 +26,9 @@ Feature: git kill: killing the given feature branch (without remote repo)
       | REPOSITORY | BRANCHES              |
       | local      | main, current-feature |
     And now I have the following commits
-      | BRANCH          | LOCATION | MESSAGE                | FILE NAME            | FILE CONTENT            |
-      | main            | local    | main commit            | conflicting_file     | main content            |
-      | current-feature | local    | current feature commit | current_feature_file | current feature content |
+      | BRANCH          | LOCATION | MESSAGE                | FILE NAME            |
+      | main            | local    | main commit            | conflicting_file     |
+      | current-feature | local    | current feature commit | current_feature_file |
 
 
   Scenario: undoing the kill
@@ -41,8 +41,4 @@ Feature: git kill: killing the given feature branch (without remote repo)
     And the existing branches are
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
-    And now I have the following commits
-      | BRANCH          | LOCATION | MESSAGE                | FILE NAME            | FILE CONTENT            |
-      | main            | local    | main commit            | conflicting_file     | main content            |
-      | current-feature | local    | current feature commit | current_feature_file | current feature content |
-      | other-feature   | local    | other feature commit   | other_feature_file   | other feature content   |
+    And I am left with my original commits

--- a/features/git-kill/supplied_branch/main_branch.feature
+++ b/features/git-kill/supplied_branch/main_branch.feature
@@ -6,9 +6,9 @@ Feature: git kill: errors when trying to kill the main branch
   Background:
     Given I have a feature branch named "feature"
     And the following commits exist in my repository
-      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
-      | feature | local and remote | good commit | good_file |
-      | main    | local and remote | main commit | main_file |
+      | BRANCH  | LOCATION         | MESSAGE     |
+      | main    | local and remote | main commit |
+      | feature | local and remote | good commit |
     And I am on the "feature" branch
 
 
@@ -23,8 +23,4 @@ Feature: git kill: errors when trying to kill the main branch
       | REPOSITORY | BRANCHES      |
       | local      | main, feature |
       | remote     | main, feature |
-    And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
-      | main    | local and remote | main commit | main_file |
-      | feature | local and remote | good commit | good_file |
-
+    And I am left with my original commits

--- a/features/git-kill/supplied_branch/on_supplied_feature_branch/with_tracking_branch.feature
+++ b/features/git-kill/supplied_branch/on_supplied_feature_branch/with_tracking_branch.feature
@@ -8,9 +8,9 @@ Feature: git kill: killing the given feature branch when on it
   Background:
     Given I have feature branches named "other-feature" and "current-feature"
     And the following commits exist in my repository
-      | BRANCH          | LOCATION         | MESSAGE                | FILE NAME            |
-      | current-feature | local and remote | current feature commit | current_feature_file |
-      | other-feature   | local and remote | other feature commit   | other_feature_file   |
+      | BRANCH          | LOCATION         | MESSAGE                |
+      | current-feature | local and remote | current feature commit |
+      | other-feature   | local and remote | other feature commit   |
     And I am on the "current-feature" branch
     And I have an uncommitted file
     When I run `git kill current-feature`
@@ -32,8 +32,8 @@ Feature: git kill: killing the given feature branch when on it
       | local      | main, other-feature |
       | remote     | main, other-feature |
     And I have the following commits
-      | BRANCH        | LOCATION         | MESSAGE              | FILE NAME          |
-      | other-feature | local and remote | other feature commit | other_feature_file |
+      | BRANCH        | LOCATION         | MESSAGE              |
+      | other-feature | local and remote | other feature commit |
 
 
   Scenario: undoing the kill
@@ -51,7 +51,4 @@ Feature: git kill: killing the given feature branch when on it
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
       | remote     | main, current-feature, other-feature |
-    And I have the following commits
-      | BRANCH          | LOCATION         | MESSAGE                | FILE NAME            |
-      | current-feature | local and remote | current feature commit | current_feature_file |
-      | other-feature   | local and remote | other feature commit   | other_feature_file   |
+    And I am left with my original commits

--- a/features/git-kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
+++ b/features/git-kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
@@ -7,9 +7,9 @@ Feature: git kill: killing the given feature branch when on it (without remote r
     Given my repo does not have a remote origin
     And I have local feature branches named "current-feature" and "other-feature"
     And the following commits exist in my repository
-      | BRANCH          | LOCATION | MESSAGE                | FILE NAME            | FILE CONTENT            |
-      | current-feature | local    | current feature commit | current_feature_file | current feature content |
-      | other-feature   | local    | other feature commit   | other_feature_file   | other feature content   |
+      | BRANCH          | LOCATION | MESSAGE                |
+      | current-feature | local    | current feature commit |
+      | other-feature   | local    | other feature commit   |
     And I am on the "current-feature" branch
     And I have an uncommitted file
     When I run `git kill current-feature`
@@ -28,11 +28,8 @@ Feature: git kill: killing the given feature branch when on it (without remote r
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
     And now I have the following commits
-      | BRANCH        | LOCATION | MESSAGE              | FILE NAME          |
-      | other-feature | local    | other feature commit | other_feature_file |
-    And now I have the following committed files
-      | BRANCH        | NAME               | CONTENT               |
-      | other-feature | other_feature_file | other feature content |
+      | BRANCH        | LOCATION | MESSAGE              |
+      | other-feature | local    | other feature commit |
 
 
   Scenario: undoing the kill
@@ -47,11 +44,5 @@ Feature: git kill: killing the given feature branch when on it (without remote r
     And the existing branches are
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
-    And now I have the following commits
-      | BRANCH          | LOCATION | MESSAGE                | FILE NAME            |
-      | current-feature | local    | current feature commit | current_feature_file |
-      | other-feature   | local    | other feature commit   | other_feature_file   |
-    And now I have the following committed files
-      | BRANCH          | NAME                 | CONTENT                 |
-      | current-feature | current_feature_file | current feature content |
-      | other-feature   | other_feature_file   | other feature content   |
+    And I am left with my original commits
+

--- a/features/git-kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
+++ b/features/git-kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
@@ -45,4 +45,3 @@ Feature: git kill: killing the given feature branch when on it (without remote r
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
     And I am left with my original commits
-

--- a/features/git-kill/supplied_branch/perennial_branch.feature
+++ b/features/git-kill/supplied_branch/perennial_branch.feature
@@ -7,9 +7,9 @@ Feature: git kill: errors when trying to kill a perennial branch
     Given I have branches named "feature" and "qa"
     And my perennial branches are configured as "qa"
     And the following commits exist in my repository
-      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
-      | feature | local and remote | good commit | good_file |
-      | qa      | local and remote | qa commit   | qa_file   |
+      | BRANCH  | LOCATION         | MESSAGE     |
+      | feature | local and remote | good commit |
+      | qa      | local and remote | qa commit   |
     And I am on the "feature" branch
 
 
@@ -24,7 +24,4 @@ Feature: git kill: errors when trying to kill a perennial branch
       | REPOSITORY | BRANCHES          |
       | local      | main, qa, feature |
       | remote     | main, qa, feature |
-    And I have the following commits
-      | BRANCH  | LOCATION         | MESSAGE     | FILE NAME |
-      | feature | local and remote | good commit | good_file |
-      | qa      | local and remote | qa commit   | qa_file   |
+    And I am left with my original commits


### PR DESCRIPTION
@kevgo @allewun 

Had to update the order of a few branches in commit tables in order to use "And I am left with my original commits" since it order them main followed by other branches in alpha order