### PR TITLE
Better separation between single and multi line error check

### DIFF
--- a/features/git-town-hack/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-hack/main_branch_rebase_tracking_branch_conflict.feature
@@ -24,7 +24,7 @@ Feature: git town-hack: resolving conflicts between main branch and its tracking
       |                  | git stash              |
       |                  | git checkout main      |
       | main             | git rebase origin/main |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town hack --abort".
       To continue after you have resolved the conflicts, run "git-town hack --continue".

--- a/features/git-town-hack/no_branch_name.feature
+++ b/features/git-town-hack/no_branch_name.feature
@@ -15,7 +15,7 @@ Feature: git town-hack: requires a branch name
   Scenario: result
     Then it runs no commands
     And I get the error "no branch name provided"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town hack <branch> [flags]

--- a/features/git-town-new-pull-request/conflict.feature
+++ b/features/git-town-new-pull-request/conflict.feature
@@ -30,7 +30,7 @@ Feature: Syncing before creating the pull request
       |         | git checkout feature               |
       | feature | git merge --no-edit origin/feature |
       |         | git merge --no-edit main           |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town new-pull-request --abort".
       To continue after you have resolved the conflicts, run "git-town new-pull-request --continue".

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/feature_branch_merge_main_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/feature_branch_merge_main_branch_conflict.feature
@@ -25,7 +25,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       |         | git checkout feature               |
       | feature | git merge --no-edit origin/feature |
       |         | git merge --no-edit main           |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town ship --abort".
       To continue after you have resolved the conflicts, run "git-town ship --continue".

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/feature_branch_merge_tracking_branch_conflict.feature
@@ -23,7 +23,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | main    | git rebase origin/main             |
       |         | git checkout feature               |
       | feature | git merge --no-edit origin/feature |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town ship --abort".
       To continue after you have resolved the conflicts, run "git-town ship --continue".

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/main_branch_rebase_tracking_branch_conflict.feature
@@ -22,7 +22,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       | feature | git fetch --prune      |
       |         | git checkout main      |
       | main    | git rebase origin/main |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town ship --abort".
       To continue after you have resolved the conflicts, run "git-town ship --continue".

--- a/features/git-town-ship/supplied_branch/feature_branch/feature_branch_merge_main_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/feature_branch_merge_main_branch_conflict.feature
@@ -26,7 +26,7 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
       |               | git checkout feature               |
       | feature       | git merge --no-edit origin/feature |
       |               | git merge --no-edit main           |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town ship --abort".
       To continue after you have resolved the conflicts, run "git-town ship --continue".

--- a/features/git-town-ship/supplied_branch/feature_branch/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/feature_branch_merge_tracking_branch_conflict.feature
@@ -24,7 +24,7 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
       | main          | git rebase origin/main             |
       |               | git checkout feature               |
       | feature       | git merge --no-edit origin/feature |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town ship --abort".
       To continue after you have resolved the conflicts, run "git-town ship --continue".

--- a/features/git-town-ship/supplied_branch/feature_branch/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/main_branch_rebase_tracking_branch_conflict.feature
@@ -23,7 +23,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       |               | git stash              |
       |               | git checkout main      |
       | main          | git rebase origin/main |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town ship --abort".
       To continue after you have resolved the conflicts, run "git-town ship --continue".

--- a/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/first_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/first_branch.feature
@@ -23,7 +23,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git checkout feature-1               |
       | feature-1 | git merge --no-edit origin/feature-1 |
       |           | git merge --no-edit main             |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/last_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/last_branch.feature
@@ -27,7 +27,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git checkout feature-2               |
       | feature-2 | git merge --no-edit origin/feature-2 |
       |           | git merge --no-edit main             |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
@@ -20,7 +20,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash                |
       |           | git checkout feature-1   |
       | feature-1 | git merge --no-edit main |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
@@ -22,7 +22,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-1 | git merge --no-edit main |
       |           | git checkout feature-2   |
       | feature-2 | git merge --no-edit main |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/first_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/first_branch.feature
@@ -22,7 +22,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git checkout feature-1               |
       | feature-1 | git merge --no-edit origin/feature-1 |
       |           | git merge --no-edit main             |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/last_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/last_branch.feature
@@ -26,7 +26,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git checkout feature-2               |
       | feature-2 | git merge --no-edit origin/feature-2 |
       |           | git merge --no-edit main             |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/all_branches/feature_branch_merge_tracking_branch_conflict/first_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_tracking_branch_conflict/first_branch.feature
@@ -22,7 +22,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git rebase origin/main               |
       |           | git checkout feature-1               |
       | feature-1 | git merge --no-edit origin/feature-1 |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/all_branches/feature_branch_merge_tracking_branch_conflict/last_branch.feature
