### PR TITLE
Offline #2: "git-town offline" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The following configuration options have defaults, so the configuration wizard d
 
 * the git-hack push flag
   * whether or not newly-hacked branches should be pushed to remote repo
-  * default: `true`
+  * default: `false`
   * possible values: `true`, `false`
 
 

--- a/features/git-town/configuration/offline-mode/display.feature
+++ b/features/git-town/configuration/offline-mode/display.feature
@@ -1,0 +1,23 @@
+Feature: Displaying the current offline status
+
+  When configuring offline mode
+  I want to know the current value for it
+  So that I can decide whether I want to adjust it.
+
+
+  Scenario: set to "true"
+    Given Git Town is in offline mode
+    When I run `git-town offline`
+    Then I see
+      """
+      true
+      """
+
+
+  Scenario: set to "false"
+    Given Git Town is not in offline mode
+    When I run `git-town offline`
+    Then I see
+      """
+      false
+      """

--- a/features/git-town/configuration/offline-mode/set.feature
+++ b/features/git-town/configuration/offline-mode/set.feature
@@ -1,0 +1,17 @@
+Feature: enabling offline mode
+
+  When developing on an airplane
+  I want to be able to use Git Town without interactions with remote origins
+  So that I can work on my code even without internet connection.
+
+
+  Scenario: enabling offline mode
+    When I run `git-town offline true`
+    Then offline mode is enabled
+
+
+  Scenario: disabling offline mode
+    Given Git Town is in offline mode
+    When I run `git-town offline false`
+    Then offline mode is disabled
+

--- a/features/step_definitions/town_steps.rb
+++ b/features/step_definitions/town_steps.rb
@@ -1,4 +1,13 @@
 # frozen_string_literal: true
