### PR TITLE
allow alias to be run in non-git directory

### DIFF
--- a/features/git-town/alias.feature
+++ b/features/git-town/alias.feature
@@ -47,3 +47,8 @@ Feature: git town: alias
       Usage:
         git-town alias (true | false) [flags]
       """
+
+  Scenario: works outside of a Git repository
+    Given I'm currently not in a git repository
+    When I run `git-town alias true`
+    Then I don't see "Not a git repository"

--- a/features/git-town/alias.feature
+++ b/features/git-town/alias.feature
@@ -48,6 +48,7 @@ Feature: git town: alias
         git-town alias (true | false) [flags]
       """
 
+
   Scenario: works outside of a Git repository
     Given I'm currently not in a git repository
     When I run `git-town alias true`

--- a/src/git/environment.go
+++ b/src/git/environment.go
@@ -4,12 +4,11 @@ import "github.com/Originate/git-town/src/util"
 
 // EnsureIsRepository asserts that the current directory is in a repository
 func EnsureIsRepository() {
-	util.Ensure(isRepository(), "This is not a Git repository.")
+	util.Ensure(IsRepository(), "This is not a Git repository.")
 }
 
-// Helpers
-
-func isRepository() bool {
+// IsRepository returns whether or not the current directory is in a repository
+func IsRepository() bool {
 	_, err := util.GetFullCommandOutput("git", "rev-parse")
 	return err == nil
 }

--- a/src/script/script.go
+++ b/src/script/script.go
@@ -34,7 +34,7 @@ func PrintCommand(cmd ...string) {
 		}
 		header = header + part
 	}
-	if strings.HasPrefix(header, "git") {
+	if strings.HasPrefix(header, "git") && git.IsRepository() {
 		header = fmt.Sprintf("[%s] %s", git.GetCurrentBranchName(), header)
 	}
 	fmt.Println()


### PR DESCRIPTION
resolves #853

Was erring when trying to print out the branch name (which was previously being printed anytime we ran a git command)