### PR TITLE
Avoid stash -u

### DIFF
--- a/features/git-town-hack/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-hack/main_branch_rebase_tracking_branch_conflict.feature
@@ -20,7 +20,8 @@ Feature: git town-hack: resolving conflicts between main branch and its tracking
     Then it runs the commands
       | BRANCH           | COMMAND                |
       | existing-feature | git fetch --prune      |
-      |                  | git stash -u           |
+      |                  | git add -A             |
+      |                  | git stash              |
       |                  | git checkout main      |
       | main             | git rebase origin/main |
     And I get the error

--- a/features/git-town-hack/nested_branches/current_branch_as_parent.feature
+++ b/features/git-town-hack/nested_branches/current_branch_as_parent.feature
@@ -19,7 +19,8 @@ Feature: Creating nested feature branches
     Then it runs the commands
       | BRANCH         | COMMAND                                      |
       | parent-feature | git fetch --prune                            |
-      |                | git stash -u                                 |
+      |                | git add -A                                   |
+      |                | git stash                                    |
       |                | git checkout main                            |
       | main           | git rebase origin/main                       |
       |                | git checkout parent-feature                  |
@@ -45,7 +46,8 @@ Feature: Creating nested feature branches
     When I run `git town-hack --undo`
     Then it runs the commands
       | BRANCH         | COMMAND                        |
-      | child-feature  | git stash -u                   |
+      | child-feature  | git add -A                     |
+      |                | git stash                      |
       |                | git push origin :child-feature |
       |                | git checkout parent-feature    |
       | parent-feature | git branch -d child-feature    |
@@ -65,7 +67,8 @@ Feature: Creating nested feature branches
     Then it runs the commands
       | BRANCH         | COMMAND                                      |
       | parent-feature | git fetch --prune                            |
-      |                | git stash -u                                 |
+      |                | git add -A                                   |
+      |                | git stash                                    |
       |                | git checkout main                            |
       | main           | git rebase origin/main                       |
       |                | git checkout parent-feature                  |
@@ -91,7 +94,8 @@ Feature: Creating nested feature branches
     When I run `git town-hack --undo`
     Then it runs the commands
       | BRANCH         | COMMAND                        |
-      | child-feature  | git stash -u                   |
+      | child-feature  | git add -A                     |
+      |                | git stash                      |
       |                | git push origin :child-feature |
       |                | git checkout parent-feature    |
       | parent-feature | git branch -d child-feature    |

--- a/features/git-town-hack/nested_branches/remote_branch_as_parent.feature
+++ b/features/git-town-hack/nested_branches/remote_branch_as_parent.feature
@@ -21,7 +21,8 @@ Feature: Forking off a remote branch
     Then it runs the commands
       | BRANCH         | COMMAND                                      |
       | main           | git fetch --prune                            |
-      |                | git stash -u                                 |
+      |                | git add -A                                   |
+      |                | git stash                                    |
       |                | git rebase origin/main                       |
       |                | git checkout parent-feature                  |
       | parent-feature | git merge --no-edit origin/parent-feature    |
@@ -52,7 +53,8 @@ Feature: Forking off a remote branch
     When I run `git town-hack --undo`
     Then it runs the commands
       | BRANCH         | COMMAND                        |
-      | child-feature  | git stash -u                   |
+      | child-feature  | git add -A                     |
+      |                | git stash                      |
       |                | git push origin :child-feature |
       |                | git checkout parent-feature    |
       | parent-feature | git branch -d child-feature    |

--- a/features/git-town-hack/on_feature_branch/in_committed_subfolder.feature
+++ b/features/git-town-hack/on_feature_branch/in_committed_subfolder.feature
@@ -21,7 +21,8 @@ Feature: git town-hack: starting a new feature from a new subfolder on the main 
       | BRANCH      | COMMAND                          |
       | feature     | git fetch --prune                |
       | <none>      | cd <%= git_root_folder %>        |
-      | feature     | git stash -u                     |
+      | feature     | git add -A                       |
+      |             | git stash                        |
       |             | git checkout main                |
       | main        | git rebase origin/main           |
       |             | git checkout -b new-feature main |

--- a/features/git-town-hack/on_feature_branch/in_uncommitted_subfolder.feature
+++ b/features/git-town-hack/on_feature_branch/in_uncommitted_subfolder.feature
@@ -20,7 +20,8 @@ Feature: git town-hack: starting a new feature from a new subfolder on the main 
       | BRANCH      | COMMAND                              |
       | feature     | git fetch --prune                    |
       | <none>      | cd <%= git_root_folder %>            |
-      | feature     | git stash -u                         |
+      | feature     | git add -A                           |
+      |             | git stash                            |
       |             | git checkout main                    |
       | main        | git rebase origin/main               |
       |             | git checkout -b new-feature main     |

