### PR TITLE
fix prompt for parent branch bug

### DIFF
--- a/src/git/config.go
+++ b/src/git/config.go
@@ -29,11 +29,11 @@ func AddToPerennialBranches(branchName string) {
 func CompileAncestorBranches(branchName string) (result []string) {
 	current := branchName
 	for {
-		parent := GetParentBranch(current)
-		result = append([]string{parent}, result...)
-		if IsMainBranch(parent) || IsPerennialBranch(parent) {
+		if IsMainBranch(current) || IsPerennialBranch(current) {
 			return
 		}
+		parent := GetParentBranch(current)
+		result = append([]string{parent}, result...)
 		current = parent
 	}
 }
@@ -102,7 +102,11 @@ func GetParentBranch(branchName string) string {
 
 // GetPerennialBranches returns all branches that are marked as perennial.
 func GetPerennialBranches() []string {
-	return strings.Split(getConfigurationValue("git-town.perennial-branch-names"), " ")
+	result := getConfigurationValue("git-town.perennial-branch-names")
+	if result == "" {
+		return []string{}
+	}
+	return strings.Split(result, " ")
 }
 
 // GetPullBranchStrategy returns the currently configured pull branch strategy.

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -21,11 +21,8 @@ func AddToPerennialBranches(branchName string) {
 	SetPerennialBranches(append(GetPerennialBranches(), branchName))
 }
 
-// CompileAncestorBranches re-calculates and returns the list of ancestor branches
-// of the given branch
-// based off the "git-town-branch.XXX.ancestors" configuration values.
-// The result starts with but does not include the perennial branch
-// from which this branch hierarchy was cut initially.
+// CompileAncestorBranches calculates and returns the list of ancestor branches
+// of the given branch based off the "git-town-branch.XXX.parent" configuration values.
 func CompileAncestorBranches(branchName string) (result []string) {
 	current := branchName
 	for {
@@ -33,10 +30,10 @@ func CompileAncestorBranches(branchName string) (result []string) {
 			return
 		}
 		parent := GetParentBranch(current)
-		result = append([]string{parent}, result...)
-		if parent == current {
-			log.Fatal(fmt.Sprintf("Infinite loop in CompileAncestorBranches with input: %s", branchName))
+		if parent == "" {
+			return
 		}
+		result = append([]string{parent}, result...)
 		current = parent
 	}
 }

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -34,6 +34,9 @@ func CompileAncestorBranches(branchName string) (result []string) {
 		}
 		parent := GetParentBranch(current)
 		result = append([]string{parent}, result...)
+		if parent == current {
+			log.Fatal(fmt.Sprintf("Infinite loop in CompileAncestorBranches with input: %s", branchName))
+		}
 		current = parent
 	}
 }

--- a/src/prompt/branch_helpers.go
+++ b/src/prompt/branch_helpers.go
@@ -15,6 +15,7 @@ import (
 type branchPromptConfig struct {
 	branchNames []string
 	prompt      string
+	transform   func(branchName string) string
 	validate    func(branchName string) error
 }
 
@@ -23,6 +24,7 @@ func askForBranch(config branchPromptConfig) string {
 		fmt.Print(config.prompt)
 		branchName, err := parseBranch(config, util.GetUserInput())
 		if err == nil {
+			branchName = config.transform(branchName)
 			err = config.validate(branchName)
 			if err == nil {
 				return branchName

--- a/src/prompt/branch_helpers.go
+++ b/src/prompt/branch_helpers.go
@@ -13,10 +13,10 @@ import (
 )
 
 type branchPromptConfig struct {
-	branchNames []string
-	prompt      string
-	transform   func(branchName string) string
-	validate    func(branchName string) error
+	branchNames       []string
+	defaultBranchName string
+	prompt            string
+	validate          func(branchName string) error
 }
 
 func askForBranch(config branchPromptConfig) string {
@@ -24,7 +24,6 @@ func askForBranch(config branchPromptConfig) string {
 		fmt.Print(config.prompt)
 		branchName, err := parseBranch(config, util.GetUserInput())
 		if err == nil {
-			branchName = config.transform(branchName)
 			err = config.validate(branchName)
 			if err == nil {
 				return branchName
@@ -44,7 +43,7 @@ func parseBranch(config branchPromptConfig, userInput string) (string, error) {
 		return parseBranchNumber(config.branchNames, userInput)
 	}
 	if userInput == "" {
-		return "", nil
+		return config.defaultBranchName, nil
 	}
 	if git.HasBranch(userInput) {
 		return userInput, nil

--- a/src/prompt/config.go
+++ b/src/prompt/config.go
@@ -21,11 +21,9 @@ func EnsureIsConfigured() {
 func ConfigureMainBranch() {
 	printConfigurationHeader()
 	newMainBranch := askForBranch(branchPromptConfig{
-		branchNames: git.GetLocalBranches(),
-		prompt:      getMainBranchPrompt(),
-		transform: func(branchName string) string {
-			return branchName
-		},
+		branchNames:       git.GetLocalBranches(),
+		defaultBranchName: "",
+		prompt:            getMainBranchPrompt(),
 		validate: func(branchName string) error {
 			if branchName == "" {
 				return errors.New("A main development branch is required to enable the features provided by Git Town")
@@ -42,11 +40,9 @@ func ConfigurePerennialBranches() {
 	var newPerennialBranches []string
 	for {
 		newPerennialBranch := askForBranch(branchPromptConfig{
-			branchNames: git.GetLocalBranches(),
-			prompt:      getPerennialBranchesPrompt(),
-			transform: func(branchName string) string {
-				return branchName
-			},
+			branchNames:       git.GetLocalBranches(),
+			defaultBranchName: "",
+			prompt:            getPerennialBranchesPrompt(),
 			validate: func(branchName string) error {
 				if branchName == git.GetMainBranch() {
 					return fmt.Errorf("'%s' is already set as the main branch", branchName)

--- a/src/prompt/config.go
+++ b/src/prompt/config.go
@@ -44,6 +44,9 @@ func ConfigurePerennialBranches() {
 		newPerennialBranch := askForBranch(branchPromptConfig{
 			branchNames: git.GetLocalBranches(),
 			prompt:      getPerennialBranchesPrompt(),
+			transform: func(branchName string) string {
+				return branchName
+			},
 			validate: func(branchName string) error {
 				if branchName == git.GetMainBranch() {
 					return fmt.Errorf("'%s' is already set as the main branch", branchName)

--- a/src/prompt/config.go
+++ b/src/prompt/config.go
@@ -23,6 +23,9 @@ func ConfigureMainBranch() {
 	newMainBranch := askForBranch(branchPromptConfig{
 		branchNames: git.GetLocalBranches(),
 		prompt:      getMainBranchPrompt(),
+		transform: func(branchName string) string {
+			return branchName
+		},
 		validate: func(branchName string) error {
 			if branchName == "" {
 				return errors.New("A main development branch is required to enable the features provided by Git Town")

--- a/src/prompt/parent_branches.go
+++ b/src/prompt/parent_branches.go
@@ -45,14 +45,9 @@ func askForBranchAncestry(branchName string) {
 		if parent == "" {
 			printParentBranchHeader()
 			parent = askForBranch(branchPromptConfig{
-				branchNames: git.GetLocalBranchesWithMainBranchFirst(),
-				prompt:      getParentBranchPrompt(current),
-				transform: func(branchName string) string {
-					if branchName == "" {
-						return git.GetMainBranch()
-					}
-					return branchName
-				},
+				branchNames:       git.GetLocalBranchesWithMainBranchFirst(),
+				defaultBranchName: git.GetMainBranch(),
+				prompt:            getParentBranchPrompt(current),
 				validate: func(branchName string) error {
 					return validateParentBranch(current, branchName)
 				},

--- a/src/prompt/parent_branches.go
+++ b/src/prompt/parent_branches.go
@@ -47,13 +47,16 @@ func askForBranchAncestry(branchName string) {
 			parent = askForBranch(branchPromptConfig{
 				branchNames: git.GetLocalBranchesWithMainBranchFirst(),
 				prompt:      getParentBranchPrompt(current),
+				transform: func(branchName string) string {
+					if branchName == "" {
+						return git.GetMainBranch()
+					}
+					return branchName
+				},
 				validate: func(branchName string) error {
 					return validateParentBranch(current, branchName)
 				},
 			})
-			if parent == "" {
-				parent = git.GetMainBranch()
-			}
 			git.SetParentBranch(current, parent)
 		}
 		if parent == git.GetMainBranch() || git.IsPerennialBranch(parent) {


### PR DESCRIPTION
First we had a bug in the code for getting perennial branches where `""` would be considered a perennial branch if none were configured. This was why our tests didn't catch this at first. 

Adding that in caused one test to go into an infinite loop as it tried to calculate the ancestor branches for `""`. I added the `defaultBranchName` function to `branchPromptConfig` in order to prevent us from asking for ancestor branches of `""`.

Then we still had a bug as asking for the ancestor branch of the main branch caused an infinite loop. Fixed that by moving the check to the beginning of the loop.