### PR TITLE
Use the proper temp dir

### DIFF
--- a/src/steps/step.go
+++ b/src/steps/step.go
@@ -1,8 +1,9 @@
 package steps
 
 import (
-	"fmt"
 	"log"
+	"os"
+	"path"
 	"regexp"
 
 	"github.com/Originate/git-town/src/git"
@@ -39,5 +40,5 @@ func getRunResultFilename(command string) string {
 		log.Fatal("Error compiling replace character expression: ", err)
 	}
 	directory := replaceCharacterRegexp.ReplaceAllString(git.GetRootDirectory(), "-")
-	return fmt.Sprintf("/tmp/%s_%s", command, directory)
+	return path.Join(os.TempDir(), command+"_"+directory)
 }


### PR DESCRIPTION
I am skeptical that `os.TempDir` really returns `/tmp` on Windows. That's too obvious of a bug to still exist in the framework classes. In any case, we should leave this decision up to the runtime and not hard-code the temp directory. It might be different on different Unix flavors. I have seen `var/tmp` and others. 