### PR TITLE
add initial support for GitLab

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
   DisplayCopNames: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'http://rubygems.org'
 
 ruby '2.3.1'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support/all'
 require 'rubocop/rake_task'
 

--- a/features/git-town-new-pull-request/gitlab.feature
+++ b/features/git-town-new-pull-request/gitlab.feature
@@ -1,0 +1,49 @@
+Feature: git-new-pull-request when origin is on GitLab
+
+  As a developer having finished a feature in a repository hosted on GitLab
+  I want to be able to easily create a pull request
+  So that I have more time for coding the next feature instead of wasting it with process boilerplate.
+
+
+  Background:
+    Given I have "open" installed
+
+
+  Scenario Outline: creating pull-requests
+    Given I have a feature branch named "feature"
+    And my remote origin is <ORIGIN>
+    And I am on the "feature" branch
+    When I run `git town-new-pull-request`
+    Then I see a new GitLab pull request for the "feature" branch in the "<REPOSITORY>" repo in my browser
+
+    Examples:
+      | ORIGIN                           | REPOSITORY |
+      | https://gitlab.com/kadu/kadu.git | kadu/kadu  |
+      | git@gitlab.com:kadu/kadu.git     | kadu/kadu  |
+
+
+  Scenario: nested feature branch with known parent
+    Given I have a feature branch named "parent-feature"
+    And I have a feature branch named "child-feature" as a child of "parent-feature"
+    And my remote origin is git@gitlab.com:kadu/kadu.git
+    And I am on the "child-feature" branch
+    When I run `git town-new-pull-request`
+    Then I see a new GitLab pull request for the "child-feature" branch against the "parent-feature" branch in the "kadu/kadu" repo in my browser
+
+
+  Scenario: nested feature branch with unknown parent (entering the parent name)
+    Given I have a feature branch named "feature"
+    And Git Town has no branch hierarchy information for "feature"
+    And my remote origin is git@gitlab.com:kadu/kadu.git
+    And I am on the "feature" branch
+    When I run `git town-new-pull-request` and enter "main"
+    Then I see a new GitLab pull request for the "feature" branch in the "kadu/kadu" repo in my browser
+
+
+  Scenario: nested feature branch with unknown parent (accepting default choice)
+    Given I have a feature branch named "feature"
+    And Git Town has no branch hierarchy information for "feature"
+    And my remote origin is git@gitlab.com:kadu/kadu.git
+    And I am on the "feature" branch
+    When I run `git town-new-pull-request` and press ENTER
+    Then I see a new GitLab pull request for the "feature" branch in the "kadu/kadu" repo in my browser

--- a/features/git-town-new-pull-request/unsupported_hosting_service.feature
+++ b/features/git-town-new-pull-request/unsupported_hosting_service.feature
@@ -13,4 +13,4 @@ Feature: git-new-pull-request: when origin is unsupported
 
   Scenario: result
     Then I get the error "Unsupported hosting service"
-    And I get the error "This command requires hosting on GitHub or Bitbucket"
+    And I get the error "This command requires hosting on GitHub, GitLab or Bitbucket"

--- a/features/git-town-new-pull-request/unsupported_hosting_service.feature
+++ b/features/git-town-new-pull-request/unsupported_hosting_service.feature
@@ -13,4 +13,4 @@ Feature: git-new-pull-request: when origin is unsupported
 
   Scenario: result
     Then I get the error "Unsupported hosting service"
-    And I get the error "This command requires hosting on GitHub, GitLab or Bitbucket"
+    And I get the error "This command requires hosting on GitHub, GitLab, or Bitbucket"

--- a/features/git-town-repo/gitlab.feature
+++ b/features/git-town-repo/gitlab.feature
@@ -1,0 +1,12 @@
+Feature: git-repo when origin is on GitLab
+
+  Scenario Outline: result
+    Given my remote origin is <ORIGIN>
+    And I have "open" installed
+    When I run `git town-repo`
+    Then I see the GitLab homepage of the "kadu/kadu" repository in my browser
+
+    Examples:
+      | ORIGIN                           |
+      | https://gitlab.com/kadu/kadu.git |
+      | git@gitlab.com:kadu/kadu.git     |

--- a/features/git-town-repo/unsupported_hosting_service.feature
+++ b/features/git-town-repo/unsupported_hosting_service.feature
@@ -6,4 +6,4 @@ Feature: git-repo when origin is unsupported
 
   Scenario: result
     Then I get the error "Unsupported hosting service"
-    And I get the error "This command requires hosting on GitHub, GitLab or Bitbucket"
+    And I get the error "This command requires hosting on GitHub, GitLab, or Bitbucket"

