### PR TITLE
Create consistent branch order on configuration

### DIFF
--- a/features/git-town/configuration/setup.feature
+++ b/features/git-town/configuration/setup.feature
@@ -6,20 +6,20 @@ Feature: Initial configuration
 
 
   Background:
-    Given I have branches named "production" and "qa"
+    Given I have branches named "production" and "dev"
     And I haven't configured Git Town yet
 
 
   Scenario: succeeds on valid main branch and perennial branch names
-    When I run `git town config --setup` and enter "main", "production", "qa" and ""
+    When I run `git town config --setup` and enter "main", "production", "dev" and ""
     Then my repo is configured with the main branch as "main"
-    And my repo is configured with perennial branches as "production" and "qa"
+    And my repo is configured with perennial branches as "production" and "dev"
 
 
   Scenario: succeeds on valid main branch and perennial branch numbers
-    When I run `git town config --setup` and enter "1", "2", "3" and ""
+    When I run `git town config --setup` and enter "2", "1", "3" and ""
     Then my repo is configured with the main branch as "main"
-    And my repo is configured with perennial branches as "production" and "qa"
+    And my repo is configured with perennial branches as "production" and "dev"
 
 
   Scenario: shows error and re-prompts on empty main branch
@@ -44,21 +44,21 @@ Feature: Initial configuration
 
 
   Scenario: shows error and re-prompts on main branch as perennial branch
-    When I run `git town config --setup` and enter "main", "main", "qa" and ""
+    When I run `git town config --setup` and enter "main", "main", "dev" and ""
     Then I see "'main' is already set as the main branch"
     And my repo is configured with the main branch as "main"
-    And my repo is configured with perennial branches as "qa"
+    And my repo is configured with perennial branches as "dev"
 
 
   Scenario: shows error and re-prompts on invalid perennial branch number
     When I run `git town config --setup` and enter "main", "4", "3" and ""
     Then I see "invalid branch number"
     And my repo is configured with the main branch as "main"
-    And my repo is configured with perennial branches as "qa"
+    And my repo is configured with perennial branches as "production"
 
 
   Scenario: shows error and re-prompts on non-existent perennial branch
-    When I run `git town config --setup` and enter "main", "non-existent", "qa", and ""
+    When I run `git town config --setup` and enter "main", "non-existent", "dev", and ""
     Then I see "branch 'non-existent' doesn't exist"
     And my repo is configured with the main branch as "main"
-    And my repo is configured with perennial branches as "qa"
+    And my repo is configured with perennial branches as "dev"

--- a/src/helpers/configuration_prompt_helpers.sh
+++ b/src/helpers/configuration_prompt_helpers.sh
@@ -5,7 +5,7 @@
 function echo_configuration_header {
   echo "Git Town needs to be configured"
   echo
-  echo_numbered_branches
+  echo_numbered_branches_alpha_order
   echo
 }
 
@@ -32,7 +32,7 @@ function ensure_knows_configuration {
 
     read user_input
     if [[ $user_input =~ $numerical_regex ]] ; then
-      main_branch_input="$(get_numbered_branch "$user_input")"
+      main_branch_input="$(get_numbered_branch_alpha_order "$user_input")"
       if [ -z "$main_branch_input" ]; then
         echo_error_header
         echo_error "invalid branch number"
@@ -60,12 +60,12 @@ function ensure_knows_configuration {
   local perennial_branches_input=''
 
   while true; do
-    echo -n "Please specify a perennial branch by name or number. Leave it blank to finish (current value: ${PERENNIAL_BRANCH_NAMES}): "      
+    echo -n "Please specify a perennial branch by name or number. Leave it blank to finish (current value: ${PERENNIAL_BRANCH_NAMES}): "
 
     read user_input
     local branch
     if [[ $user_input =~ $numerical_regex ]] ; then
-      branch="$(get_numbered_branch "$user_input")"
+      branch="$(get_numbered_branch_alpha_order "$user_input")"
       if [ -z "$branch" ]; then
         echo_error_header
         echo_error "invalid branch number"

--- a/src/helpers/git_helpers/branch_configuration_helpers.sh
+++ b/src/helpers/git_helpers/branch_configuration_helpers.sh
@@ -80,7 +80,7 @@ function delete_ancestors_entry {
 }
 
 
-# Prints branches prefixed by a number and a colon
+# Prints branches prefixed by a number and a colon with the main branch first
 function echo_numbered_branches {
   local branches="$(local_branches_with_main_first | tr '\n' ' ')"
   local branch
@@ -93,6 +93,22 @@ function echo_numbered_branches {
     number=$(( number + 1 ))
   done
 }
+
+# Prints branches prefixed by a number and a colon with the order given alphabetically
+function echo_numbered_branches_alpha_order {
+  local branches="$(local_branches | tr '\n' ' ')"
+  local branch
+  local number=1
+  for branch in $branches; do
+    output_style_bold
+    printf "%3s: " "$number"
+    output_style_reset
+    echo "$branch"
+    number=$(( number + 1 ))
+  done
+}
+
+
 
 
 # Prints the header for the prompt when asking for parent branches
@@ -185,11 +201,18 @@ function ensure_knows_parent_branches {
 
 
 # Returns the branch name for the number shown in print_numbered_branches
+# when printed with the main branch first
 function get_numbered_branch {
   local number=$1
   local_branches_with_main_first | sed -n "${number}p"
 }
 
+# Returns the branch name for the number shown in print_numbered_branches
+# when printed in alpha order
+function get_numbered_branch_alpha_order {
+  local number=$1
+  local_branches | sed -n "${number}p"
+}
 
 # Returns whether the given branch has child branches
 function has_child_branches {


### PR DESCRIPTION
When I configure for the first time on a repo, there is non-determinism in how I select perennial branches. 
For example, consider I have a repo with a `master` branch and a perennial `dev` branch.
When I configure for the first time, the flow goes like this:

```
Git Town needs to be configured

  1: dev
  2: master

Please specify the main development branch by name or number (current value: None): 2
Please specify a perennial branch by name or number. Leave it blank to finish (current value: ): 1
Please specify a perennial branch by name or number. Leave it blank to finish (current value: ): 

[dev] git fetch --prune

Feature branches can be branched directly off 
master or from other feature branches.

The former allows to develop and ship features completely independent of each other.
The latter allows to build on top of currently unshipped features.

  1: master
  2: dev

Please specify the parent branch of dev by name or number (default: master): 1


[dev] git checkout master
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.

[master] git rebase origin/master
Current branch master is up to date.

[master] git checkout dev
Switched to branch 'dev'
Your branch is up-to-date with 'origin/dev'.

[dev] git merge --no-edit origin/dev
Already up-to-date.

[dev] git merge --no-edit master
Already up-to-date.
```
Then, checking the `.git/config` file we see that master was set to the main and perennial branch.
This is because in the configure flow, the `get_numbered_branch` selects numbers according to main branch first. The first time we print out the branches, there is no main branch so the branches are echoed  in alphabetical order. However, when we select a perennial branch, a main branch has been selected so the order that `get_numbered_branch` sees is different than what was echoed to the screen. I resolve this by creating a consistent alphabetical order in the configure step. 
This may also fix the issues encountered #726 although I'm not certain without more testing on my end.