### PR TITLE
added tests

### DIFF
--- a/features/git-town/configuration/already_set.feature
+++ b/features/git-town/configuration/already_set.feature
@@ -1,8 +1,8 @@
 Feature: listing the configuration
 
-  As a user configuring Git Town,
+  As a user running the Git Town configuration wizard,
   I want to see the existing configuration values
-  and be able to change them.
+  So that I can change it more effectively
 
 
   Background:
@@ -12,17 +12,17 @@ Feature: listing the configuration
   Scenario: everything is configured
     Given I have configured the main branch name as "main"
     And my perennial branches are configured as "qa"
-  	When I run `git town config --setup`
-      Then I see
-        """
-        Git Town needs to be configured
-        
-          1: main
-          2: production
-          3: qa
-        
-        Please specify the main development branch by name or number (current value: main): Please specify a perennial branch by name or number. Leave it blank to finish (current value: qa):
-        """
+    When I run `git town config --setup`
+    Then I see
+      """
+      Git Town needs to be configured
+      
+        1: main
+        2: production
+        3: qa
+      
+      Please specify the main development branch by name or number (current value: main): Please specify a perennial branch by name or number. Leave it blank to finish (current value: qa):
+      """
 
 
   Scenario: empty input
@@ -31,4 +31,12 @@ Feature: listing the configuration
     When I run `git town config --setup` and enter "" and ""
     And my repo is configured with the main branch as "main"
     And my repo is configured with no perennial branches
+
+
+  Scenario: non-empty input
+    Given I have configured the main branch name as "main"
+    And my perennial branches are configured as "qa"
+    When I run `git town config --setup` and enter "main", "production" and ""
+    And my repo is configured with the main branch as "main"
+    And my repo is configured with perennial branches as "production"
 

--- a/features/git-town/configuration/already_set.feature
+++ b/features/git-town/configuration/already_set.feature
@@ -1,0 +1,34 @@
+Feature: listing the configuration
+
+  As a user configuring Git Town,
+  I want to see the existing configuration values
+  and be able to change them.
+
+
+  Background:
+    Given I have branches named "production" and "qa"
+
+
+  Scenario: everything is configured
+    Given I have configured the main branch name as "main"
+    And my perennial branches are configured as "qa"
+  	When I run `git town config --setup`
+      Then I see
+        """
+        Git Town needs to be configured
+        
+          1: main
+          2: production
+          3: qa
+        
+        Please specify the main development branch by name or number (current value: main): Please specify a perennial branch by name or number. Leave it blank to finish (current value: qa):
+        """
+
+
+  Scenario: empty input
+    Given I have configured the main branch name as "main"
+    And my perennial branches are configured as "qa"
+    When I run `git town config --setup` and enter "" and ""
+    And my repo is configured with the main branch as "main"
+    And my repo is configured with no perennial branches
+

--- a/src/helpers/configuration.sh
+++ b/src/helpers/configuration.sh
@@ -26,4 +26,6 @@ if [[ "$@" =~ --bypass-automatic-configuration ]]; then
   return 0
 fi
 
-ensure_knows_configuration
+if [ "$(are_perennial_branches_configured)" = false ] && [ "$(is_main_branch_configured)" = false ]; then
+  ensure_knows_configuration
+fi

