### PR TITLE
remove duplicate output

### DIFF
--- a/src/prompt/config.go
+++ b/src/prompt/config.go
@@ -12,8 +12,6 @@ import (
 // EnsureIsConfigured has the user to confgure the main branch and perennial branches if needed
 func EnsureIsConfigured() {
 	if git.GetMainBranch() == "" {
-		fmt.Println("Git Town needs to be configured")
-		fmt.Println()
 		ConfigureMainBranch()
 		ConfigurePerennialBranches()
 	}


### PR DESCRIPTION
resolves #887

This gets written in as part of the configuration header which gets printed when calling `ConfigureMainBranch` or `ConfigurePerennialBranches`. We already have a feature test that this line gets written. I don't think its worth writing a test that this doesn't get output twice.