### PR TITLE
Separate embedded Ruby directives via empty line

### DIFF
--- a/features/step_definitions/branch_configuration_steps.rb
+++ b/features/step_definitions/branch_configuration_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Given(/^Git Town is aware of this branch hierarchy$/) do |table|
   table.hashes.each do |row|
     set_parent_branch branch: row['BRANCH'], parent: row['PARENT']

--- a/features/step_definitions/branch_steps.rb
+++ b/features/step_definitions/branch_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Given(/^(I|my coworker) (?:am|is) on the "(.+?)" branch$/) do |who, branch_name|
   user = (who == 'I') ? :developer : :coworker
   in_repository user do

--- a/features/step_definitions/browser_steps.rb
+++ b/features/step_definitions/browser_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Then(/^I see a new (.+?) pull request for the "([^"]+)" branch in the "(.+?)" repo in my browser$/) do |domain, branch, repo|
   url = pull_request_url domain: domain, branch: branch, repo: repo
   expect(@last_run_result.out.strip).to include "#{@tool} called with: #{url}"

--- a/features/step_definitions/changes_steps.rb
+++ b/features/step_definitions/changes_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Then(/^there are no open changes$/) do
   expect(run('git status --short').out).to eql ''
 end

--- a/features/step_definitions/commit_steps.rb
+++ b/features/step_definitions/commit_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Given(/^the following commits? exists? in (my|my coworker's) repository( on another machine)?$/) do |who, remote, commits_table|
   user = (who == 'my') ? 'developer' : 'coworker'
   user += '_secondary' if remote

--- a/features/step_definitions/environment_steps.rb
+++ b/features/step_definitions/environment_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Given(/^I'm currently not in a git repository$/) do
   FileUtils.rm_rf '.git'
 end

--- a/features/step_definitions/files_steps.rb
+++ b/features/step_definitions/files_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Given(/^my repo ignores files named "([^"]*)"$/) do |filename|
   create_local_commit branch: current_branch_name,
                       file_name: '.gitignore',

--- a/features/step_definitions/folder_steps.rb
+++ b/features/step_definitions/folder_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Given(/^I have an existing Git autocompletion symlink$/) do
   symlinked_file = File.join(REPOSITORY_BASE, '.config/completions/custom')
   FileUtils.mkdir_p File.dirname(FISH_AUTOCOMPLETIONS_PATH)

--- a/features/step_definitions/merge_steps.rb
+++ b/features/step_definitions/merge_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Then(/^my repo(?: still)? has a merge in progress$/) do
   expect(merge_in_progress?).to be_truthy
 end

--- a/features/step_definitions/rebase_steps.rb
+++ b/features/step_definitions/rebase_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Then(/^my repo (?:still )?has a rebase in progress$/) do
   expect(rebase_in_progress).to be_truthy
 end

--- a/features/step_definitions/remote_steps.rb
+++ b/features/step_definitions/remote_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Given(/^my repo has an upstream repo$/) do
   clone_repository :origin, :upstream, bare: true
   clone_repository :upstream, :upstream_developer

--- a/features/step_definitions/run_steps.rb
+++ b/features/step_definitions/run_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 When(/^(I|my coworker) (?:run|runs|have run) `([^`]+)`$/) do |who, commands|
   user = (who == 'I') ? :developer : :coworker
   in_repository user do

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Given(/^I have the following tags$/) do |tags|
   tags.hashes.each do |tag|
     send "create_#{tag['LOCATION']}_tag", tag['NAME']

--- a/features/step_definitions/tool_steps.rb
+++ b/features/step_definitions/tool_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Given(/^I have "(.+?)" installed$/) do |tool|
   @tool = tool
   update_installed_tools [tool]

--- a/features/step_definitions/town_steps.rb
+++ b/features/step_definitions/town_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Given(/^I don't have a main branch name configured$/) do
   delete_main_branch_configuration
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Given(/^(I|my coworker) fetch(?:es)? updates$/) do |who|
   user = (who == 'I') ? :developer : :coworker
   in_repository user do


### PR DESCRIPTION
It improves readability if the Ruby directives are separated via an empty line