### PR TITLE
fix git town-repo for ssh repo url

### DIFF
--- a/features/git-town-new-pull-request/bitbucket.feature
+++ b/features/git-town-new-pull-request/bitbucket.feature
@@ -28,3 +28,5 @@ Feature: git-new-pull-request when origin is on Bitbucket
       | https://username@bitbucket.org/Originate/originate.github.com     | Originate/originate.github.com |
       | git@bitbucket.org/Originate/originate.github.com.git              | Originate/originate.github.com |
       | git@bitbucket.org/Originate/originate.github.com                  | Originate/originate.github.com |
+      | ssh://git@bitbucket.org/Originate/git-town.git                    | Originate/git-town             |
+      | ssh://git@bitbucket.org/Originate/git-town                        | Originate/git-town             |

--- a/features/git-town-new-pull-request/github.feature
+++ b/features/git-town-new-pull-request/github.feature
@@ -31,6 +31,8 @@ Feature: git-new-pull-request when origin is on GitHub
       | https://github.com/Originate/originate.github.com     | Originate/originate.github.com |
       | git@github.com:Originate/originate.github.com.git     | Originate/originate.github.com |
       | git@github.com:Originate/originate.github.com         | Originate/originate.github.com |
+      | ssh://git@github.com/Originate/git-town.git           | Originate/git-town             |
+      | ssh://git@github.com/Originate/git-town               | Originate/git-town             |
 
 
   Scenario: nested feature branch with known parent

--- a/features/git-town-repo/bitbucket.feature
+++ b/features/git-town-repo/bitbucket.feature
@@ -14,4 +14,5 @@ Feature: git-repo when origin is on Bitbucket
       | https://username@bitbucket.org/Originate/git-town     |
       | git@bitbucket.org/Originate/git-town.git              |
       | git@bitbucket.org/Originate/git-town                  |
+      | ssh://git@bitbucket.org/Originate/git-town.git        |
       | ssh://git@bitbucket.org/Originate/git-town            |

--- a/features/git-town-repo/bitbucket.feature
+++ b/features/git-town-repo/bitbucket.feature
@@ -14,3 +14,4 @@ Feature: git-repo when origin is on Bitbucket
       | https://username@bitbucket.org/Originate/git-town     |
       | git@bitbucket.org/Originate/git-town.git              |
       | git@bitbucket.org/Originate/git-town                  |
+      | ssh://git@bitbucket.org/Originate/git-town            |

--- a/features/git-town-repo/github.feature
+++ b/features/git-town-repo/github.feature
@@ -7,11 +7,12 @@ Feature: git-repo when origin is on GitHub
     Then I see the GitHub homepage of the "Originate/git-town" repository in my browser
 
     Examples:
-      | ORIGIN                                    |
-      | http://github.com/Originate/git-town.git  |
-      | http://github.com/Originate/git-town      |
-      | https://github.com/Originate/git-town.git |
-      | https://github.com/Originate/git-town     |
-      | git@github.com:Originate/git-town.git     |
-      | git@github.com:Originate/git-town         |
-      | ssh://git@github.com/Originate/git-town   |
+      | ORIGIN                                      |
+      | http://github.com/Originate/git-town.git    |
+      | http://github.com/Originate/git-town        |
+      | https://github.com/Originate/git-town.git   |
+      | https://github.com/Originate/git-town       |
+      | git@github.com:Originate/git-town.git       |
+      | git@github.com:Originate/git-town           |
+      | ssh://git@github.com/Originate/git-town.git |
+      | ssh://git@github.com/Originate/git-town     |

--- a/features/git-town-repo/github.feature
+++ b/features/git-town-repo/github.feature
@@ -14,3 +14,4 @@ Feature: git-repo when origin is on GitHub
       | https://github.com/Originate/git-town     |
       | git@github.com:Originate/git-town.git     |
       | git@github.com:Originate/git-town         |
+      | ssh://git@github.com/Originate/git-town   |

--- a/src/helpers/git_helpers/remote_helpers.sh
+++ b/src/helpers/git_helpers/remote_helpers.sh
@@ -16,14 +16,14 @@ function remote_url {
 
 # Returns the domain of the remote repository
 function remote_domain {
-  remote_url | sed -E "s#(https?://([^@]*@)?|git@)([^/:]+).*#\3#"
+  remote_url | sed -E "s#(^[^:]*://([^@]*@)?|git@)([^/:]+).*#\3#"
 }
 
 
 # Returns the USER/REPO for the remote repository
 function remote_repository_name {
   local domain=$(remote_domain)
-  remote_url | sed -E "s#.*$domain[/:](.+)#\1#" | sed "s/\.git$//" | sed 's#ssh://git@[^/]*/##'
+  remote_url | sed -E "s#.*$domain[/:](.+)#\1#" | sed "s/\.git$//"
 }
 
 

--- a/src/helpers/git_helpers/remote_helpers.sh
+++ b/src/helpers/git_helpers/remote_helpers.sh
@@ -23,7 +23,7 @@ function remote_domain {
 # Returns the USER/REPO for the remote repository
 function remote_repository_name {
   local domain=$(remote_domain)
-  remote_url | sed -E "s#.*$domain[/:](.+)#\1#" | sed "s/\.git$//"
+  remote_url | sed -E "s#.*$domain[/:](.+)#\1#" | sed "s/\.git$//" | sed 's#ssh://git@[^/]*/##'
 }
 
 


### PR DESCRIPTION
Hi

when I use ssh protocal in repo url, like 
 
$ git config --local --list
remote.origin.url=ssh://git@github.com/[some-org]/[some-repo.git]
OR
remote.origin.url=ssh://git@bitbucket.org/[some-org]/[some-repo.git]

$ git repo  # will open browser and go to the next url.

https://github.com/ssh://git@github.com/[some-org]/[some-repo]
https://bitbucket.org/ssh://git@bitbucket.org/[some-org]/[some-repo]

This PR will fix this problem.
