### PR TITLE
(WIP) Sync branch before creating a new pull request

### DIFF
--- a/features/git-new-pull-request/on_outdated_branch.feature
+++ b/features/git-new-pull-request/on_outdated_branch.feature
@@ -1,0 +1,47 @@
+@debug-commands
+Feature: Syncing before creating the pull request
+
+  As a developer
+  I want that GT syncs my feature branch before creating a pull request for it
+  So that my reviewers see the most up-to-date version of my code and their review is accurate.
+
+
+  Background:
+    Given I have a feature branch named "feature"
+    And the following commits exist in my repository
+      | BRANCH  | LOCATION | MESSAGE               | FILE NAME           |
+      | main    | local    | local main commit     | local_main_file     |
+      |         | remote   | remote main commit    | remote_main_file    |
+      | feature | local    | local feature commit  | local_feature_file  |
+      |         | remote   | remote feature commit | remote_feature_file |
+    And I have "open" installed
+    And my remote origin is git@github.com:Originate/git-town.git
+    And I am on the "feature" branch
+    When I run `git new-pull-request`
+
+
+  Scenario: result
+    Then it runs the commands
+      | BRANCH  | COMMAND                            |
+      | feature | git fetch --prune                  |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
+      |         | git push                           |
+      |         | git checkout feature               |
+      | feature | git merge --no-edit origin/feature |
+      |         | git merge --no-edit main           |
+      |         | git push                           |
+    And I see a new GitHub pull request for the "feature" branch in the "<REPOSITORY>" repo in my browser
+    And I am still on the "feature" branch
+    And I still have my uncommitted file
+    And I have the following commits
+      | BRANCH  | LOCATION         | MESSAGE                                                    | FILE NAME           |
+      | main    | local and remote | remote main commit                                         | remote_main_file    |
+      |         |                  | local main commit                                          | local_main_file     |
+      | feature | local and remote | local feature commit                                       | local_feature_file  |
+      |         |                  | remote feature commit                                      | remote_feature_file |
+      |         |                  | Merge remote-tracking branch 'origin/feature' into feature |                     |
+      |         |                  | remote main commit                                         | remote_main_file    |
+      |         |                  | local main commit                                          | local_main_file     |
+      |         |                  | Merge branch 'main' into feature                           |                     |
+

--- a/features/git-new-pull-request/on_outdated_branch.feature
+++ b/features/git-new-pull-request/on_outdated_branch.feature
@@ -1,4 +1,3 @@
-@debug-commands
 Feature: Syncing before creating the pull request
 
   As a developer

--- a/src/git-new-pull-request
+++ b/src/git-new-pull-request
@@ -2,6 +2,31 @@
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/helpers/helpers.sh"
 
 
-activate_driver_family 'code_hosting'
-ensure_knows_parent_branches "$INITIAL_BRANCH_NAME"
-create_pull_request "$(remote_repository_name)" "$INITIAL_BRANCH_NAME" "$(parent_branch "$INITIAL_BRANCH_NAME")"
+# Echoes the names of all branches that should be synced in the current session
+function branches_to_sync {
+  ancestor_branches "$INITIAL_BRANCH_NAME" | tr ' ' '\n'
+  echo "$INITIAL_BRANCH_NAME"
+}
+
+
+function preconditions {
+  activate_driver_family 'code_hosting'
+  if [ "$HAS_REMOTE" = true ]; then
+    fetch
+  fi
+  ensure_knows_parent_branches "$INITIAL_BRANCH_NAME"
+  export RUN_IN_GIT_ROOT=true
+  export STASH_OPEN_CHANGES=true
+}
+
+
+function steps {
+  branches_to_sync | while read branch_name; do
+    sync_branch_steps "$branch_name"
+  done
+  echo "checkout $INITIAL_BRANCH_NAME"
+  echo "create_pull_request $(remote_repository_name) $INITIAL_BRANCH_NAME $(parent_branch "$INITIAL_BRANCH_NAME")"
+}
+
+
+run "$@"

--- a/src/git-new-pull-request
+++ b/src/git-new-pull-request
@@ -24,7 +24,6 @@ function steps {
   branches_to_sync | while read branch_name; do
     sync_branch_steps "$branch_name"
   done
-  echo "checkout $INITIAL_BRANCH_NAME"
   echo "create_pull_request $(remote_repository_name) $INITIAL_BRANCH_NAME $(parent_branch "$INITIAL_BRANCH_NAME")"
 }
 


### PR DESCRIPTION
@charlierudolph @allewun 

This PR makes `git-new-pull-request` sync the current branch before creating the PR.

I think the production code more or less works. I have issues testing it, however, and would appreciate some suggestions. Here is the issue: 
* creating the PR requires that the remote is set to GitHub
* setting the remote to GitHub causes the test to push real branches up to the real GitHub repo
* because that setup is mangled, the command doesn't run properly and errors out

I can't think of a better way to test this right now. What do you think?