--- a/features/git-town-hack/on_feature_branch/with_remote_origin.feature
+++ b/features/git-town-hack/on_feature_branch/with_remote_origin.feature
@@ -20,7 +20,8 @@ Feature: git town-hack: starting a new feature from a feature branch (with remot
     Then it runs the commands
       | BRANCH           | COMMAND                          |
       | existing-feature | git fetch --prune                |
-      |                  | git stash -u                     |
+      |                  | git add -A                       |
+      |                  | git stash                        |
       |                  | git checkout main                |
       | main             | git rebase origin/main           |
       |                  | git checkout -b new-feature main |

--- a/features/git-town-hack/on_feature_branch/without_remote_origin.feature
+++ b/features/git-town-hack/on_feature_branch/without_remote_origin.feature
@@ -20,7 +20,8 @@ Feature: git town-hack: starting a new feature from a feature branch (without re
   Scenario: result
     Then it runs the commands
       | BRANCH           | COMMAND                          |
-      | existing-feature | git stash -u                     |
+      | existing-feature | git add -A                       |
+      |                  | git stash                        |
       |                  | git checkout -b new-feature main |
       | new-feature      | git stash pop                    |
     And I end up on the "new-feature" branch

--- a/features/git-town-hack/on_main_branch/in_subfolder.feature
+++ b/features/git-town-hack/on_main_branch/in_subfolder.feature
@@ -19,7 +19,8 @@ Feature: git town-hack: starting a new feature from a subfolder on the main bran
       | BRANCH      | COMMAND                           |
       | main        | git fetch --prune                 |
       | <none>      | cd <%= git_root_folder %>         |
-      | main        | git stash -u                      |
+      | main        | git add -A                        |
+      |             | git stash                         |
       |             | git rebase origin/main            |
       |             | git push                          |
       |             | git checkout -b new-feature main  |

--- a/features/git-town-hack/on_main_branch/with_remote_origin.feature
+++ b/features/git-town-hack/on_main_branch/with_remote_origin.feature
@@ -18,7 +18,8 @@ Feature: git town-hack: starting a new feature from the main branch (with remote
     Then it runs the commands
       | BRANCH      | COMMAND                          |
       | main        | git fetch --prune                |
-      |             | git stash -u                     |
+      |             | git add -A                       |
+      |             | git stash                        |
       |             | git rebase origin/main           |
       |             | git checkout -b new-feature main |
       | new-feature | git push -u origin new-feature   |

--- a/features/git-town-hack/on_main_branch/with_upstream.feature
+++ b/features/git-town-hack/on_main_branch/with_upstream.feature
@@ -14,7 +14,8 @@ Feature: git-hack: on the main branch with a upstream remote
     Then it runs the commands
       | BRANCH      | COMMAND                          |
       | main        | git fetch --prune                |
-      |             | git stash -u                     |
+      |             | git add -A                       |
+      |             | git stash                        |
       |             | git rebase origin/main           |
       |             | git fetch upstream               |
       |             | git rebase upstream/main         |

--- a/features/git-town-hack/on_main_branch/without_remote_origin.feature
+++ b/features/git-town-hack/on_main_branch/without_remote_origin.feature
@@ -18,7 +18,8 @@ Feature: git town-hack: starting a new feature from the main branch (without rem
   Scenario: result
     Then it runs the commands
       | BRANCH      | COMMAND                          |
-      | main        | git stash -u                     |
+      | main        | git add -A                       |
+      |             | git stash                        |
       |             | git checkout -b new-feature main |
       | new-feature | git stash pop                    |
     And I end up on the "new-feature" branch

--- a/features/git-town-new-pull-request/conflict.feature
+++ b/features/git-town-new-pull-request/conflict.feature
@@ -23,7 +23,8 @@ Feature: Syncing before creating the pull request
     Then it runs the commands
       | BRANCH  | COMMAND                            |
       | feature | git fetch --prune                  |
-      |         | git stash -u                       |
+      |         | git add -A                         |
+      |         | git stash                          |
       |         | git checkout main                  |
       | main    | git rebase origin/main             |
       |         | git checkout feature               |

--- a/features/git-town-new-pull-request/on_outdated_branch.feature
+++ b/features/git-town-new-pull-request/on_outdated_branch.feature
@@ -27,7 +27,8 @@ Feature: Syncing before creating the pull request
     Then it runs the commands
       | BRANCH         | COMMAND                                   |
       | child-feature  | git fetch --prune                         |
-      |                | git stash -u                              |
+      |                | git add -A                                |
+      |                | git stash                                 |
       |                | git checkout main                         |
       | main           | git rebase origin/main                    |
       |                | git push                                  |

--- a/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/in_sync.feature
+++ b/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/in_sync.feature
@@ -28,7 +28,8 @@ Feature: git town-rename-branch: renaming a perennial branch with a tracking bra
     Then it runs the commands
       | BRANCH             | COMMAND                                       |
       | production         | git fetch --prune                             |
-      |                    | git stash -u                                  |
+      |                    | git add -A                                    |
+      |                    | git stash                                     |
       |                    | git checkout -b renamed-production production |
       | renamed-production | git push -u origin renamed-production         |
       |                    | git push origin :production                   |
@@ -49,7 +50,8 @@ Feature: git town-rename-branch: renaming a perennial branch with a tracking bra
     When I run `git town-rename-branch --undo`
     Then it runs the commands
         | BRANCH             | COMMAND                                              |
-        | renamed-production | git stash -u                                         |
+        | renamed-production | git add -A                                           |
+        |                    | git stash                                            |
         |                    | git branch production <%= sha 'production commit' %> |
         |                    | git push -u origin production                        |
         |                    | git push origin :renamed-production                  |

--- a/features/git-town-ship/supplied_branch/feature_branch/empty_commit_message.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/empty_commit_message.feature
@@ -18,7 +18,8 @@ Feature: git town-ship: aborting the ship of the supplied feature branch by ente
     Then it runs the commands
       | BRANCH        | COMMAND                                      |
       | other-feature | git fetch --prune                            |
-      |               | git stash -u                                 |
+      |               | git add -A                                   |
+      |               | git stash                                    |
       |               | git checkout main                            |
       | main          | git rebase origin/main                       |
       |               | git checkout feature                         |

--- a/features/git-town-ship/supplied_branch/feature_branch/feature_branch_merge_main_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/feature_branch_merge_main_branch_conflict.feature
@@ -18,7 +18,8 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
     Then it runs the commands
       | BRANCH        | COMMAND                            |
       | other-feature | git fetch --prune                  |
-      |               | git stash -u                       |
+      |               | git add -A                         |
+      |               | git stash                          |
       |               | git checkout main                  |
       | main          | git rebase origin/main             |
       |               | git push                           |

--- a/features/git-town-ship/supplied_branch/feature_branch/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/feature_branch_merge_tracking_branch_conflict.feature
@@ -18,7 +18,8 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
     Then it runs the commands
       | BRANCH        | COMMAND                            |
       | other-feature | git fetch --prune                  |
-      |               | git stash -u                       |
+      |               | git add -A                         |
+      |               | git stash                          |
       |               | git checkout main                  |
       | main          | git rebase origin/main             |
       |               | git checkout feature               |

--- a/features/git-town-ship/supplied_branch/feature_branch/in_subfolder.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/in_subfolder.feature
@@ -18,7 +18,8 @@ Feature: git town-ship: shipping the supplied feature branch from a subfolder
       | BRANCH        | COMMAND                            |
       | other-feature | git fetch --prune                  |
       | <none>        | cd <%= git_root_folder %>          |
-      | other-feature | git stash -u                       |
+      | other-feature | git add -A                         |
+      |               | git stash                          |
       |               | git checkout main                  |
       | main          | git rebase origin/main             |
       |               | git checkout feature               |

--- a/features/git-town-ship/supplied_branch/feature_branch/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/main_branch_rebase_tracking_branch_conflict.feature
@@ -19,7 +19,8 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
     Then it runs the commands
       | BRANCH        | COMMAND                |
       | other-feature | git fetch --prune      |
-      |               | git stash -u           |
+      |               | git add -A             |
+      |               | git stash              |
       |               | git checkout main      |
       | main          | git rebase origin/main |
     And I get the error

--- a/features/git-town-ship/supplied_branch/feature_branch/no_diff.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/no_diff.feature
@@ -18,7 +18,8 @@ Feature: git town-ship: errors when trying to ship the supplied feature branch t
     Then it runs the commands
       | BRANCH        | COMMAND                                      |
       | other-feature | git fetch --prune                            |
-      |               | git stash -u                                 |
+      |               | git add -A                                   |
+      |               | git stash                                    |
       |               | git checkout main                            |
       | main          | git rebase origin/main                       |
       |               | git checkout empty-feature                   |

--- a/features/git-town-ship/supplied_branch/feature_branch/remote_only_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/remote_only_branch.feature
@@ -20,7 +20,8 @@ Feature: git town-ship: shipping the supplied feature branch with a tracking bra
     Then it runs the commands
       | BRANCH        | COMMAND                            |
       | other-feature | git fetch --prune                  |
-      |               | git stash -u                       |
+      |               | git add -A                         |
+      |               | git stash                          |
       |               | git checkout main                  |
       | main          | git rebase origin/main             |
       |               | git checkout feature               |

--- a/features/git-town-ship/supplied_branch/feature_branch/with_tracking_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/with_tracking_branch.feature
@@ -17,7 +17,8 @@ Feature: git town-ship: shipping the supplied feature branch with a tracking bra
     Then it runs the commands
       | BRANCH        | COMMAND                            |
       | other-feature | git fetch --prune                  |
-      |               | git stash -u                       |
+      |               | git add -A                         |
+      |               | git stash                          |
       |               | git checkout main                  |
       | main          | git rebase origin/main             |
       |               | git checkout feature               |

--- a/features/git-town-ship/supplied_branch/feature_branch/without_remote_origin.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/without_remote_origin.feature
@@ -17,7 +17,8 @@ Feature: git town-ship: shipping the supplied feature branch without a remote or
   Scenario: result
     Then it runs the commands
       | BRANCH        | COMMAND                      |
-      | other-feature | git stash -u                 |
+      | other-feature | git add -A                   |
+      |               | git stash                    |
       |               | git checkout feature         |
       | feature       | git merge --no-edit main     |
       |               | git checkout main            |

--- a/features/git-town-ship/supplied_branch/feature_branch/without_tracking_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/without_tracking_branch.feature
@@ -17,7 +17,8 @@ Feature: git town-ship: shipping the supplied feature branch without a tracking 
     Then it runs the commands
       | BRANCH        | COMMAND                            |
       | other-feature | git fetch --prune                  |
-      |               | git stash -u                       |
+      |               | git add -A                         |
+      |               | git stash                          |
       |               | git checkout main                  |
       | main          | git rebase origin/main             |
       |               | git checkout feature               |

--- a/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/first_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/first_branch.feature
@@ -17,7 +17,8 @@ Feature: git town-sync --all: handling merge conflicts between feature branch an
     Then it runs the commands
       | BRANCH    | COMMAND                              |
       | main      | git fetch --prune                    |
-      |           | git stash -u                         |
+      |           | git add -A                           |
+      |           | git stash                            |
       |           | git rebase origin/main               |
       |           | git checkout feature-1               |
       | feature-1 | git merge --no-edit origin/feature-1 |

--- a/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/last_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/last_branch.feature
@@ -17,7 +17,8 @@ Feature: git town-sync --all: handling merge conflicts between feature branch an
     Then it runs the commands
       | BRANCH    | COMMAND                              |
       | main      | git fetch --prune                    |
-      |           | git stash -u                         |
+      |           | git add -A                           |
+      |           | git stash                            |
       |           | git rebase origin/main               |
       |           | git checkout feature-1               |
       | feature-1 | git merge --no-edit origin/feature-1 |

--- a/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
@@ -16,7 +16,8 @@ Feature: git town-sync --all: handling merge conflicts between feature branch an
   Scenario: result
     Then it runs the commands
       | BRANCH    | COMMAND                  |
-      | main      | git stash -u             |
+      | main      | git add -A               |
+      |           | git stash                |
       |           | git checkout feature-1   |
       | feature-1 | git merge --no-edit main |
     And I get the error

--- a/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
@@ -16,7 +16,8 @@ Feature: git town-sync --all: handling merge conflicts between feature branch an
   Scenario: result
     Then it runs the commands
       | BRANCH    | COMMAND                  |
-      | main      | git stash -u             |
+      | main      | git add -A               |
+      |           | git stash                |
       |           | git checkout feature-1   |
       | feature-1 | git merge --no-edit main |
       |           | git checkout feature-2   |

--- a/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/first_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/first_branch.feature
@@ -16,7 +16,8 @@ Feature: git town-sync --all: handling merge conflicts between feature branch an
     Then it runs the commands
       | BRANCH    | COMMAND                              |
       | main      | git fetch --prune                    |
-      |           | git stash -u                         |
+      |           | git add -A                           |
+      |           | git stash                            |
       |           | git rebase origin/main               |
       |           | git checkout feature-1               |
       | feature-1 | git merge --no-edit origin/feature-1 |

--- a/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/last_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/last_branch.feature
@@ -16,7 +16,8 @@ Feature: git town-sync --all: handling merge conflicts between feature branch an
     Then it runs the commands
       | BRANCH    | COMMAND                              |
       | main      | git fetch --prune                    |
-      |           | git stash -u                         |
+      |           | git add -A                           |
+      |           | git stash                            |
       |           | git rebase origin/main               |
       |           | git checkout feature-1               |
       | feature-1 | git merge --no-edit origin/feature-1 |

--- a/features/git-town-sync/all_branches/feature_branch_merge_tracking_branch_conflict/first_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_tracking_branch_conflict/first_branch.feature
@@ -17,7 +17,8 @@ Feature: git town-sync --all: handling merge conflicts between feature branch an
     Then it runs the commands
       | BRANCH    | COMMAND                              |
       | main      | git fetch --prune                    |
-      |           | git stash -u                         |
+      |           | git add -A                           |
+      |           | git stash                            |
       |           | git rebase origin/main               |
       |           | git checkout feature-1               |
       | feature-1 | git merge --no-edit origin/feature-1 |

--- a/features/git-town-sync/all_branches/feature_branch_merge_tracking_branch_conflict/last_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_tracking_branch_conflict/last_branch.feature
@@ -17,7 +17,8 @@ Feature: git town-sync --all: handling merge conflicts between feature branch an
     Then it runs the commands
       | BRANCH    | COMMAND                              |
       | main      | git fetch --prune                    |
-      |           | git stash -u                         |
+      |           | git add -A                           |
+      |           | git stash                            |
       |           | git rebase origin/main               |
       |           | git checkout feature-1               |
       | feature-1 | git merge --no-edit origin/feature-1 |

--- a/features/git-town-sync/all_branches/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/all_branches/main_branch_rebase_tracking_branch_conflict.feature
@@ -16,7 +16,8 @@ Feature: git town-sync --all: handling rebase conflicts between main branch and 
     Then it runs the commands
       | BRANCH | COMMAND                |
       | main   | git fetch --prune      |
-      |        | git stash -u           |
+      |        | git add -A             |
+      |        | git stash              |
       |        | git rebase origin/main |
     And I get the error
       """

--- a/features/git-town-sync/all_branches/no_conflict/feature_branches.feature
+++ b/features/git-town-sync/all_branches/no_conflict/feature_branches.feature
@@ -16,7 +16,8 @@ Feature: git town-sync --all: syncs all feature branches
     Then it runs the commands
       | BRANCH    | COMMAND                              |
       | feature-1 | git fetch --prune                    |
-      |           | git stash -u                         |
+      |           | git add -A                           |
+      |           | git stash                            |
       |           | git checkout main                    |
       | main      | git rebase origin/main               |
       |           | git checkout feature-1               |

--- a/features/git-town-sync/all_branches/no_conflict/perennial_branches.feature
+++ b/features/git-town-sync/all_branches/no_conflict/perennial_branches.feature
@@ -18,7 +18,8 @@ Feature: git town-sync --all: syncs all perennial branches
     Then it runs the commands
       | BRANCH     | COMMAND                      |
       | main       | git fetch --prune            |
-      |            | git stash -u                 |
+      |            | git add -A                   |
+      |            | git stash                    |
       |            | git rebase origin/main       |
       |            | git checkout production      |
       | production | git rebase origin/production |

--- a/features/git-town-sync/all_branches/no_conflict/remote_only_branches.feature
+++ b/features/git-town-sync/all_branches/no_conflict/remote_only_branches.feature
@@ -17,7 +17,8 @@ Feature: git town-sync --all: does not sync remote only branches
     Then it runs the commands
       | BRANCH     | COMMAND                               |
       | main       | git fetch --prune                     |
-      |            | git stash -u                          |
+      |            | git add -A                            |
+      |            | git stash                             |
       |            | git rebase origin/main                |
       |            | git checkout my-feature               |
       | my-feature | git merge --no-edit origin/my-feature |

--- a/features/git-town-sync/all_branches/no_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/all_branches/no_conflict/without_remote_origin.feature
@@ -16,7 +16,8 @@ Feature: git town-sync --all: syncs all feature branches (without remote repo)
   Scenario: result
     Then it runs the commands
       | BRANCH    | COMMAND                  |
-      | feature-1 | git stash -u             |
+      | feature-1 | git add -A               |
+      |           | git stash                |
       |           | git merge --no-edit main |
       |           | git checkout feature-2   |
       | feature-2 | git merge --no-edit main |

--- a/features/git-town-sync/all_branches/perennial_branch_rebase_tracking_branch_conflict/first_branch.feature
+++ b/features/git-town-sync/all_branches/perennial_branch_rebase_tracking_branch_conflict/first_branch.feature
@@ -18,7 +18,8 @@ Feature: git town-sync --all: handling rebase conflicts between perennial branch
     And it runs the commands
       | BRANCH     | COMMAND                      |
       | main       | git fetch --prune            |
-      |            | git stash -u                 |
+      |            | git add -A                   |
+      |            | git stash                    |
       |            | git rebase origin/main       |
       |            | git checkout production      |
       | production | git rebase origin/production |

--- a/features/git-town-sync/all_branches/perennial_branch_rebase_tracking_branch_conflict/last_branch.feature
+++ b/features/git-town-sync/all_branches/perennial_branch_rebase_tracking_branch_conflict/last_branch.feature
@@ -18,7 +18,8 @@ Feature: git town-sync --all: handling rebase conflicts between perennial branch
     And it runs the commands
       | BRANCH     | COMMAND                      |
       | main       | git fetch --prune            |
-      |            | git stash -u                 |
+      |            | git add -A                   |
+      |            | git stash                    |
       |            | git rebase origin/main       |
       |            | git checkout production      |
       | production | git rebase origin/production |

--- a/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
+++ b/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
@@ -16,7 +16,8 @@ Feature: git town-sync: resolving conflicts between the current feature branch a
     Then it runs the commands
       | BRANCH  | COMMAND                            |
       | feature | git fetch --prune                  |
-      |         | git stash -u                       |
+      |         | git add -A                         |
+      |         | git stash                          |
       |         | git checkout main                  |
       | main    | git rebase origin/main             |
       |         | git push                           |

--- a/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
@@ -15,7 +15,8 @@ Feature: git town-sync: resolving conflicts between the current feature branch a
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                  |
-      | feature | git stash -u             |
+      | feature | git add -A               |
+      |         | git stash                |
       |         | git merge --no-edit main |
     And I get the error
       """

--- a/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
+++ b/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
@@ -15,7 +15,8 @@ Feature: git town-sync: resolving conflicts between the current feature branch a
     Then it runs the commands
       | BRANCH  | COMMAND                            |
       | feature | git fetch --prune                  |
-      |         | git stash -u                       |
+      |         | git add -A                         |
+      |         | git stash                          |
       |         | git checkout main                  |
       | main    | git rebase origin/main             |
       |         | git push                           |

--- a/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_tracking_branch_conflict.feature
@@ -20,7 +20,8 @@ Feature: git town-sync: resolving conflicts between the current feature branch a
     Then it runs the commands
       | BRANCH  | COMMAND                            |
       | feature | git fetch --prune                  |
-      |         | git stash -u                       |
+      |         | git add -A                         |
+      |         | git stash                          |
       |         | git checkout main                  |
       | main    | git rebase origin/main             |
       |         | git checkout feature               |

--- a/features/git-town-sync/current_branch/feature_branch/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/feature_branch/main_branch_rebase_tracking_branch_conflict.feature
@@ -20,7 +20,8 @@ Feature: git town-sync: resolving conflicts between the main branch and its trac
     Then it runs the commands
       | BRANCH  | COMMAND                |
       | feature | git fetch --prune      |
-      |         | git stash -u           |
+      |         | git add -A             |
+      |         | git stash              |
       |         | git checkout main      |
       | main    | git rebase origin/main |
     And I get the error

--- a/features/git-town-sync/current_branch/feature_branch/nested_feature_branch/known_parents.feature
+++ b/features/git-town-sync/current_branch/feature_branch/nested_feature_branch/known_parents.feature
@@ -22,7 +22,8 @@ Feature: git town-sync: syncing a nested feature branch (with known parent branc
     Then it runs the commands
       | BRANCH         | COMMAND                                   |
       | child-feature  | git fetch --prune                         |
-      |                | git stash -u                              |
+      |                | git add -A                                |
+      |                | git stash                                 |
       |                | git checkout main                         |
       | main           | git rebase origin/main                    |
       |                | git push                                  |

--- a/features/git-town-sync/current_branch/feature_branch/no_conflict/with_merge_pull_branch_strategy.feature
+++ b/features/git-town-sync/current_branch/feature_branch/no_conflict/with_merge_pull_branch_strategy.feature
@@ -23,7 +23,8 @@ Feature: git-sync: on a feature branch with merge pull branch strategy
     Then it runs the commands
       | BRANCH  | COMMAND                            |
       | feature | git fetch --prune                  |
-      |         | git stash -u                       |
+      |         | git add -A                         |
+      |         | git stash                          |
       |         | git checkout main                  |
       | main    | git merge --no-edit origin/main    |
       |         | git push                           |

--- a/features/git-town-sync/current_branch/feature_branch/no_conflict/with_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/feature_branch/no_conflict/with_tracking_branch.feature
@@ -22,7 +22,8 @@ Feature: git town-sync: syncing the current feature branch with a tracking branc
     Then it runs the commands
       | BRANCH  | COMMAND                            |
       | feature | git fetch --prune                  |
-      |         | git stash -u                       |
+      |         | git add -A                         |
+      |         | git stash                          |
       |         | git checkout main                  |
       | main    | git rebase origin/main             |
       |         | git push                           |

--- a/features/git-town-sync/current_branch/feature_branch/no_conflict/with_upstream.feature
+++ b/features/git-town-sync/current_branch/feature_branch/no_conflict/with_upstream.feature
@@ -16,7 +16,8 @@ Feature: git-sync: on a feature branch with a upstream remote
     Then it runs the commands
       | BRANCH  | COMMAND                            |
       | feature | git fetch --prune                  |
-      |         | git stash -u                       |
+      |         | git add -A                         |
+      |         | git stash                          |
       |         | git checkout main                  |
       | main    | git rebase origin/main             |
       |         | git fetch upstream                 |

--- a/features/git-town-sync/current_branch/feature_branch/no_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/feature_branch/no_conflict/without_remote_origin.feature
@@ -18,7 +18,8 @@ Feature: git town-sync: syncing the current feature branch (without a tracking b
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                  |
-      | feature | git stash -u             |
+      | feature | git add -A               |
+      |         | git stash                |
       |         | git merge --no-edit main |
       |         | git stash pop            |
     And I am still on the "feature" branch

--- a/features/git-town-sync/current_branch/feature_branch/no_conflict/without_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/feature_branch/no_conflict/without_tracking_branch.feature
@@ -19,7 +19,8 @@ Feature: git town-sync: syncing the current feature branch without a tracking br
     Then it runs the commands
       | BRANCH  | COMMAND                    |
       | feature | git fetch --prune          |
-      |         | git stash -u               |
+      |         | git add -A                 |
+      |         | git stash                  |
       |         | git checkout main          |
       | main    | git rebase origin/main     |
       |         | git push                   |

--- a/features/git-town-sync/current_branch/feature_branch/with_ignored_files.feature
+++ b/features/git-town-sync/current_branch/feature_branch/with_ignored_files.feature
@@ -1,0 +1,17 @@
+Feature: syncing with ignored files
+
+  As a developer using an IDE that creates a temp folder I don't want to check in
+  I want "git town-sync" to leave those ignored files alone
+  So that my IDE settings are not deleted while developing.
+
+  - all files ignored by Git survive a "git sync" process unchanged
+
+
+  Scenario: running "git sync" with ignored files
+    Given my repo ignores files named "ignored"
+    And I have a feature branch named "feature"
+    And I am on the "feature" branch
+    And I have an uncommitted file with name: "somefile" and content: "important"
+    And I have an uncommitted file with name: "test/ignored/important" and content: "very important"
+    When I run `git town-sync`
+    Then my workspace still contains the file "test/ignored/important" with content "very important"

--- a/features/git-town-sync/current_branch/main_branch/no_conflict/with_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/main_branch/no_conflict/with_tracking_branch.feature
@@ -19,7 +19,8 @@ Feature: git town-sync: syncing the main branch
     Then it runs the commands
       | BRANCH | COMMAND                |
       | main   | git fetch --prune      |
-      |        | git stash -u           |
+      |        | git add -A             |
+      |        | git stash              |
       |        | git rebase origin/main |
       |        | git push               |
       |        | git push --tags        |

--- a/features/git-town-sync/current_branch/main_branch/no_conflict/with_upstream.feature
+++ b/features/git-town-sync/current_branch/main_branch/no_conflict/with_upstream.feature
@@ -14,7 +14,8 @@ Feature: git-sync: on the main branch with a upstream remote
     Then it runs the commands
       | BRANCH | COMMAND                  |
       | main   | git fetch --prune        |
-      |        | git stash -u             |
+      |        | git add -A               |
+      |        | git stash                |
       |        | git rebase origin/main   |
       |        | git fetch upstream       |
       |        | git rebase upstream/main |

--- a/features/git-town-sync/current_branch/main_branch/no_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/main_branch/no_conflict/without_remote_origin.feature
@@ -18,7 +18,8 @@ Feature: git town-sync: syncing the main branch (without remote repo)
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND       |
-      | main   | git stash -u  |
+      | main   | git add -A    |
+      |        | git stash     |
       |        | git stash pop |
     And I am still on the "main" branch
     And I still have my uncommitted file

--- a/features/git-town-sync/current_branch/main_branch/rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/main_branch/rebase_tracking_branch_conflict.feature
@@ -19,7 +19,8 @@ Feature: git town-sync: resolving conflicts between the main branch and its trac
     Then it runs the commands
       | BRANCH | COMMAND                |
       | main   | git fetch --prune      |
-      |        | git stash -u           |
+      |        | git add -A             |
+      |        | git stash              |
       |        | git rebase origin/main |
     And I get the error
       """

--- a/features/git-town-sync/current_branch/perennial_branch/no_conflict/with_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/no_conflict/with_tracking_branch.feature
@@ -21,7 +21,8 @@ Feature: git town-sync: syncing the current perennial branch
     Then it runs the commands
       | BRANCH | COMMAND              |
       | qa     | git fetch --prune    |
-      |        | git stash -u         |
+      |        | git add -A           |
+      |        | git stash            |
       |        | git rebase origin/qa |
       |        | git push             |
       |        | git push --tags      |

--- a/features/git-town-sync/current_branch/perennial_branch/no_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/no_conflict/without_remote_origin.feature
@@ -20,7 +20,8 @@ Feature: git town-sync: syncing the current perennial branch (without remote rep
   Scenario: no conflict
     Then it runs the commands
       | BRANCH | COMMAND       |
-      | qa     | git stash -u  |
+      | qa     | git add -A    |
+      |        | git stash     |
       |        | git stash pop |
     And I am still on the "qa" branch
     And I still have my uncommitted file

--- a/features/git-town-sync/current_branch/perennial_branch/rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/rebase_tracking_branch_conflict.feature
@@ -20,7 +20,8 @@ Feature: git town-sync: resolving conflicts between the current perennial branch
     Then it runs the commands
       | BRANCH | COMMAND              |
       | qa     | git fetch --prune    |
-      |        | git stash -u         |
+      |        | git add -A           |
+      |        | git stash            |
       |        | git rebase origin/qa |
     And I get the error
       """

--- a/features/git-town-sync/folder_does_not_exist_on_main_branch/conflict.feature
+++ b/features/git-town-sync/folder_does_not_exist_on_main_branch/conflict.feature
@@ -22,7 +22,8 @@ Feature: git town-sync: syncing inside a folder that doesn't exist on the main b
       | BRANCH          | COMMAND                                    |
       | current-feature | git fetch --prune                          |
       | <none>          | cd <%= git_root_folder %>                  |
-      | current-feature | git stash -u                               |
+      | current-feature | git add -A                                 |
+      |                 | git stash                                  |
       |                 | git checkout main                          |
       | main            | git rebase origin/main                     |
       |                 | git checkout current-feature               |

--- a/features/git-town-sync/folder_does_not_exist_on_main_branch/no_conflict.feature
+++ b/features/git-town-sync/folder_does_not_exist_on_main_branch/no_conflict.feature
@@ -22,7 +22,8 @@ Feature: git town-sync: syncing inside a folder that doesn't exist on the main b
       | BRANCH          | COMMAND                                    |
       | current-feature | git fetch --prune                          |
       | <none>          | cd <%= git_root_folder %>                  |
-      | current-feature | git stash -u                               |
+      | current-feature | git add -A                                 |
+      |                 | git stash                                  |
       |                 | git checkout main                          |
       | main            | git rebase origin/main                     |
       |                 | git checkout current-feature               |
@@ -55,7 +56,8 @@ Feature: git town-sync: syncing inside a folder that doesn't exist on the main b
     Then it runs the commands
       | BRANCH          | COMMAND                           |
       | <none>          | cd <%= git_root_folder %>         |
-      | current-feature | git stash -u                      |
+      | current-feature | git add -A                        |
+      |                 | git stash                         |
       |                 | git checkout other-feature        |
       | other-feature   | git checkout current-feature      |
       | current-feature | git checkout main                 |

--- a/features/step_definitions/files_steps.rb
+++ b/features/step_definitions/files_steps.rb
@@ -1,3 +1,11 @@
+Given(/^my repo ignores files named "([^"]*)"$/) do |filename|
+  create_local_commit branch: current_branch_name,
+                      file_name: '.gitignore',
+                      file_content: filename,
+                      message: 'ignoring files'
+end
+
+
 Given(/^I have an uncommitted file(?: with name: "(.+?)" and content: "(.+?)")?$/) do |name, content|
   @uncommitted_file_name = name || 'uncommitted_file'
   @uncommitted_file_content = content || 'uncommitted content'
@@ -32,4 +40,9 @@ Then(/^my uncommitted file is stashed$/) do
   expect(uncommitted_files).to_not include @uncommitted_file_name
   expect(stash_size).to eql 1
   @non_empty_stash_expected = true
+end
+
+
+Then(/^my workspace still contains the file "([^"]*)" with content "([^"]*)"$/) do |filename, content|
+  verify_file filename, content
 end

--- a/features/support/files_helpers.rb
+++ b/features/support/files_helpers.rb
@@ -40,6 +40,19 @@ DEFAULT_UNCOMMITTED_FILE_ATTRIBUTES = {
 }.freeze
 
 
+def ignore_file filename
+  create_local_commit branch: current_branch_name,
+                      file_name: '.gitignore',
+                      file_content: filename,
+                      message: 'ignoring files'
+end
+
+
+def verify_file filename, content
+  expect(IO.read filename).to eql content
+end
+
+
 def verify_uncommitted_file options
   options.reverse_merge! DEFAULT_UNCOMMITTED_FILE_ATTRIBUTES
   expect(uncommitted_files).to include options[:name]

--- a/src/helpers/git_helpers/open_changes_helpers.sh
+++ b/src/helpers/git_helpers/open_changes_helpers.sh
@@ -42,7 +42,8 @@ function restore_open_changes {
 
 # Stashes uncommitted changes
 function stash_open_changes {
-  run_command "git stash -u"
+  run_command "git add -A"
+  run_command "git stash"
 }
 
 


### PR DESCRIPTION
fixes #744 
alternative to #745 

This PR implements @charlierudolph's [idea](https://github.com/Originate/git-town/pull/745#issuecomment-248042786) to first stage all uncommitted files, so than we can then run a normal `git stash` instead of the dangerous `git stash -u`, thereby avoiding that Git runs `git clean` that will sometimes remove ignored files that are still needed.

@charlierudolph @Bowbaq 