### PR TITLE
rename-branch implicitly uses current branch

### DIFF
--- a/documentation/commands/git-town-rename-branch.md
+++ b/documentation/commands/git-town-rename-branch.md
@@ -6,7 +6,7 @@ git-town-rename-branch - rename a branch both locally and remotely
 #### SYNOPSIS
 
 ```
-git town-rename-branch <old_branch_name> <new_branch_name> [-f]
+git town-rename-branch [<old_branch_name>] <new_branch_name> [-f]
 ```
 
 
@@ -36,6 +36,7 @@ When run on a perennial branch
 ```
 <old_branch_name>
     The name of the branch to rename.
+    If omitted, the current branch will be renamed.
 
 <new_branch_name>
     The new name of the branch.

--- a/features/git-town-rename-branch/current_branch.feature
+++ b/features/git-town-rename-branch/current_branch.feature
@@ -11,8 +11,8 @@ Feature: git town-rename-branch: rename current branch implicitly
     And the following commits exist in my repository
       | BRANCH     | LOCATION         | MESSAGE     |
       | main       | local and remote | main commit |
-      | production | local and remote | prod commit |
       | feature    | local and remote | feat commit |
+      | production | local and remote | prod commit |
 
 
   Scenario: rename feature branch
@@ -25,6 +25,14 @@ Feature: git town-rename-branch: rename current branch implicitly
       | main            | local and remote | main commit |
       | production      | local and remote | prod commit |
       | renamed-feature | local and remote | feat commit |
+
+
+  Scenario: rename branch to itself
+    Given I am on the "feature" branch
+    When I run `git town-rename-branch feature`
+    Then I see "Renaming branch to same name, nothing to do."
+    And I end up on the "feature" branch
+    And I am left with my original commits
 
 
   Scenario: rename perennial branch

--- a/features/git-town-rename-branch/current_branch.feature
+++ b/features/git-town-rename-branch/current_branch.feature
@@ -11,27 +11,49 @@ Feature: git town-rename-branch: rename current branch implicitly
     And the following commits exist in my repository
       | BRANCH     | LOCATION         | MESSAGE     |
       | main       | local and remote | main commit |
-      | production | local and remote | main commit |
-      | feature    | local and remote | main commit |
+      | production | local and remote | prod commit |
+      | feature    | local and remote | feat commit |
 
 
   Scenario: rename feature branch
     When I am on the "feature" branch
     And I run `git town-rename-branch renamed-feature`
     Then I end up on the "renamed-feature" branch
+    And my repo is configured with perennial branches as "production"
     And I have the following commits
       | BRANCH          | LOCATION         | MESSAGE     |
       | main            | local and remote | main commit |
-      | production      | local and remote | main commit |
-      | renamed-feature | local and remote | main commit |
+      | production      | local and remote | prod commit |
+      | renamed-feature | local and remote | feat commit |
 
 
   Scenario: rename perennial branch
     When I am on the "production" branch
     And I run `git town-rename-branch renamed-production -f`
     Then I end up on the "renamed-production" branch
+    And my repo is configured with perennial branches as "renamed-production"
     And I have the following commits
       | BRANCH             | LOCATION         | MESSAGE     |
       | main               | local and remote | main commit |
-      | feature            | local and remote | main commit |
-      | renamed-production | local and remote | main commit |
+      | feature            | local and remote | feat commit |
+      | renamed-production | local and remote | prod commit |
+
+
+  Scenario: undo rename branch
+    Given I am on the "feature" branch
+    And I run `git town-rename-branch renamed-feature`
+    When I run `git town-rename-branch --undo`
+    Then it runs the commands
+        | BRANCH          | COMMAND                                     |
+        | renamed-feature | git branch feature <%= sha 'feat commit' %> |
+        |                 | git push -u origin feature                  |
+        |                 | git push origin :renamed-feature            |
+        |                 | git checkout feature                        |
+        | feature         | git branch -d renamed-feature               |
+    And I end up on the "feature" branch
+    And my repo is configured with perennial branches as "production"
+    And I have the following commits
+      | BRANCH     | LOCATION         | MESSAGE     |
+      | main       | local and remote | main commit |
+      | feature    | local and remote | feat commit |
+      | production | local and remote | prod commit |

--- a/features/git-town-rename-branch/current_branch.feature
+++ b/features/git-town-rename-branch/current_branch.feature
@@ -1,0 +1,37 @@
+Feature: git town-rename-branch: rename current branch implicitly
+
+  As a developer wishing to rename the current branch
+  I should be able reference the current branch implicitly
+  So that I can perform my rename quickly.
+
+
+  Background:
+    Given I have a feature branch named "feature"
+    And I have a perennial branch named "production"
+    And the following commits exist in my repository
+      | BRANCH     | LOCATION         | MESSAGE     |
+      | main       | local and remote | main commit |
+      | production | local and remote | main commit |
+      | feature    | local and remote | main commit |
+
+
+  Scenario: rename feature branch
+    When I am on the "feature" branch
+    And I run `git town-rename-branch renamed-feature`
+    Then I end up on the "renamed-feature" branch
+    And I have the following commits
+      | BRANCH          | LOCATION         | MESSAGE     |
+      | main            | local and remote | main commit |
+      | production      | local and remote | main commit |
+      | renamed-feature | local and remote | main commit |
+
+
+  Scenario: rename perennial branch
+    When I am on the "production" branch
+    And I run `git town-rename-branch renamed-production -f`
+    Then I end up on the "renamed-production" branch
+    And I have the following commits
+      | BRANCH             | LOCATION         | MESSAGE     |
+      | main               | local and remote | main commit |
+      | feature            | local and remote | main commit |
+      | renamed-production | local and remote | main commit |

--- a/features/git-town-rename-branch/current_branch.feature
+++ b/features/git-town-rename-branch/current_branch.feature
@@ -16,8 +16,8 @@ Feature: git town-rename-branch: rename current branch implicitly
 
 
   Scenario: rename feature branch
-    When I am on the "feature" branch
-    And I run `git town-rename-branch renamed-feature`
+    Given I am on the "feature" branch
+    When I run `git town-rename-branch renamed-feature`
     Then I end up on the "renamed-feature" branch
     And my repo is configured with perennial branches as "production"
     And I have the following commits
@@ -28,8 +28,16 @@ Feature: git town-rename-branch: rename current branch implicitly
 
 
   Scenario: rename perennial branch
-    When I am on the "production" branch
-    And I run `git town-rename-branch renamed-production -f`
+    Given I am on the "production" branch
+    When I run `git town-rename-branch renamed-production`
+    Then it runs no commands
+    And I get the error "The branch 'production' is not a feature branch."
+    And I get the error "Run 'git town-rename-branch production renamed-production -f' to force the rename, then reconfigure git-town on any other clones of this repo."
+
+
+  Scenario: rename perennial branch (forced)
+    Given I am on the "production" branch
+    When I run `git town-rename-branch renamed-production -f`
     Then I end up on the "renamed-production" branch
     And my repo is configured with perennial branches as "renamed-production"
     And I have the following commits

--- a/features/git-town-rename-branch/feature_branch/branch_and_destination_same.feature
+++ b/features/git-town-rename-branch/feature_branch/branch_and_destination_same.feature
@@ -16,7 +16,7 @@ Feature: git town-rename-branch: does nothing if renaming a feature branch onto 
 
 
   Scenario: result
-    Then I see "Renaming branch to same name, nothing needed."
+    Then I see "Renaming branch to same name, nothing to do."
     And I end up on the "current-feature" branch
     And I still have my uncommitted file
     And I am left with my original commits

--- a/features/git-town-rename-branch/invalid_invocation.feature
+++ b/features/git-town-rename-branch/invalid_invocation.feature
@@ -1,4 +1,4 @@
-Feature: git town-rename-branch: requires >= 1 and < 2 branch names, and an optional force flag
+Feature: git town-rename-branch: requires 1 or 2 branch names, and an optional force flag
 
   As a developer invoking town-rename-branch with incorrect arity
   I should be reminded that I have to provide the branch names to this command

--- a/features/git-town-rename-branch/invalid_invocation.feature
+++ b/features/git-town-rename-branch/invalid_invocation.feature
@@ -1,6 +1,6 @@
-Feature: git town-rename-branch: requires two branch names
+Feature: git town-rename-branch: requires >= 1 and < 2 branch names, and an optional force flag
 
-  As a developer forgetting to provide the name of the branch and its new name
+  As a developer invoking town-rename-branch with incorrect arity
   I should be reminded that I have to provide the branch names to this command
   So that I can use it correctly without having to look that fact up in the readme.
 
@@ -17,5 +17,13 @@ Feature: git town-rename-branch: requires two branch names
     When I run `git town-rename-branch`
     Then it runs no commands
     And I get the error "No branch name provided"
+    And I am still on the "current-feature" branch
+    And I am left with my original commits
+
+
+  Scenario: three branch names given
+    When I run `git town-rename-branch one two three`
+    Then it runs no commands
+    And I get the error "Extraneous argument 'three'. See 'git town-rename-branch --help' for usage"
     And I am still on the "current-feature" branch
     And I am left with my original commits

--- a/features/git-town-rename-branch/not_enough_branch_names.feature
+++ b/features/git-town-rename-branch/not_enough_branch_names.feature
@@ -19,11 +19,3 @@ Feature: git town-rename-branch: requires two branch names
     And I get the error "No branch name provided"
     And I am still on the "current-feature" branch
     And I am left with my original commits
-
-
-  Scenario: one branch name given
-    When I run `git town-rename-branch current-feature`
-    Then it runs no commands
-    And I get the error "No branch name provided"
-    And I am still on the "current-feature" branch
-    And I am left with my original commits

--- a/features/git-town-rename-branch/perennial_branch/branch_and_destination_same.feature
+++ b/features/git-town-rename-branch/perennial_branch/branch_and_destination_same.feature
@@ -16,7 +16,7 @@ Feature: git town-rename-branch: does nothing if renaming a perennial branch ont
 
 
   Scenario: result
-    Then I see "Renaming branch to same name, nothing needed."
+    Then I see "Renaming branch to same name, nothing to do."
     And I end up on the "production" branch
     And I still have my uncommitted file
     And I am left with my original commits

--- a/man/man1/git-town-rename-branch.1
+++ b/man/man1/git-town-rename-branch.1
@@ -5,7 +5,7 @@ git-town-rename-branch \- rename a branch both locally and remotely
 
 
 .SH "SYNOPSIS"
-\fIgit town-rename-branch\fR <old_branch_name> <new_branch_name> [-f]
+\fIgit town-rename-branch\fR [<old_branch_name>] <new_branch_name> [-f]
 
 
 .SH "DESCRIPTION"
@@ -39,6 +39,8 @@ When run on a perennial branch
 .SH "OPTIONS"
 .IP "<old_branch_name>" 4
 The name of the branch to rename.
+.br
+If omitted, the current branch will be renamed.
 
 .IP "<new_branch_name>" 4
 The new name of the branch.

--- a/src/git-town-rename-branch
+++ b/src/git-town-rename-branch
@@ -23,13 +23,17 @@ function preconditions {
     fi
   elif (( $# == 3 )); then
     if [[ $3 == "-f" ]]; then
+      target_branch_name=$1
+      destination_branch_name=$2
       force_rename=true
+    elif [[ -n $3 ]]; then
+      echo_error_header
+      echo_error "Extraneous argument '$3'. See 'git town-rename-branch --help' for usage."
+      exit_with_error newline
     fi
-    target_branch_name=$1
-    destination_branch_name=$2
   else
     echo_error_header
-    echo_error "See 'git town-rename-branch --help' for usage instructions."
+    echo_error "See 'git town-rename-branch --help' for usage."
     exit_with_error newline
   fi
 
@@ -49,7 +53,7 @@ function preconditions {
   fi
 
   if [ "$target_branch_name" == "$destination_branch_name" ]; then
-    echo "Renaming branch to same name, nothing needed."
+    echo "Renaming branch to same name, nothing to do."
     exit_with_status 0
   fi
 

--- a/src/git-town-rename-branch
+++ b/src/git-town-rename-branch
@@ -3,9 +3,7 @@ source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/helpers/helpers.sh"
 
 
 function preconditions {
-  target_branch_name=$1
-  destination_branch_name=$2
-  force_parameter=$3
+  force_rename=false
 
   if (( $# == 0 )); then
     echo_error_header
@@ -18,25 +16,23 @@ function preconditions {
     if [[ $2 == "-f" ]]; then
       target_branch_name=$(get_current_branch_name)
       destination_branch_name=$1
-      force_parameter=$2
+      force_rename=true
     else
       target_branch_name=$1
       destination_branch_name=$2
     fi
   elif (( $# == 3 )); then
+    if [[ $3 == "-f" ]]; then
+      force_rename=true
+    fi
     target_branch_name=$1
     destination_branch_name=$2
-    force_parameter=$3
   else
     echo_error_header
     echo_error "See 'git town-rename-branch --help' for usage instructions."
     exit_with_error newline
   fi
 
-  force_rename=false
-  if [ "$force_parameter" == "-f" ]; then
-    force_rename=true
-  fi
 
   if [ "$(is_main_branch "$target_branch_name")" = true ]; then
     echo_error_header

--- a/src/git-town-rename-branch
+++ b/src/git-town-rename-branch
@@ -7,6 +7,32 @@ function preconditions {
   destination_branch_name=$2
   force_parameter=$3
 
+  if (( $# == 0 )); then
+    echo_error_header
+    echo_error "No branch name provided to rename to."
+    exit_with_error newline
+  elif (( $# == 1 )); then
+    target_branch_name=$(get_current_branch_name)
+    destination_branch_name=$1
+  elif (( $# == 2 )); then
+    if [[ $2 == "-f" ]]; then
+      target_branch_name=$(get_current_branch_name)
+      destination_branch_name=$1
+      force_parameter=$2
+    else
+      target_branch_name=$1
+      destination_branch_name=$2
+    fi
+  elif (( $# == 3 )); then
+    target_branch_name=$1
+    destination_branch_name=$2
+    force_parameter=$3
+  else
+    echo_error_header
+    echo_error "See 'git town-rename-branch --help' for usage instructions."
+    exit_with_error newline
+  fi
+
   force_rename=false
   if [ "$force_parameter" == "-f" ]; then
     force_rename=true
@@ -15,18 +41,6 @@ function preconditions {
   if [ "$(is_main_branch "$target_branch_name")" = true ]; then
     echo_error_header
     echo_error "The main branch cannot be renamed."
-    exit_with_error newline
-  fi
-
-  if [ -z "$target_branch_name" ]; then
-    echo_error_header
-    echo_error "No branch name provided to rename."
-    exit_with_error newline
-  fi
-
-  if [ -z "$destination_branch_name" ]; then
-    echo_error_header
-    echo_error "No branch name provided to rename to."
     exit_with_error newline
   fi
 


### PR DESCRIPTION
This mirrors the native `git branch -m` command more closely.

Allows for the following:

```bash
git town-rename-branch new_name
git town-rename-branch old_name new_name
```