--- a/features/git-town-repo/unsupported_hosting_service.feature
+++ b/features/git-town-repo/unsupported_hosting_service.feature
@@ -6,4 +6,4 @@ Feature: git-repo when origin is unsupported
 
   Scenario: result
     Then I get the error "Unsupported hosting service"
-    And I get the error "This command requires hosting on GitHub or Bitbucket"
+    And I get the error "This command requires hosting on GitHub, GitLab or Bitbucket"

--- a/features/step_definitions/branch_configuration_steps.rb
+++ b/features/step_definitions/branch_configuration_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Given(/^Git Town is aware of this branch hierarchy$/) do |table|
   table.hashes.each do |row|
     set_parent_branch branch: row['BRANCH'], parent: row['PARENT']

--- a/features/step_definitions/branch_steps.rb
+++ b/features/step_definitions/branch_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Given(/^(I|my coworker) (?:am|is) on the "(.+?)" branch$/) do |who, branch_name|
   user = (who == 'I') ? :developer : :coworker
   in_repository user do

--- a/features/step_definitions/browser_steps.rb
+++ b/features/step_definitions/browser_steps.rb
@@ -10,6 +10,6 @@ Then(/^I see a new (.+?) pull request for the "([^"]+)" branch against the "(.+?
 end
 
 
-Then(/^I see the (Bitbucket|GitHub) homepage of the "(.+?)" repository in my browser$/) do |domain, repository|
+Then(/^I see the (Bitbucket|GitHub|GitLab) homepage of the "(.+?)" repository in my browser$/) do |domain, repository|
   expect(@last_run_result.out.strip).to eql "#{@tool} called with: #{repository_homepage_url domain, repository}"
 end

--- a/features/step_definitions/browser_steps.rb
+++ b/features/step_definitions/browser_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then(/^I see a new (.+?) pull request for the "([^"]+)" branch in the "(.+?)" repo in my browser$/) do |domain, branch, repo|
   url = pull_request_url domain: domain, branch: branch, repo: repo
   expect(@last_run_result.out.strip).to include "#{@tool} called with: #{url}"

--- a/features/step_definitions/changes_steps.rb
+++ b/features/step_definitions/changes_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then(/^there are no open changes$/) do
   expect(run('git status --short').out).to eql ''
 end

