### PR TITLE
Update tertestrial.yml

### DIFF
--- a/tertestrial.yml
+++ b/tertestrial.yml
@@ -2,9 +2,9 @@ actions:
 
   - match:
       filename: '\.feature$'
-    command: 'bundle exec cuke {{filename}}'
+    command: 'bundle exec cucumber {{filename}}'
 
   - match:
       filename: '\.feature$'
       line: '\d+'
-    command: 'bundle exec cuke {{filename}}:{{line}}'
+    command: 'bundle exec cucumber {{filename}}:{{line}}'


### PR DESCRIPTION
@kevgo

The cuke command which uses `parallel_cucumber`, does not support `<file>:<line>` syntax. Also there is no need to use `parallel_cucumber` when running a single feature or scenario