+++ b/features/git-town-sync/all_branches/feature_branch_merge_tracking_branch_conflict/last_branch.feature
@@ -26,7 +26,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git push                             |
       |           | git checkout feature-2               |
       | feature-2 | git merge --no-edit origin/feature-2 |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/all_branches/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/all_branches/main_branch_rebase_tracking_branch_conflict.feature
@@ -19,7 +19,7 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
       |        | git add -A             |
       |        | git stash              |
       |        | git rebase origin/main |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/all_branches/perennial_branch_rebase_tracking_branch_conflict/first_branch.feature
+++ b/features/git-town-sync/all_branches/perennial_branch_rebase_tracking_branch_conflict/first_branch.feature
@@ -23,7 +23,7 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       |            | git rebase origin/main       |
       |            | git checkout production      |
       | production | git rebase origin/production |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/all_branches/perennial_branch_rebase_tracking_branch_conflict/last_branch.feature
+++ b/features/git-town-sync/all_branches/perennial_branch_rebase_tracking_branch_conflict/last_branch.feature
@@ -25,7 +25,7 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       | production | git rebase origin/production |
       |            | git checkout qa              |
       | qa         | git rebase origin/qa         |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
+++ b/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
@@ -24,7 +24,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git checkout feature               |
       | feature | git merge --no-edit origin/feature |
       |         | git merge --no-edit main           |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
@@ -18,7 +18,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       | feature | git add -A               |
       |         | git stash                |
       |         | git merge --no-edit main |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
+++ b/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
@@ -23,7 +23,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git checkout feature               |
       | feature | git merge --no-edit origin/feature |
       |         | git merge --no-edit main           |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/feature_branch/feature_branch_merge_tracking_branch_conflict.feature
@@ -26,7 +26,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       | main    | git rebase origin/main             |
       |         | git checkout feature               |
       | feature | git merge --no-edit origin/feature |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/current_branch/feature_branch/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/feature_branch/main_branch_rebase_tracking_branch_conflict.feature
@@ -24,7 +24,7 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
       |         | git stash              |
       |         | git checkout main      |
       | main    | git rebase origin/main |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/current_branch/main_branch/rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/main_branch/rebase_tracking_branch_conflict.feature
@@ -22,7 +22,7 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
       |        | git add -A             |
       |        | git stash              |
       |        | git rebase origin/main |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town-sync/current_branch/perennial_branch/rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/rebase_tracking_branch_conflict.feature
@@ -23,7 +23,7 @@ Feature: git-town sync: resolving conflicts between the current perennial branch
       |        | git add -A           |
       |        | git stash            |
       |        | git rebase origin/qa |
-    And I get the error
+    And I get the error:
       """
       To abort, run "git-town sync --abort".
       To continue after you have resolved the conflicts, run "git-town sync --continue".

--- a/features/git-town/alias.feature
+++ b/features/git-town/alias.feature
@@ -42,7 +42,7 @@ Feature: git town: alias
   Scenario: invalid value
     When I run `git-town alias other`
     Then I get the error "Invalid value: 'other'"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town alias (true | false) [flags]

--- a/features/git-town/configuration/hack_push_flag/update.feature
+++ b/features/git-town/configuration/hack_push_flag/update.feature
@@ -18,7 +18,7 @@ Feature: set the hack-push flag
   Scenario: invalid flag
     When I run `git-town hack-push-flag woof`
     Then I get the error "Invalid value: 'woof'"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town hack-push-flag [(true | false)] [flags]

--- a/features/git-town/configuration/perennial_branches/add_branch.feature
+++ b/features/git-town/configuration/perennial_branches/add_branch.feature
@@ -35,7 +35,7 @@ Feature: add a branch to the perennial branches configuration
   Scenario: not providing a branch name
     When I run `git-town perennial-branches --add`
     Then I get the error "Error: flag needs an argument: --add"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town perennial-branches [flags]

--- a/features/git-town/configuration/perennial_branches/invalid_option.feature
+++ b/features/git-town/configuration/perennial_branches/invalid_option.feature
@@ -8,7 +8,7 @@ Feature: passing an invalid option to the perennial branch configuration
   Scenario: using invalid option
     When I run `git-town perennial-branches --invalid-option`
     Then I get the error "Error: unknown flag: --invalid-option"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town perennial-branches [flags]

--- a/features/git-town/configuration/perennial_branches/remove_branch.feature
+++ b/features/git-town/configuration/perennial_branches/remove_branch.feature
@@ -23,7 +23,7 @@ Feature: remove a branch from the perennial branches configuration
   Scenario: not providing a branch name
     When I run `git-town perennial-branches --remove`
     Then I get the error "Error: flag needs an argument: --remove"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town perennial-branches [flags]

--- a/features/git-town/configuration/pull_branch_strategy/update.feature
+++ b/features/git-town/configuration/pull_branch_strategy/update.feature
@@ -18,7 +18,7 @@ Feature: set the pull branch strategy
   Scenario: invalid strategy
     When I run `git-town pull-branch-strategy woof`
     Then I get the error "Invalid value: 'woof'"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town pull-branch-strategy [(rebase | merge)] [flags]

--- a/features/git-town/configuration/set_parent_branch.feature
+++ b/features/git-town/configuration/set_parent_branch.feature
@@ -20,7 +20,7 @@ Feature: update the parent of a nested feature branch
 
   Scenario: invalid child branch name
     When I run `git-town set-parent-branch non-existing parent-feature`
-    Then I get the error
+    Then I get the error:
       """
       There is no branch named 'non-existing'
       """
@@ -28,7 +28,7 @@ Feature: update the parent of a nested feature branch
 
   Scenario: invalid parent branch name
     When I run `git-town set-parent-branch child-feature non-existing`
-    Then I get the error
+    Then I get the error:
       """
       There is no branch named 'non-existing'
       """

--- a/features/git-town/town.feature
+++ b/features/git-town/town.feature
@@ -2,7 +2,7 @@ Feature: Show correct git town usage
 
   Scenario: invalid git town command
     When I run `git-town invalidcommand`
-    Then I get the error
+    Then I get the error:
       """
       Error: unknown command "invalidcommand" for "git-town"
       Run 'git-town --help' for usage.

