### PR TITLE
Display cop names

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 AllCops:
   TargetRubyVersion: 2.2
 
+  DisplayCopNames: true
+
+  DisplayStyleGuide: true
+
 
 Metrics/AbcSize:
   Max: 19


### PR DESCRIPTION
@charlierudolph @allewun 

Displays the name of cops that fail the Rubocop test suite. This makes it easier to google those issues, or configure them.