--- a/src/helpers/configuration_prompt_helpers.sh
+++ b/src/helpers/configuration_prompt_helpers.sh
@@ -16,78 +16,80 @@ function ensure_knows_configuration {
   local numerical_regex='^[0-9]+$'
   local user_input
 
-  if [ "$(is_main_branch_configured)" = false ]; then
-    if [ "$header_shown" = false ]; then
-      echo_configuration_header
-      header_shown=true
+  if [ "$header_shown" = false ]; then
+    echo_configuration_header
+    header_shown=true
+  fi
+
+  local main_branch_input
+
+  while [ -z "$main_branch_input" ]; do
+    if [ "$(is_main_branch_configured)" = true ]; then
+      echo -n "Please specify the main development branch by name or number (current value: ${MAIN_BRANCH_NAME}): "
+    else
+      echo -n "Please specify the main development branch by name or number (current value: None): "
     fi
 
-    local main_branch_input
-
-    while [ -z "$main_branch_input" ]; do
-      echo -n "Please specify the main development branch by name or number: "
-      read user_input
-      if [[ $user_input =~ $numerical_regex ]] ; then
-        main_branch_input="$(get_numbered_branch "$user_input")"
-        if [ -z "$main_branch_input" ]; then
-          echo_error_header
-          echo_error "invalid branch number"
-        fi
-      elif [ -z "$user_input" ]; then
+    read user_input
+    if [[ $user_input =~ $numerical_regex ]] ; then
+      main_branch_input="$(get_numbered_branch "$user_input")"
+      if [ -z "$main_branch_input" ]; then
+        echo_error_header
+        echo_error "invalid branch number"
+      fi
+    elif [ -z "$user_input" ]; then
+      if [ "$(is_main_branch_configured)" = true ]; then
+        main_branch_input=$MAIN_BRANCH_NAME
+      else
         echo_error_header
         echo_error "no input received"
-      else
-        if [ "$(has_branch "$user_input")" == true ]; then
-          main_branch_input=$user_input
-        else
-          echo_error_header
-          echo_error "branch '$user_input' doesn't exist"
-        fi
       fi
-    done
+    else
+      if [ "$(has_branch "$user_input")" == true ]; then
+        main_branch_input=$user_input
+      else
+        echo_error_header
+        echo_error "branch '$user_input' doesn't exist"
+      fi
+    fi
+  done
 
-    store_configuration main-branch-name "$main_branch_input"
-  fi
+  store_configuration main-branch-name "$main_branch_input"
 
-  if [ "$(are_perennial_branches_configured)" = false ]; then
-    if [ "$header_shown" = false ]; then
-      echo_configuration_header
-      header_shown=true
+
+  local perennial_branches_input=''
+
+  while true; do
+    echo -n "Please specify a perennial branch by name or number. Leave it blank to finish (current value: ${PERENNIAL_BRANCH_NAMES}): "      
+
+    read user_input
+    local branch
+    if [[ $user_input =~ $numerical_regex ]] ; then
+      branch="$(get_numbered_branch "$user_input")"
+      if [ -z "$branch" ]; then
+        echo_error_header
+        echo_error "invalid branch number"
+      fi
+    elif [ -z "$user_input" ]; then
+      break
+    else
+      if [ "$(has_branch "$user_input")" == true ]; then
+        if [ "$user_input" == "$MAIN_BRANCH_NAME" ]; then
+          echo_error_header
+          echo_error "'$user_input' is already set as the main branch"
+        else
+          branch=$user_input
+        fi
+      else
+        echo_error_header
+        echo_error "branch '$user_input' doesn't exist"
+      fi
     fi
 
-    local perennial_branches_input=''
+    if [ -n "$branch" ]; then
+      perennial_branches_input="$(insert_string "$perennial_branches_input" ' ' "$branch")"
+    fi
+  done
 
-    while true; do
-      echo -n "Please specify a perennial branch by name or number (blank line to finish): "
-      read user_input
-      local branch
-      if [[ $user_input =~ $numerical_regex ]] ; then
-        branch="$(get_numbered_branch "$user_input")"
-        if [ -z "$branch" ]; then
-          echo_error_header
-          echo_error "invalid branch number"
-        fi
-      elif [ -z "$user_input" ]; then
-        break
-      else
-        if [ "$(has_branch "$user_input")" == true ]; then
-          if [ "$user_input" == "$MAIN_BRANCH_NAME" ]; then
-            echo_error_header
-            echo_error "'$user_input' is already set as the main branch"
-          else
-            branch=$user_input
-          fi
-        else
-          echo_error_header
-          echo_error "branch '$user_input' doesn't exist"
-        fi
-      fi
-
-      if [ -n "$branch" ]; then
-        perennial_branches_input="$(insert_string "$perennial_branches_input" ' ' "$branch")"
-      fi
-    done
-
-    store_configuration perennial-branch-names "$perennial_branches_input"
-  fi
+  store_configuration perennial-branch-names "$perennial_branches_input"
 }


### PR DESCRIPTION
git town config --setup will now still prompt you to enter in values for configuration parameters if values are already set. For main-branch-name it'll show you the current value (if there is one) and if you press enter it'll just use the current value. For perennial-branch-name, it'll show you the current value (if there is one) and if you press enter, it'll change it to be none. 