### PR TITLE
store perennial branches as space separated list

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * **BREAKING CHANGE**: update internal storage of perennial branches
-  * if you have configured multiple perennial branches they will need to be reset
+  * if you have configured multiple perennial branches, you will need to reset your configuration
     * run `git town config --reset`
     * you will be prompted to re-enter your configuration the next time you use a Git Town command
 * `git sync --all`: pushes tags

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* **BREAKING CHANGE**: update internal storage of perennial branches
+  * if you have configured multiple perennial branches they will need to be reset
+    * run `git config --unset git-town.perennial-branch-names`
+    * you will be prompted to re-enter them the next time you use a Git Town command
 * `git sync --all`: pushes tags
   ([#464](https://github.com/Originate/git-town/issues/464))
 * `git town version`: Homebrew installs no longer print date and SHA

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,8 +4,8 @@
 
 * **BREAKING CHANGE**: update internal storage of perennial branches
   * if you have configured multiple perennial branches they will need to be reset
-    * run `git config --unset git-town.perennial-branch-names`
-    * you will be prompted to re-enter them the next time you use a Git Town command
+    * run `git town config --reset`
+    * you will be prompted to re-enter your configuration the next time you use a Git Town command
 * `git sync --all`: pushes tags
   ([#464](https://github.com/Originate/git-town/issues/464))
 * `git town version`: Homebrew installs no longer print date and SHA

--- a/documentation/development/branch_hierarchy.md
+++ b/documentation/development/branch_hierarchy.md
@@ -17,7 +17,7 @@ This is stored in the git config under `git-town.main-branch-name`
 These are branches that serve some special purpose, such as deployment.
 Perennial branches cannot be killed or shipped,
 and only rebase with their own tracking branch when synced.
-These are stored in the git config under `git-town.perennial-branch-names` as a comma seperated list.
+These are stored in the git config under `git-town.perennial-branch-names` as a space seperated list.
 
 
 ## Nested Feature Branches

--- a/features/step_definitions/town_steps.rb
+++ b/features/step_definitions/town_steps.rb
@@ -22,13 +22,13 @@ end
 
 Given(/^my non-feature branches are configured as (.*)$/) do |data|
   branch_names = Kappamaki.from_sentence data
-  set_configuration 'non-feature-branch-names', branch_names.join(', ')
+  set_configuration 'non-feature-branch-names', branch_names.join(' ')
 end
 
 
 Given(/^my perennial branches are configured as (.*)$/) do |data|
   branch_names = Kappamaki.from_sentence data
-  set_configuration 'perennial-branch-names', branch_names.join(', ')
+  set_configuration 'perennial-branch-names', branch_names.join(' ')
 end
 
 

--- a/features/step_definitions/town_steps.rb
+++ b/features/step_definitions/town_steps.rb
@@ -57,12 +57,12 @@ end
 
 Then(/^my perennial branches are now configured as (.*)$/) do |data|
   perennial_branches = Kappamaki.from_sentence(data)
-  expect(perennial_branch_configuration.split(',').map(&:strip)).to match_array perennial_branches
+  expect(perennial_branch_configuration.split(' ').map(&:strip)).to match_array perennial_branches
 end
 
 
 Then(/^my perennial branches are still not configured$/) do
-  expect(perennial_branch_configuration.split(',')).to be_empty
+  expect(perennial_branch_configuration.split(' ')).to be_empty
 end
 
 

--- a/src/helpers/configuration_helpers.sh
+++ b/src/helpers/configuration_helpers.sh
@@ -20,7 +20,7 @@ function add_perennial_branch {
     echo_inline_error "'$branch_name' is already set as the main branch"
     exit_with_error
   else
-    local new_branches=$(insert_string "$PERENNIAL_BRANCH_NAMES" ',' "$branch_name")
+    local new_branches=$(insert_string "$PERENNIAL_BRANCH_NAMES" ' ' "$branch_name")
     store_configuration perennial-branch-names "$new_branches"
   fi
 }
@@ -52,7 +52,7 @@ function echo_perennial_branch_usage {
 function ensure_valid_perennial_branches {
   local branches=$1
 
-  split_string "$branches" ',' | while read branch; do
+  split_string "$branches" ' ' | while read branch; do
     if [[ "$branch" == "$MAIN_BRANCH_NAME" ]]; then
       echo_error_header
       echo_error "'$branch' is already set as the main branch"
@@ -99,7 +99,7 @@ function remove_perennial_branch {
     echo_inline_error "'$branch_name' is not a perennial branch"
     exit_with_error
   else
-    local new_branches=$(remove_string "$PERENNIAL_BRANCH_NAMES" ',' "$branch_name")
+    local new_branches=$(remove_string "$PERENNIAL_BRANCH_NAMES" ' ' "$branch_name")
     store_configuration perennial-branch-names "$new_branches"
   fi
 }
@@ -172,7 +172,7 @@ function show_config {
   echo_inline_bold "Perennial branches:"
   if [ -n "$PERENNIAL_BRANCH_NAMES" ]; then
     echo
-    split_string "$PERENNIAL_BRANCH_NAMES" ","
+    split_string "$PERENNIAL_BRANCH_NAMES" " "
   else
     echo ' [none]'
   fi
@@ -190,7 +190,7 @@ function show_main_branch {
 
 function show_perennial_branches {
   if [ -n "$PERENNIAL_BRANCH_NAMES" ]; then
-    split_string "$PERENNIAL_BRANCH_NAMES" ","
+    split_string "$PERENNIAL_BRANCH_NAMES" " "
   fi
 }
 

--- a/src/helpers/configuration_helpers.sh
+++ b/src/helpers/configuration_helpers.sh
@@ -135,7 +135,7 @@ function setup_configuration_main_branch {
 function setup_configuration_perennial_branches {
   echo "Git Town supports perennial branches like 'release' or 'production'."
   echo "These branches cannot be shipped and will not merge '$MAIN_BRANCH_NAME' when syncing."
-  echo "Please enter your perennial branches as a comma separated list or a blank line to skip."
+  echo "Please enter your perennial branches as a space separated list or a blank line to skip."
   echo "Example: 'qa, production'"
   read perennial_input
 

--- a/src/helpers/git_helpers/branch_helpers.sh
+++ b/src/helpers/git_helpers/branch_helpers.sh
@@ -78,7 +78,7 @@ function ensure_has_branch {
 function ensure_has_branches {
   local branches=$1
 
-  split_string "$branches" ',' | while read branch; do
+  split_string "$branches" ' ' | while read branch; do
     ensure_has_branch "$branch"
   done
 }

--- a/src/helpers/git_helpers/feature_branch_helpers.sh
+++ b/src/helpers/git_helpers/feature_branch_helpers.sh
@@ -59,7 +59,7 @@ function is_main_branch {
 function is_perennial_branch {
   local branch_name=$1
 
-  if echo "$PERENNIAL_BRANCH_NAMES" | tr ',' '\n' | grep -q "^ *$branch_name *$"; then
+  if echo "$PERENNIAL_BRANCH_NAMES" | tr ' ' '\n' | grep -q "^ *$branch_name *$"; then
     echo true
   else
     echo false


### PR DESCRIPTION
@kevgo @allewun 

Branch names are allowed to have commas in them. 
This is a breaking change if you have multiple perennial branches. 
I'd suggest just telling people that when they upgrade and have them clear their perennial branches and reset.  