--- a/features/shared/too_many_arguments.feature
+++ b/features/shared/too_many_arguments.feature
@@ -9,7 +9,7 @@ Feature: too many arguments
     When I run `git-town hack arg1 arg2`
     Then it runs no commands
     And I get the error "Too many arguments"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town hack <branch> [flags]
@@ -19,7 +19,7 @@ Feature: too many arguments
   Scenario: hack-push-flag
     When I run `git-town hack-push-flag arg1 arg2`
     Then I get the error "Too many arguments"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town hack-push-flag [(true | false)] [flags]
@@ -30,7 +30,7 @@ Feature: too many arguments
     When I run `git-town kill arg1 arg2`
     Then it runs no commands
     And I get the error "Too many arguments"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town kill [<branch>] [flags]
@@ -40,7 +40,7 @@ Feature: too many arguments
   Scenario: main-branch
     When I run `git-town main-branch arg1 arg2`
     Then I get the error "Too many arguments"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town main-branch [<branch>]
@@ -51,7 +51,7 @@ Feature: too many arguments
     When I run `git-town new-pull-request arg1`
     Then it runs no commands
     And I get the error "Too many arguments"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town new-pull-request [flags]
@@ -61,7 +61,7 @@ Feature: too many arguments
   Scenario: perennial-branches
     When I run `git-town perennial-branches arg1`
     Then I get the error "Too many arguments"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town perennial-branches [flags]
@@ -72,7 +72,7 @@ Feature: too many arguments
     When I run `git-town prune-branches arg1`
     Then it runs no commands
     And I get the error "Too many arguments"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town prune-branches [flags]
@@ -82,7 +82,7 @@ Feature: too many arguments
   Scenario: pull-branch-strategy
     When I run `git-town pull-branch-strategy arg1 arg2`
     Then I get the error "Too many arguments"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town pull-branch-strategy [(rebase | merge)] [flags]
@@ -93,7 +93,7 @@ Feature: too many arguments
     When I run `git-town repo arg1`
     Then it runs no commands
     And I get the error "Too many arguments"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town repo [flags]
@@ -104,7 +104,7 @@ Feature: too many arguments
     When I run `git-town sync arg1`
     Then it runs no commands
     And I get the error "Too many arguments"
-    And I get the error
+    And I get the error:
       """
       Usage:
         git-town sync [flags]

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -47,7 +47,7 @@ end
 
 
 
-Then(/^I get the error$/) do |error_message|
+Then(/^I get the error:$/) do |error_message|
   @error_expected = true
   expect(@last_run_result).to_not be_nil, 'Error message expected, but no commands were run'
   expect(@last_run_result.error).to be_truthy
@@ -66,7 +66,7 @@ end
 
 
 Then(/^I get the error "(.+?)"$/) do |error_message|
-  step 'I get the error', error_message
+  step 'I get the error:', error_message
 end
 
 


### PR DESCRIPTION
Steps that use a dedicated text block for multi-line errors should end with a colon, so that they are better distinguishable from the version that checks single-line errors.

This refactoring prepares infrastructure to test #913 better