### PR TITLE
Show branch ancestry

### DIFF
--- a/src/helpers/configuration_helpers.sh
+++ b/src/helpers/configuration_helpers.sh
@@ -132,6 +132,8 @@ function show_branch_ancestry {
     echo_inline_bold "Branch ancestry: "
     echo
     ( cd "$tempdir" || exit; tree -d -n --noreport . )
+
+    rm -rf "$tempdir"
   fi
 }
 

--- a/src/helpers/configuration_helpers.sh
+++ b/src/helpers/configuration_helpers.sh
@@ -120,18 +120,18 @@ function run_config_operation {
 
 
 function show_branch_ancestry {
-  if [ $(has_tool 'tree') = true ]; then
+  if [ "$(has_tool 'tree')" = true ]; then
     ensure_knows_parent_branches "$(all_registered_branches)"
 
     local tempdir="$(mktemp -d)"
     for branch_name in $(all_registered_branches); do
-      ancestry_path=$(ancestor_branches $branch_name | tr ' ' '/')
-      mkdir -p "$tempdir/$ancestry_path"
+      ancestry_path=$(ancestor_branches "$branch_name" | tr ' ' '/')
+      mkdir -p "$tempdir/$ancestry_path/$branch_name"
     done
 
     echo_inline_bold "Branch ancestry: "
     echo
-    (cd $tempdir; tree -d -n --noreport .)
+    ( cd "$tempdir"; tree -d -n --noreport . )
   fi
 }
 

--- a/src/helpers/configuration_helpers.sh
+++ b/src/helpers/configuration_helpers.sh
@@ -131,7 +131,7 @@ function show_branch_ancestry {
 
     echo_inline_bold "Branch ancestry: "
     echo
-    ( cd "$tempdir"; tree -d -n --noreport . )
+    ( cd "$tempdir" || exit; tree -d -n --noreport . )
   fi
 }
 

--- a/src/helpers/configuration_helpers.sh
+++ b/src/helpers/configuration_helpers.sh
@@ -119,6 +119,23 @@ function run_config_operation {
 }
 
 
+function show_branch_ancestry {
+  if [ $(has_tool 'tree') = true ]; then
+    ensure_knows_parent_branches "$(all_registered_branches)"
+
+    local tempdir="$(mktemp -d)"
+    for branch_name in $(all_registered_branches); do
+      ancestry_path=$(ancestor_branches $branch_name | tr ' ' '/')
+      mkdir -p "$tempdir/$ancestry_path"
+    done
+
+    echo_inline_bold "Branch ancestry: "
+    echo
+    (cd $tempdir; tree -d -n --noreport .)
+  fi
+}
+
+
 function show_config {
   echo_inline_bold "Main branch: "
   show_main_branch
@@ -129,6 +146,8 @@ function show_config {
   else
     echo ' [none]'
   fi
+
+  show_branch_ancestry
 }
 
 


### PR DESCRIPTION
@kevgo @charlierudolph 
Implements #651.

Works well, but relies on `tree`. Don't yet have a good solution for when `tree` isn't installed.

![screen shot 2015-10-01 at 2 46 48 am](https://cloud.githubusercontent.com/assets/1256911/10217782/e0195d1e-67e6-11e5-9723-ddcac91e8e52.png)