+
+Given(/^Git Town is in offline mode$/) do
+  set_global_configuration 'offline', true
+end
+
+Given(/^Git Town is not in offline mode$/) do
+  set_global_configuration 'offline', false
+end
+
 Given(/^I don't have a main branch name configured$/) do
   delete_main_branch_configuration
 end
@@ -71,4 +80,14 @@ end
 
 Then(/^I see the initial configuration prompt$/) do
   step %(I see "Git Town needs to be configured")
+end
+
+
+Then(/^offline mode is enabled$/) do
+  expect(get_configuration('offline')).to eql 'true'
+end
+
+
+Then(/^offline mode is disabled$/) do
+  expect(get_configuration('offline')).to eql 'false'
 end

--- a/features/support/town_helpers.rb
+++ b/features/support/town_helpers.rb
@@ -50,3 +50,8 @@ end
 def set_configuration configuration, value
   run "git config git-town.#{configuration} '#{value}'"
 end
+
+
+def set_global_configuration configuration, value
+  run "git config --global git-town.#{configuration} '#{value}'"
+end

--- a/src/cmd/alias.go
+++ b/src/cmd/alias.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/Originate/git-town/src/git"
 	"github.com/Originate/git-town/src/script"
+	"github.com/Originate/git-town/src/util"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +30,7 @@ When aliases are set, you can run "git hack" instead of having to run "git town 
 
 Note that this can conflict with other tools that also define additional Git commands.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		toggle := stringToBool(args[0])
+		toggle := util.StringToBool(args[0])
 		for _, command := range commandsToAlias {
 			if toggle {
 				addAlias(command)

--- a/src/cmd/hack_push_flag.go
+++ b/src/cmd/hack_push_flag.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Originate/git-town/src/git"
+	"github.com/Originate/git-town/src/util"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +21,7 @@ The default value is false.`,
 		if len(args) == 0 {
 			printHackPushFlag()
 		} else {
-			setHackPushFlag(stringToBool(args[0]))
+			setHackPushFlag(util.StringToBool(args[0]))
 		}
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/src/cmd/hack_push_flag.go
+++ b/src/cmd/hack_push_flag.go
@@ -14,7 +14,7 @@ var hackPushFlagCommand = &cobra.Command{
 
 Newly hacked branches will be pushed upon creation
 if and only if "hack-push-flag" is true.
-The default value is true.`,
+The default value is false.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		git.EnsureIsRepository()
 		if len(args) == 0 {

--- a/src/cmd/offline-mode.go
+++ b/src/cmd/offline-mode.go
@@ -12,7 +12,6 @@ var offlineCommand = &cobra.Command{
 	Use:   "offline [(true | false)]",
 	Short: "Displays or sets offline mode",
 	Run: func(cmd *cobra.Command, args []string) {
-		git.EnsureIsRepository()
 		if len(args) == 0 {
 			printOfflineFlag()
 		} else {

--- a/src/cmd/offline-mode.go
+++ b/src/cmd/offline-mode.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/Originate/git-town/src/git"
+	"github.com/Originate/git-town/src/util"
+	"github.com/spf13/cobra"
+)
+
+var offlineCommand = &cobra.Command{
+	Use:   "offline [(true | false)]",
+	Short: "Displays or sets offline mode",
+	Run: func(cmd *cobra.Command, args []string) {
+		git.EnsureIsRepository()
+		if len(args) == 0 {
+			printOfflineFlag()
+		} else {
+			setOfflineFlag(util.StringToBool(args[0]))
+		}
+	},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 1 {
+			err := validateBooleanArgument(args[0])
+			if err != nil {
+				return err
+			}
+		}
+		return validateMaxArgs(args, 1)
+	},
+}
+
+func printOfflineFlag() {
+	fmt.Println(git.GetPrintableOfflineFlag())
+}
+
+func setOfflineFlag(value bool) {
+	git.UpdateOffline(value)
+}
+
+func init() {
+	RootCmd.AddCommand(offlineCommand)
+}

--- a/src/cmd/shared.go
+++ b/src/cmd/shared.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"log"
-	"strconv"
 )
 
 // These variables represent command-line flags
@@ -19,14 +17,6 @@ var (
 var abortFlagDescription = "Abort a previous command that resulted in a conflict"
 var continueFlagDescription = "Continue a previous command that resulted in a conflict"
 var undoFlagDescription = "Undo a previous command"
-
-func stringToBool(arg string) bool {
-	value, err := strconv.ParseBool(arg)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return value
-}
 
 func validateArgsCount(args []string, count int) error {
 	err := validateMinArgs(args, count)

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -195,7 +195,7 @@ func IsMainBranch(branchName string) bool {
 
 // IsOffline returns whether Git Town is currently in offline mode
 func IsOffline() bool {
-	return util.StringToBool(getGlobalConfigurationValueWithDefault("git-town.offline", "false"))
+	return util.StringToBool(getConfigurationValueWithDefault("git-town.offline", "false"))
 }
 
 // IsPerennialBranch returns whether the branch with the given name is
@@ -262,7 +262,16 @@ func UpdateShouldHackPush(value bool) {
 
 // Helpers
 
+// getConfigurationValue returns the given configuration value,
+// from either global or local Git configuration
 func getConfigurationValue(key string) (result string) {
+	result, _ = util.GetFullCommandOutput("git", "config", key)
+	return
+}
+
+// getLocalConfigurationValue returns the given configuration value
+// only from the local Git configuration
+func getLocalConfigurationValue(key string) (result string) {
 	if hasConfigurationValue("local", key) {
 		result = util.GetCommandOutput("git", "config", key)
 	}
@@ -289,14 +298,6 @@ func getConfigurationKeysMatching(toMatch string) (result []string) {
 		}
 	}
 	return
-}
-
-func getGlobalConfigurationValueWithDefault(key, defaultValue string) string {
-	value := GetGlobalConfigurationValue(key)
-	if value == "" {
-		value = defaultValue
-	}
-	return value
 }
 
 func hasConfigurationValue(location, key string) bool {

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -193,6 +193,11 @@ func IsMainBranch(branchName string) bool {
 	return branchName == GetMainBranch()
 }
 
+// IsOffline returns whether Git Town is currently in offline mode
+func IsOffline() bool {
+	return util.StringToBool(getGlobalConfigurationValueWithDefault("git-town.offline", "false"))
+}
+
 // IsPerennialBranch returns whether the branch with the given name is
 // a perennial branch.
 func IsPerennialBranch(branchName string) bool {
@@ -244,6 +249,11 @@ func ShouldHackPush() bool {
 	return getConfigurationValueWithDefault("git-town.hack-push-flag", "false") == "true"
 }
 
+// UpdateOffline updates whether Git Town is in offline mode
+func UpdateOffline(value bool) {
+	setGlobalConfigurationValue("git-town.offline", strconv.FormatBool(value))
+}
+
 // UpdateShouldHackPush updates whether the current repository is configured to push
 // freshly created branches up to the origin remote.
 func UpdateShouldHackPush(value bool) {
@@ -281,12 +291,24 @@ func getConfigurationKeysMatching(toMatch string) (result []string) {
 	return
 }
 
+func getGlobalConfigurationValueWithDefault(key, defaultValue string) string {
+	value := GetGlobalConfigurationValue(key)
+	if value == "" {
+		value = defaultValue
+	}
+	return value
+}
+
 func hasConfigurationValue(location, key string) bool {
 	return util.DoesCommandOuputContainLine([]string{"git", "config", "-l", "--" + location, "--name"}, key)
 }
 
 func setConfigurationValue(key, value string) {
 	util.GetCommandOutput("git", "config", key, value)
+}
+
+func setGlobalConfigurationValue(key, value string) {
+	util.GetCommandOutput("git", "config", "--global", key, value)
 }
 
 func removeConfigurationValue(key string) {

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -262,13 +262,6 @@ func UpdateShouldHackPush(value bool) {
 
 // Helpers
 
-// getConfigurationValue returns the given configuration value,
-// from either global or local Git configuration
-func getConfigurationValue(key string) (result string) {
-	result, _ = util.GetFullCommandOutput("git", "config", key)
-	return
-}
-
 // getLocalConfigurationValue returns the given configuration value
 // only from the local Git configuration
 func getLocalConfigurationValue(key string) (result string) {

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -246,7 +246,7 @@ func SetPullBranchStrategy(strategy string) {
 // ShouldHackPush returns whether the current repository is configured to push
 // freshly created branches up to the origin remote.
 func ShouldHackPush() bool {
-	return getLocalConfigurationValueWithDefault("git-town.hack-push-flag", "false") == "true"
+	return util.StringToBool(getLocalConfigurationValueWithDefault("git-town.hack-push-flag", "false"))
 }
 
 // UpdateOffline updates whether Git Town is in offline mode

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -262,6 +262,13 @@ func UpdateShouldHackPush(value bool) {
 
 // Helpers
 
+// getConfigurationValue returns the given configuration value,
+// from either global or local Git configuration
+func getConfigurationValue(key string) (result string) {
+	result, _ = util.GetFullCommandOutput("git", "config", key)
+	return
+}
+
 // getLocalConfigurationValue returns the given configuration value
 // only from the local Git configuration
 func getLocalConfigurationValue(key string) (result string) {
@@ -272,7 +279,7 @@ func getLocalConfigurationValue(key string) (result string) {
 }
 
 func getConfigurationValueWithDefault(key, defaultValue string) string {
-	value := getLocalConfigurationValue(key)
+	value := getConfigurationValue(key)
 	if value == "" {
 		return defaultValue
 	}

--- a/src/git/printable.go
+++ b/src/git/printable.go
@@ -38,3 +38,8 @@ func GetPrintableBranchTree(branchName string) (result string) {
 	}
 	return
 }
+
+// GetPrintableOfflineFlag returns a user printable offline flag
+func GetPrintableOfflineFlag() string {
+	return strconv.FormatBool(IsOffline())
+}

--- a/src/util/string.go
+++ b/src/util/string.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"log"
+	"strconv"
+)
+
+// StringToBool parses the given string into a bool
+func StringToBool(arg string) bool {
+	value, err := strconv.ParseBool(arg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return value
+}


### PR DESCRIPTION
I had copious free time on the plane without internet, so I finished the offline mode for Git Town.
I am submitting the changes as a series of PRs, so that it is easier to review them.

This PR is the first one. It adds a `git-town offline` command that allows to enable/disable and display the status of offline mode. Offline mode is set globally for Git Town, i.e. affects all repositories alike. 