### PR TITLE
refactor steps to use tables

### DIFF
--- a/cucumber_lint.yml
+++ b/cucumber_lint.yml
@@ -5,3 +5,6 @@ consistent_empty_lines:
   between_feature_and_description: 1
   between_feature_and_element: 1
   between_scenario_outline_and_examples: 1
+
+consistent_table_headers:
+  enabled: false

--- a/features/git-town/configuration/already_set.feature
+++ b/features/git-town/configuration/already_set.feature
@@ -16,11 +16,11 @@ Feature: listing the configuration
     Then I see
       """
       Git Town needs to be configured
-      
+
         1: main
         2: production
         3: qa
-      
+
       Please specify the main development branch by name or number (current value: main): Please specify a perennial branch by name or number. Leave it blank to finish (current value: qa):
       """
 
@@ -36,7 +36,9 @@ Feature: listing the configuration
   Scenario: non-empty input
     Given I have configured the main branch name as "main"
     And my perennial branches are configured as "qa"
-    When I run `git town config --setup` and enter "main", "production" and ""
+    When I run `git town config --setup` and enter:
+      | main       |
+      | production |
+      |            |
     And my repo is configured with the main branch as "main"
     And my repo is configured with perennial branches as "production"
-

--- a/features/git-town/configuration/setup.feature
+++ b/features/git-town/configuration/setup.feature
@@ -11,54 +11,83 @@ Feature: Initial configuration
 
 
   Scenario: succeeds on valid main branch and perennial branch names
-    When I run `git town config --setup` and enter "main", "production", "dev" and ""
+    When I run `git town config --setup` and enter:
+      | main       |
+      | production |
+      | dev        |
+      |            |
     Then my repo is configured with the main branch as "main"
     And my repo is configured with perennial branches as "production" and "dev"
 
 
   Scenario: succeeds on valid main branch and perennial branch numbers
-    When I run `git town config --setup` and enter "2", "1", "3" and ""
+    When I run `git town config --setup` and enter:
+      | 2 |
+      | 1 |
+      | 3 |
+      |   |
     Then my repo is configured with the main branch as "main"
     And my repo is configured with perennial branches as "production" and "dev"
 
 
   Scenario: shows error and re-prompts on empty main branch
-    When I run `git town config --setup` and enter "", "main" and ""
+    When I run `git town config --setup` and enter:
+      |      |
+      | main |
+      |      |
     Then I see "no input received"
     And my repo is configured with the main branch as "main"
     And my repo is configured with no perennial branches
 
 
   Scenario: shows error and re-prompts on invalid main branch number
-    When I run `git town config --setup` and enter "4", "main" and ""
+    When I run `git town config --setup` and enter:
+      | 4    |
+      | main |
+      |      |
     Then I see "invalid branch number"
     And my repo is configured with the main branch as "main"
     And my repo is configured with no perennial branches
 
 
   Scenario: shows error and re-prompts on non-existent main branch
-    When I run `git town config --setup` and enter "non-existent", "main" and ""
+    When I run `git town config --setup` and enter:
+      | non-existent |
+      | main         |
+      |              |
     Then I see "branch 'non-existent' doesn't exist"
     And my repo is configured with the main branch as "main"
     And my repo is configured with no perennial branches
 
 
   Scenario: shows error and re-prompts on main branch as perennial branch
-    When I run `git town config --setup` and enter "main", "main", "dev" and ""
+    When I run `git town config --setup` and enter:
+      | main |
+      | main |
+      | dev  |
+      |      |
     Then I see "'main' is already set as the main branch"
     And my repo is configured with the main branch as "main"
     And my repo is configured with perennial branches as "dev"
 
 
   Scenario: shows error and re-prompts on invalid perennial branch number
-    When I run `git town config --setup` and enter "main", "4", "3" and ""
+    When I run `git town config --setup` and enter:
+      | main |
+      | 4    |
+      | 3    |
+      |      |
     Then I see "invalid branch number"
     And my repo is configured with the main branch as "main"
     And my repo is configured with perennial branches as "production"
 
 
   Scenario: shows error and re-prompts on non-existent perennial branch
-    When I run `git town config --setup` and enter "main", "non-existent", "dev", and ""
+    When I run `git town config --setup` and enter:
+      | main         |
+      | non-existent |
+      | dev          |
+      |              |
     Then I see "branch 'non-existent' doesn't exist"
     And my repo is configured with the main branch as "main"
     And my repo is configured with perennial branches as "dev"

--- a/features/shared/entering_parent_branch.feature
+++ b/features/shared/entering_parent_branch.feature
@@ -83,7 +83,10 @@ Feature: Entering a parent branch name when prompted
 
 
   Scenario: creating a loop
-    When I run `git town-sync` and enter "feature-1" and "feature-2" and "main"
+    When I run `git town-sync` and enter:
+      | feature-1 |
+      | feature-2 |
+      | main      |
     Then I see "Please specify the parent branch of feature-2"
     And I see "Nested branch loop detected: 'feature-1' is an ancestor of 'feature-2'"
     And Git Town is now aware of this branch hierarchy

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -20,10 +20,16 @@ When(/^I run `(.+?)` and enter "(.*?)"$/) do |command, input|
 end
 
 
+When(/^I run `(.+?)` and enter:$/) do |command, table|
+  @result = run command, inputs: table.raw.map { |row| row[0] }
+end
+
+
 When(/^I run `(.+?)` and enter an empty commit message$/) do |command|
   # In vim "dG" removes all lines and "ZZ" saves and exits
   step "I run `#{command}` and enter \"dGZZ\""
 end
+
 
 When(/^I run `(.+?)` and don't change the default commit message$/) do |command|
   # In vim "ZZ" saves and exits


### PR DESCRIPTION
@kevgo 

Refactored any step that was passing in 3 or more inputs.

Had to disable the cucumber lint rule about table headers as there have no headers. Can reenable it only if we add a header row to the table.