--- a/features/step_definitions/commit_steps.rb
+++ b/features/step_definitions/commit_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Given(/^the following commits? exists? in (my|my coworker's) repository( on another machine)?$/) do |who, remote, commits_table|
   user = (who == 'my') ? 'developer' : 'coworker'
   user += '_secondary' if remote

--- a/features/step_definitions/debug_steps.rb
+++ b/features/step_definitions/debug_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # These steps are for debugging purposes only.
 # Please keep them around.
 

--- a/features/step_definitions/environment_steps.rb
+++ b/features/step_definitions/environment_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Given(/^I'm currently not in a git repository$/) do
   FileUtils.rm_rf '.git'
 end

--- a/features/step_definitions/files_steps.rb
+++ b/features/step_definitions/files_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Given(/^my repo ignores files named "([^"]*)"$/) do |filename|
   create_local_commit branch: current_branch_name,
                       file_name: '.gitignore',

--- a/features/step_definitions/folder_steps.rb
+++ b/features/step_definitions/folder_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Given(/^I already have the Git autocompletion symlink$/) do
   FileUtils.mkdir_p File.dirname(FISH_AUTOCOMPLETIONS_PATH)
   FileUtils.symlink 'foo', FISH_AUTOCOMPLETIONS_PATH

--- a/features/step_definitions/merge_steps.rb
+++ b/features/step_definitions/merge_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then(/^my repo(?: still)? has a merge in progress$/) do
   expect(merge_in_progress?).to be_truthy
 end

--- a/features/step_definitions/rebase_steps.rb
+++ b/features/step_definitions/rebase_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Then(/^my repo (?:still )?has a rebase in progress$/) do
   expect(rebase_in_progress).to be_truthy
 end

--- a/features/step_definitions/remote_steps.rb
+++ b/features/step_definitions/remote_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Given(/^my repo has an upstream repo$/) do
   clone_repository :origin, :upstream, bare: true
   clone_repository :upstream, :upstream_developer

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 When(/^(I|my coworker) runs? `([^`]+)`$/) do |who, commands|
   user = (who == 'I') ? :developer : :coworker
   in_repository user do

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Given(/^I have the following tags$/) do |tags|
   tags.hashes.each do |tag|
     send "create_#{tag['LOCATION']}_tag", tag['NAME']

--- a/features/step_definitions/tool_steps.rb
+++ b/features/step_definitions/tool_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Given(/^I have "(.+?)" installed$/) do |tool|
   @tool = tool
   update_installed_tools [tool]

--- a/features/step_definitions/town_steps.rb
+++ b/features/step_definitions/town_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Given(/^I don't have a main branch name configured$/) do
   delete_main_branch_configuration
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Given(/^(I|my coworker) fetch(?:es)? updates$/) do |who|
   user = (who == 'I') ? :developer : :coworker
   in_repository user do

--- a/features/support/branch_configuration_helpers.rb
+++ b/features/support/branch_configuration_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Returns the branch hierarchy information that is currently configured in the current repository
 def configured_branch_hierarchy_information ignore_errors: false
   result = Mortadella::Horizontal.new headers: %w(BRANCH PARENT)

--- a/features/support/branch_helpers.rb
+++ b/features/support/branch_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Returns the branch name for the given location
 def branch_name_for_location location, branch
   case location

--- a/features/support/cherrypick_helpers.rb
+++ b/features/support/cherrypick_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 def cherrypick_in_progress
   output_of('git status').include? 'You are currently cherry-picking'
 end

--- a/features/support/commit_helpers.rb
+++ b/features/support/commit_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Returns the array of the file names committed for the supplied sha
 def committed_files sha
   array_output_of "git diff-tree --no-commit-id --name-only -r #{sha}"

--- a/features/support/commits_finder.rb
+++ b/features/support/commits_finder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Encapsulates finding Git commits in flexible ways
 #
 # After initializing with the desired attributes for the commit list,

--- a/features/support/commits_list.rb
+++ b/features/support/commits_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Encapsulates building up a list of commits
 #
 # Commit lists contain very specific data about commits.

--- a/features/support/configuration_helpers.rb
+++ b/features/support/configuration_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 def configure_git user
   run "git config user.name #{user}"
   run "git config user.email #{user}@example.com"

--- a/features/support/core_ext/hash.rb
+++ b/features/support/core_ext/hash.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Monkey patches to the Hash class that make testing easier
 class Hash
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support/all'
 require 'kappamaki'
 require 'mortadella'

--- a/features/support/files_helpers.rb
+++ b/features/support/files_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Returns the content of the file with the given name on the given branch
 def content_of file:, for_sha:
   result = output_of "git show #{for_sha}:#{file}"

--- a/features/support/folders_helpers.rb
+++ b/features/support/folders_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Returns the full path to the folder with the given name inside the current
 # Git workspace
 def git_folder folder_name

--- a/features/support/merge_helpers.rb
+++ b/features/support/merge_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 def merge_in_progress?
   output_of('git status').include? 'You have unmerged paths'
 end

--- a/features/support/rebase_helpers.rb
+++ b/features/support/rebase_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 def rebase_in_progress
   output_of('git status').include? 'You are currently rebasing'
 end

--- a/features/support/remote_helpers.rb
+++ b/features/support/remote_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'cgi'
 
 

--- a/features/support/remote_helpers.rb
+++ b/features/support/remote_helpers.rb
@@ -6,6 +6,7 @@ def base_url domain
   case domain
   when 'Bitbucket' then 'https://bitbucket.org'
   when 'GitHub' then 'https://github.com'
+  when 'GitLab' then 'https://gitlab.com'
   else fail "Unknown domain: #{domain}"
   end
 end
@@ -24,6 +25,12 @@ end
 def github_pull_request_url branch:, parent_branch: nil, repo:
   to_compare = parent_branch ? "#{parent_branch}...#{branch}" : branch
   "https://github.com/#{repo}/compare/#{to_compare}?expand=1"
+end
+
+# Returns the URL for making pull requests on GitLab
+def gitlab_pull_request_url branch:, parent_branch: nil, repo:
+  to_compare = parent_branch ? "#{parent_branch}...#{branch}" : branch
+  "https://gitlab.com/#{repo}/compare/#{to_compare}?expand=1"
 end
 
 

--- a/features/support/repository_helpers.rb
+++ b/features/support/repository_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Execute the block at the given path
 def at_path path
   cwd = Dir.pwd

--- a/features/support/rspec_helpers.rb
+++ b/features/support/rspec_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 def commits_diff actual, expected
   out = ''
 

--- a/features/support/run_helpers.rb
+++ b/features/support/run_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 def array_output_of command, ignore_errors: false
   output_of(command, ignore_errors: ignore_errors).split("\n").map(&:strip)
 end

--- a/features/support/stash_helpers.rb
+++ b/features/support/stash_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Returns the number of unpopped stashes
 def stash_size
   integer_output_of 'git stash list | wc -l'

--- a/features/support/tag_finder.rb
+++ b/features/support/tag_finder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Finds Git tags, returns them as TagList instances
 class TagFinder
 

--- a/features/support/tag_helpers.rb
+++ b/features/support/tag_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Creates a tag with the given name in the local repo
 def create_local_tag tag_name
   run "git tag -a #{tag_name} -m '#{tag_name}'"

--- a/features/support/tag_list.rb
+++ b/features/support/tag_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Represents a sorted list of Git tags and their locations
 class TagList
 

--- a/features/support/tool_helpers.rb
+++ b/features/support/tool_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Configures the test environment to assume only the given set of tools are installed
 def update_installed_tools tools
   File.open(TOOLS_INSTALLED_FILENAME, 'w') do |file|

--- a/features/support/town_helpers.rb
+++ b/features/support/town_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 def add_perennial_branch branch
   old_value = perennial_branch_configuration
   new_value = [old_value, branch].reject(&:blank?).join(' ')

--- a/src/drivers/code_hosting/activate.sh
+++ b/src/drivers/code_hosting/activate.sh
@@ -25,7 +25,7 @@ function activate_driver_for_code_hosting {
   else
     echo_error_header
     echo_usage "Unsupported hosting service."
-    echo_usage 'This command requires hosting on GitHub, GitLab or Bitbucket.'
+    echo_usage 'This command requires hosting on GitHub, GitLab, or Bitbucket.'
     exit_with_error newline
   fi
 }

--- a/src/drivers/code_hosting/activate.sh
+++ b/src/drivers/code_hosting/activate.sh
@@ -14,14 +14,18 @@ function activate_driver_for_code_hosting {
     activate_driver 'code_hosting' 'github'
   elif [ "$origin_hostname" == 'bitbucket.org' ]; then
     activate_driver 'code_hosting' 'bitbucket'
+  elif [ "$origin_hostname" == 'gitlab.com' ]; then
+    activate_driver 'code_hosting' 'gitlab'
   elif [ "$(contains_string "$origin_hostname" github)" == true ]; then
     activate_driver 'code_hosting' 'github'
   elif [ "$(contains_string "$origin_hostname" bitbucket)" == true ]; then
     activate_driver 'code_hosting' 'bitbucket'
+  elif [ "$(contains_string "$origin_hostname" gitlab)" == true ]; then
+    activate_driver 'code_hosting' 'gitlab'
   else
     echo_error_header
     echo_usage "Unsupported hosting service."
-    echo_usage 'This command requires hosting on GitHub or Bitbucket.'
+    echo_usage 'This command requires hosting on GitHub, GitLab or Bitbucket.'
     exit_with_error newline
   fi
 }

--- a/src/drivers/code_hosting/gitlab.sh
+++ b/src/drivers/code_hosting/gitlab.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+
+function create_pull_request {
+  local repository=$1
+  local branch=$2
+  local parent_branch=$3
+
+  local to_compare;
+  if [ "$parent_branch" = "$MAIN_BRANCH_NAME" ]; then
+    # Allow Github to redirect to the proper place if this repository is a fork
+    to_compare="$branch"
+  else
+    to_compare="$parent_branch...$branch"
+  fi
+
+  open_browser "https://gitlab.com/$repository/compare/$to_compare?expand=1"
+}
+
+
+function show_repo {
+  local repository=$1
+
+  open_browser "https://gitlab.com/$repository"
+}

--- a/src/drivers/code_hosting/gitlab.sh
+++ b/src/drivers/code_hosting/gitlab.sh
@@ -6,9 +6,9 @@ function create_pull_request {
   local branch=$2
   local parent_branch=$3
 
-  local to_compare;
+  local to_compare
   if [ "$parent_branch" = "$MAIN_BRANCH_NAME" ]; then
-    # Allow Github to redirect to the proper place if this repository is a fork
+    # Allow GitLab to redirect to the proper place if this repository is a fork
     to_compare="$branch"
   else
     to_compare="$parent_branch...$branch"


### PR DESCRIPTION
This pull request contains one working cucumber test for gitlab. It's a start to satisfy #742 

This pull request does fail the full rake tests but it does pass the gitlab feature tests.

I'd be interested in getting support so that all tests pass.

diff --git a/features/git-town-repo/gitlab.feature b/features/git-town-repo/gitlab.feature
new file mode 100644
index 0000000..353e9ca
--- /dev/null
+++ b/features/git-town-repo/gitlab.feature
@@ -0,0 +1,12 @@
+Feature: git-repo when origin is on GitLab
+
+  Scenario Outline: result
+    Given my remote origin is <ORIGIN>
+    And I have "open" installed
+    When I run `git town-repo`
+    Then I see the GitLab homepage of the "kadu/kadu" repository in my browser
+
+    Examples:
+      | ORIGIN                           |
+      | https://gitlab.com/kadu/kadu.git |
+      | git@gitlab.com:kadu/kadu.git     |
diff --git a/features/step_definitions/browser_steps.rb b/features/step_definitions/browser_steps.rb
index 0e7195e..3995fb4 100644
--- a/features/step_definitions/browser_steps.rb
+++ b/features/step_definitions/browser_steps.rb
@@ -10,6 +10,6 @@ Then(/^I see a new (.+?) pull request for the "([^"]+)" branch against the "(.+?
 end

-Then(/^I see the (Bitbucket|GitHub) homepage of the "(.+?)" repository in my browser$/) do |domain, repository|
+Then(/^I see the (Bitbucket|GitHub|GitLab) homepage of the "(.+?)" repository in my browser$/) do |domain, repository|
   expect(@last_run_result.out.strip).to eql "#{@tool} called with: #{repository_homepage_url domain, repository}"
 end
diff --git a/features/support/remote_helpers.rb b/features/support/remote_helpers.rb
index 1a15253..1ffd2c9 100644
--- a/features/support/remote_helpers.rb
+++ b/features/support/remote_helpers.rb
@@ -6,6 +6,7 @@ def base_url domain
   case domain
   when 'Bitbucket' then 'https://bitbucket.org'
   when 'GitHub' then 'https://github.com'
+  when 'GitLab' then 'https://gitlab.com'
   else fail "Unknown domain: #{domain}"
   end
 end
@@ -26,6 +27,12 @@ def github_pull_request_url branch:, parent_branch: nil, repo:
   "https://github.com/#{repo}/compare/#{to_compare}?expand=1"
 end

+# Returns the URL for making pull requests on GitLab
+def gitlab_pull_request_url branch:, parent_branch: nil, repo:
+  to_compare = parent_branch ? "#{parent_branch}...#{branch}" : branch
+  "https://gitlab.com/#{repo}/compare/#{to_compare}?expand=1"
+end
+

 # Returns the remote URL for a new pull request for the given domain and branch
 def pull_request_url domain:, branch:, parent_branch: nil, repo:
diff --git a/src/drivers/code_hosting/activate.sh b/src/drivers/code_hosting/activate.sh
index fc09a8f..cccfc90 100644
--- a/src/drivers/code_hosting/activate.sh
+++ b/src/drivers/code_hosting/activate.sh
@@ -14,14 +14,18 @@ function activate_driver_for_code_hosting {
     activate_driver 'code_hosting' 'github'
   elif [ "$origin_hostname" == 'bitbucket.org' ]; then
     activate_driver 'code_hosting' 'bitbucket'
+  elif [ "$origin_hostname" == 'gitlab.com' ]; then
+    activate_driver 'code_hosting' 'gitlab'
   elif [ "$(contains_string "$origin_hostname" github)" == true ]; then
     activate_driver 'code_hosting' 'github'
   elif [ "$(contains_string "$origin_hostname" bitbucket)" == true ]; then
     activate_driver 'code_hosting' 'bitbucket'
+  elif [ "$(contains_string "$origin_hostname" gitlab)" == true ]; then
+    activate_driver 'code_hosting' 'gitlab'
   else
     echo_error_header
     echo_usage "Unsupported hosting service."
-    echo_usage 'This command requires hosting on GitHub or Bitbucket.'
+    echo_usage 'This command requires hosting on GitHub, GitLab or Bitbucket.'
     exit_with_error newline
   fi
 }
diff --git a/src/drivers/code_hosting/gitlab.sh b/src/drivers/code_hosting/gitlab.sh
new file mode 100644
index 0000000..20f5cfd
--- /dev/null
+++ b/src/drivers/code_hosting/gitlab.sh
@@ -0,0 +1,25 @@
+#!/usr/bin/env bash
+
+
+function create_pull_request {
+  local repository=$1
+  local branch=$2
+  local parent_branch=$3
+
+  local to_compare;
+  if [ "$parent_branch" = "$MAIN_BRANCH_NAME" ]; then
+    # Allow Github to redirect to the proper place if this repository is a fork
+    to_compare="$branch"
+  else
+    to_compare="$parent_branch...$branch"
+  fi
+
+  open_browser "https://gitlab.com/$repository/compare/$to_compare?expand=1"
+}
+
+
+function show_repo {
+  local repository=$1
+
+  open_browser "https://gitlab.com/$repository"
+}