### PR TITLE
Fixed #678.

### DIFF
--- a/src/helpers/undo_helpers.sh
+++ b/src/helpers/undo_helpers.sh
@@ -31,7 +31,7 @@ function _undo_steps {
   local step="${step_with_arguments[0]}"
   local arguments="${step_with_arguments[*]:1}"
   local fn="$step_name$step"
-  if [ "$(type "$fn" 2>&1 | grep -c 'not found')" = 0 ]; then
+  if type "${fn}" > /dev/null 2>&1; then
     eval "$fn $arguments"
   fi
 }


### PR DESCRIPTION
The `grep` command looks for a 'not found' string but in
a non English system the `if` command fails.

Reference: <http://stackoverflow.com/a/677212/1152679>