### PR TITLE
fix prompt spacing

### DIFF
--- a/src/prompt/config.go
+++ b/src/prompt/config.go
@@ -69,7 +69,7 @@ func getMainBranchPrompt() (result string) {
 		coloredBranchName := color.New(color.Bold).Add(color.FgCyan).Sprintf(currentMainBranch)
 		result += fmt.Sprintf(" (current value: %s)", coloredBranchName)
 	}
-	result += ":"
+	result += ": "
 	return
 }
 
@@ -80,7 +80,7 @@ func getPerennialBranchesPrompt() (result string) {
 		coloredBranchNames := color.New(color.Bold).Add(color.FgCyan).Sprintf(strings.Join(currentPerennialBranches, ", "))
 		result += fmt.Sprintf(" (current value: %s)", coloredBranchNames)
 	}
-	result += ":"
+	result += ": "
 	return
 }
 


### PR DESCRIPTION
A couple of the prompts didn't have a space after and thus the cursor started right next to the colon.