### PR TITLE
Defining steps without echo

### DIFF
--- a/src/git-extract
+++ b/src/git-extract
@@ -58,9 +58,9 @@ function preconditions {
 
 function steps {
   sync_branch_steps "$MAIN_BRANCH_NAME"
-  echo "create_and_checkout_feature_branch '$target_branch_name'"
-  echo "cherry_pick '$SHAs'"
-  echo_if_true "create_tracking_branch $target_branch_name" "$HAS_REMOTE"
+  step "create_and_checkout_feature_branch '$target_branch_name'"
+  step "cherry_pick '$SHAs'"
+  step_if_true "create_tracking_branch $target_branch_name" "$HAS_REMOTE"
 }
 
 

--- a/src/git-hack
+++ b/src/git-hack
@@ -40,8 +40,8 @@ function steps {
   done
   sync_branch_steps "$parent_branch_name"
 
-  echo "create_and_checkout_feature_branch $target_branch_name $parent_branch_name"
-  echo_if_true "create_tracking_branch $target_branch_name" "$HAS_REMOTE"
+  step "create_and_checkout_feature_branch $target_branch_name $parent_branch_name"
+  step_if_true "create_tracking_branch $target_branch_name" "$HAS_REMOTE"
 }
 
 

--- a/src/git-kill
+++ b/src/git-kill
@@ -33,22 +33,22 @@ function preconditions {
 function steps {
   if [ "$(has_local_branch "$target_branch")" = true ]; then
     if [ "$target_branch" = "$INITIAL_BRANCH_NAME" ]; then
-      echo_if_true "commit_open_changes" "$INITIAL_OPEN_CHANGES"
-      echo "checkout $parent_branch_name"
+      step_if_true "commit_open_changes" "$INITIAL_OPEN_CHANGES"
+      step "checkout $parent_branch_name"
     fi
 
     if [ "$(has_tracking_branch "$target_branch")" = true ]; then
-      echo "delete_remote_branch $target_branch"
+      step "delete_remote_branch $target_branch"
     fi
 
-    echo "delete_local_branch $target_branch force"
+    step "delete_local_branch $target_branch force"
 
     # update branch hierarchy information
-    echo_update_child_branches "$target_branch" "$parent_branch_name"
-    echo "delete_parent_entry $target_branch"
-    echo "delete_all_ancestor_entries"
+    steps_to_update_child_branches "$target_branch" "$parent_branch_name"
+    step "delete_parent_entry $target_branch"
+    step "delete_all_ancestor_entries"
   else
-    echo "delete_remote_only_branch $target_branch"
+    step "delete_remote_only_branch $target_branch"
   fi
 }
 

--- a/src/git-prune-branches
+++ b/src/git-prune-branches
@@ -26,8 +26,8 @@ function steps {
   local initial_branch_deleted=false
 
   if [ "$INITIAL_BRANCH_NAME" != "$MAIN_BRANCH_NAME" ]; then
-    echo_if_true "stash_open_changes" "$INITIAL_OPEN_CHANGES"
-    echo "checkout_main_branch"
+    step_if_true "stash_open_changes" "$INITIAL_OPEN_CHANGES"
+    step "checkout_main_branch"
   fi
 
   for local_branch_name in $(local_merged_branches); do
@@ -36,29 +36,29 @@ function steps {
         initial_branch_deleted=true
       fi
       if [ "$(has_tracking_branch "$local_branch_name")" = true ]; then
-        echo "delete_remote_branch $local_branch_name"
+        step "delete_remote_branch $local_branch_name"
       fi
-      echo "delete_local_branch $local_branch_name"
+      step "delete_local_branch $local_branch_name"
     fi
-    echo_if_true "delete_parent_entry $local_branch_name" "$(knows_parent_branch "$local_branch_name")"
+    step_if_true "delete_parent_entry $local_branch_name" "$(knows_parent_branch "$local_branch_name")"
   done
 
   for remote_branch_name in $(remote_only_merged_branches); do
     if [ "$(should_delete_branch "$remote_branch_name")" = true ]; then
-      echo "delete_remote_only_branch $remote_branch_name"
-      echo_if_true "delete_parent_entry $remote_branch_name" "$(knows_parent_branch "$remote_branch_name")"
+      step "delete_remote_only_branch $remote_branch_name"
+      step_if_true "delete_parent_entry $remote_branch_name" "$(knows_parent_branch "$remote_branch_name")"
     fi
   done
 
   if [ "$INITIAL_BRANCH_NAME" != "$MAIN_BRANCH_NAME" ] && [ "$initial_branch_deleted" = false ]; then
-    echo "checkout $INITIAL_BRANCH_NAME"
-    echo_if_true "restore_open_changes" "$INITIAL_OPEN_CHANGES"
+    step "checkout $INITIAL_BRANCH_NAME"
+    step_if_true "restore_open_changes" "$INITIAL_OPEN_CHANGES"
   fi
 
   # Remove non-existing branches from the branch hierarchy
   for branch_name in $(all_registered_branches); do
     if [ "$(has_branch "$branch_name")" == "false" ]; then
-      echo "delete_parent_entry $branch_name"
+      step "delete_parent_entry $branch_name"
     fi
   done
 }

--- a/src/git-rename-branch
+++ b/src/git-rename-branch
@@ -66,25 +66,25 @@ function preconditions {
 
 
 function steps {
-  echo "create_and_checkout_branch '$destination_branch_name' '$target_branch_name'"
+  step "create_and_checkout_branch '$destination_branch_name' '$target_branch_name'"
 
   if [ "$(has_tracking_branch "$target_branch_name")" = true ]; then
-    echo "create_tracking_branch $destination_branch_name"
-    echo "delete_remote_branch $target_branch_name"
+    step "create_tracking_branch $destination_branch_name"
+    step "delete_remote_branch $target_branch_name"
   fi
 
   if [ "$(is_perennial_branch "$target_branch_name")" = true ]; then
-    echo "remove_perennial_branch $target_branch_name"
-    echo "add_perennial_branch $destination_branch_name"
+    step "remove_perennial_branch $target_branch_name"
+    step "add_perennial_branch $destination_branch_name"
   fi
 
   # update branch hierarchy information
-  echo_update_child_branches "$target_branch_name" "$destination_branch_name"
-  echo delete_parent_entry "$target_branch_name"
-  echo store_parent_branch "$destination_branch_name" "$parent_branch_name"
-  echo "delete_all_ancestor_entries"
+  steps_to_update_child_branches "$target_branch_name" "$destination_branch_name"
+  step delete_parent_entry "$target_branch_name"
+  step store_parent_branch "$destination_branch_name" "$parent_branch_name"
+  step "delete_all_ancestor_entries"
 
-  echo "delete_local_branch '$target_branch_name' force"
+  step "delete_local_branch '$target_branch_name' force"
 }
 
 

--- a/src/git-ship
+++ b/src/git-ship
@@ -54,33 +54,33 @@ function preconditions {
 
 function steps {
   if [ "$HAS_REMOTE" = true ]; then
-    echo "fetch"
+    step "fetch"
     sync_branch_steps "$MAIN_BRANCH_NAME"
   fi
 
-  echo "checkout $target_branch_name"
-  echo "merge_tracking_branch"
-  echo "merge $MAIN_BRANCH_NAME"
-  echo "ensure_has_shippable_changes"
-  echo "checkout_main_branch"
-  echo "squash_merge $target_branch_name"
-  echo "commit_squash_merge $target_branch_name $commit_options"
+  step "checkout $target_branch_name"
+  step "merge_tracking_branch"
+  step "merge $MAIN_BRANCH_NAME"
+  step "ensure_has_shippable_changes"
+  step "checkout_main_branch"
+  step "squash_merge $target_branch_name"
+  step "commit_squash_merge $target_branch_name $commit_options"
 
-  echo_if_true "push_branch $MAIN_BRANCH_NAME" "$HAS_REMOTE"
+  step_if_true "push_branch $MAIN_BRANCH_NAME" "$HAS_REMOTE"
 
   if [ "$(has_tracking_branch "$target_branch_name")" = true ] &&
      [ "$(has_child_branches "$target_branch_name")" = false ]; then
-    echo "delete_remote_branch $target_branch_name"
+    step "delete_remote_branch $target_branch_name"
   fi
-  echo "delete_local_branch $target_branch_name force"
+  step "delete_local_branch $target_branch_name force"
 
   # update branch hierarchy information
-  echo "delete_parent_entry $target_branch_name"
-  echo_update_child_branches "$target_branch_name" "$MAIN_BRANCH_NAME"
-  echo "delete_all_ancestor_entries"
+  step "delete_parent_entry $target_branch_name"
+  steps_to_update_child_branches "$target_branch_name" "$MAIN_BRANCH_NAME"
+  step "delete_all_ancestor_entries"
 
   if [ "$target_branch_name" != "$INITIAL_BRANCH_NAME" ]; then
-    echo "checkout $INITIAL_BRANCH_NAME"
+    step "checkout $INITIAL_BRANCH_NAME"
   fi
 }
 

--- a/src/git-sync
+++ b/src/git-sync
@@ -63,10 +63,10 @@ function steps {
     sync_branch_steps "$branch_name"
   done
 
-  echo "checkout $INITIAL_BRANCH_NAME"
+  step "checkout $INITIAL_BRANCH_NAME"
 
   if [ "$HAS_REMOTE" = true ] && [ "$should_push_tags" = true ]; then
-    echo "push_tags"
+    step "push_tags"
   fi
 }
 

--- a/src/git-sync-fork
+++ b/src/git-sync-fork
@@ -18,11 +18,11 @@ function preconditions {
 
 
 function steps {
-  echo "checkout_main_branch"
-  echo "fetch_upstream"
-  echo "rebase upstream/$MAIN_BRANCH_NAME"
-  echo "push_branch $MAIN_BRANCH_NAME"
-  echo "checkout $INITIAL_BRANCH_NAME"
+  step "checkout_main_branch"
+  step "fetch_upstream"
+  step "rebase upstream/$MAIN_BRANCH_NAME"
+  step "push_branch $MAIN_BRANCH_NAME"
+  step "checkout $INITIAL_BRANCH_NAME"
 }
 
 

--- a/src/helpers/git_helpers/branch_configuration_helpers.sh
+++ b/src/helpers/git_helpers/branch_configuration_helpers.sh
@@ -110,13 +110,13 @@ function echo_parent_branch_header {
 
 
 # Updates the child branches of the given branch to point to the other given branch
-function echo_update_child_branches {
+function steps_to_update_child_branches {
   local branch=$1
   local new_parent=$2
 
   child_branches "$branch" | while read branch_name; do
-    echo delete_ancestors_entry "$branch_name"
-    echo store_parent_branch "$branch_name" "$new_parent"
+    step "delete_ancestors_entry $branch_name"
+    step "store_parent_branch $branch_name $new_parent"
   done
 }
 

--- a/src/helpers/script_helpers.sh
+++ b/src/helpers/script_helpers.sh
@@ -11,11 +11,11 @@ function abort_command {
 
 
 function command_steps {
-  echo_if_all_true "change_directory $(git_root)" "$RUN_IN_GIT_ROOT" "$IN_SUB_FOLDER"
-  echo_if_all_true "stash_open_changes" "$STASH_OPEN_CHANGES" "$INITIAL_OPEN_CHANGES"
+  step_if_all_true "change_directory $(git_root)" "$RUN_IN_GIT_ROOT" "$IN_SUB_FOLDER"
+  step_if_all_true "stash_open_changes" "$STASH_OPEN_CHANGES" "$INITIAL_OPEN_CHANGES"
   steps
-  echo_if_all_true "restore_open_changes" "$STASH_OPEN_CHANGES" "$INITIAL_OPEN_CHANGES"
-  echo_if_all_true "change_directory $INITIAL_DIRECTORY" "$RUN_IN_GIT_ROOT" "$IN_SUB_FOLDER"
+  step_if_all_true "restore_open_changes" "$STASH_OPEN_CHANGES" "$INITIAL_OPEN_CHANGES"
+  step_if_all_true "change_directory $INITIAL_DIRECTORY" "$RUN_IN_GIT_ROOT" "$IN_SUB_FOLDER"
 }
 
 
@@ -124,7 +124,8 @@ function run {
   else
     remove_step_files
     preconditions "$@"
-    command_steps > "$STEPS_FILE"
+    echo '' > "$STEPS_FILE"
+    command_steps
     run_steps "$STEPS_FILE" undoable
   fi
 }
@@ -188,6 +189,41 @@ function skip_current_branch_steps {
 # This should be overriden in commands when necessary
 function skippable {
   echo false
+}
+
+
+# Adds a step to the current command
+function step {
+  echo "$@" >> "$STEPS_FILE"
+}
+
+
+# Adds the given step if the given condition is true
+function step_if_true {
+  local command="$1"
+  local condition="$2"
+
+  if [ "$condition" = true ]; then
+    step "$command"
+  fi
+}
+
+
+# Adds the given step if all the given conditions are true
+function step_if_all_true {
+  local command="$1"
+  shift
+
+  local runStep=true
+  for condition in "$@"; do
+    if [ "$condition" != true ]; then
+      runStep=false
+    fi
+  done
+
+  if [ "$runStep" = true ]; then
+    step "$command"
+  fi
 }
 
 

--- a/src/helpers/script_helpers.sh
+++ b/src/helpers/script_helpers.sh
@@ -213,14 +213,14 @@ function step_if_all_true {
   local command="$1"
   shift
 
-  local runStep=true
+  local allTrue=true
   for condition in "$@"; do
     if [ "$condition" != true ]; then
-      runStep=false
+      allTrue=false
     fi
   done
 
-  if [ "$runStep" = true ]; then
+  if [ "$allTrue" = true ]; then
     step "$command"
   fi
 }

--- a/src/helpers/script_helpers.sh
+++ b/src/helpers/script_helpers.sh
@@ -124,7 +124,6 @@ function run {
   else
     remove_step_files
     preconditions "$@"
-    echo '' > "$STEPS_FILE"
     command_steps
     run_steps "$STEPS_FILE" undoable
   fi

--- a/src/helpers/sync_helpers.sh
+++ b/src/helpers/sync_helpers.sh
@@ -12,20 +12,20 @@ function sync_branch_steps {
   # there may be changes to perennial branches, otherwise only sync feature
   # branches because perennial branches will not need syncing
   if [ "$HAS_REMOTE" = true ] || [ "$is_feature" = true ]; then
-    echo "checkout $branch"
+    step "checkout $branch"
 
     if [ "$is_feature" = true ]; then
-      echo "merge_tracking_branch"
-      echo "merge $(parent_branch "$branch")"
+      step "merge_tracking_branch"
+      step "merge $(parent_branch "$branch")"
     else
-      echo "rebase_tracking_branch"
+      step "rebase_tracking_branch"
     fi
 
     if [ "$HAS_REMOTE" = true ]; then
       if [ "$(has_tracking_branch "$branch")" == true ]; then
-        echo "push_branch $branch"
+        step "push_branch $branch"
       else
-        echo "create_tracking_branch $branch"
+        step "create_tracking_branch $branch"
       fi
     fi
   fi

--- a/src/helpers/terminal_helpers.sh
+++ b/src/helpers/terminal_helpers.sh
@@ -26,35 +26,6 @@ function echo_error {
 }
 
 
-# Prints the first argument if all following arguments are true
-function echo_if_all_true {
-  local string="$1"
-  shift
-
-  local shouldEcho=true
-  for condition in "$@"; do
-    if [ "$condition" != true ]; then
-      shouldEcho=false
-    fi
-  done
-
-  if [ "$shouldEcho" = true ]; then
-    echo "$string"
-  fi
-}
-
-
-# Prints the string if the condition is true
-function echo_if_true {
-  local string="$1"
-  local condition="$2"
-
-  if [ "$condition" = true ]; then
-    echo "$string"
-  fi
-}
-
-
 # Prints the message indented
 function echo_indented {
   echo "$@" | indent


### PR DESCRIPTION
@charlierudolph @allewun @ricmatsui 

We run more and more into the situation where commands have to interact with the user in some form to determine the correct set of steps. An example is #663.

The current architecture uses `echo` to gather all the commands to be run by a GT command. Echo is overused in Bash, and using it for data flow here prevents us from using it to print information to the user during the step determination workflow. In the end, all we do with these steps is to write them to a file.

This PR refactors the steps infrastructure. It adds a dedicated `step` command, which appends the given command to $STEPS_FILE directly. This enables us to use the `echo` command in the step determination workflows down the line. It also makes step definitions blocks in the various GT commands more readable. 