### PR TITLE
hotfix #1: Improve configuration naming

### DIFF
--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -96,7 +96,7 @@ func ensureParentBranchIsMainBranch(branchName string) {
 
 func getShipStepList(config shipConfig) (result steps.StepList) {
 	mainBranch := git.GetMainBranch()
-	areInitialAndBranchToShipDifferent := config.BranchToShip != config.InitialBranch
+	isShippingInitialBranch := config.BranchToShip == config.InitialBranch
 	result.AppendList(steps.GetSyncBranchSteps(mainBranch))
 	result.Append(steps.CheckoutBranchStep{BranchName: config.BranchToShip})
 	result.Append(steps.MergeTrackingBranchStep{})
@@ -117,10 +117,10 @@ func getShipStepList(config shipConfig) (result steps.StepList) {
 		result.Append(steps.SetParentBranchStep{BranchName: child, ParentBranchName: mainBranch})
 	}
 	result.Append(steps.DeleteAncestorBranchesStep{})
-	if areInitialAndBranchToShipDifferent {
+	if !isShippingInitialBranch {
 		result.Append(steps.CheckoutBranchStep{BranchName: config.InitialBranch})
 	}
-	result.Wrap(steps.WrapOptions{RunInGitRoot: true, StashOpenChanges: areInitialAndBranchToShipDifferent})
+	result.Wrap(steps.WrapOptions{RunInGitRoot: true, StashOpenChanges: !isShippingInitialBranch})
 	return
 }
 

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -96,7 +96,7 @@ func ensureParentBranchIsMainBranch(branchName string) {
 
 func getShipStepList(config shipConfig) (result steps.StepList) {
 	mainBranch := git.GetMainBranch()
-	areInitialAndTargetDifferent := config.BranchToShip != config.InitialBranch
+	areInitialAndBranchToShipDifferent := config.BranchToShip != config.InitialBranch
 	result.AppendList(steps.GetSyncBranchSteps(mainBranch))
 	result.Append(steps.CheckoutBranchStep{BranchName: config.BranchToShip})
 	result.Append(steps.MergeTrackingBranchStep{})
@@ -117,10 +117,10 @@ func getShipStepList(config shipConfig) (result steps.StepList) {
 		result.Append(steps.SetParentBranchStep{BranchName: child, ParentBranchName: mainBranch})
 	}
 	result.Append(steps.DeleteAncestorBranchesStep{})
-	if areInitialAndTargetDifferent {
+	if areInitialAndBranchToShipDifferent {
 		result.Append(steps.CheckoutBranchStep{BranchName: config.InitialBranch})
 	}
-	result.Wrap(steps.WrapOptions{RunInGitRoot: true, StashOpenChanges: areInitialAndTargetDifferent})
+	result.Wrap(steps.WrapOptions{RunInGitRoot: true, StashOpenChanges: areInitialAndBranchToShipDifferent})
 	return
 }
 

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -15,7 +15,7 @@ import (
 type shipConfig struct {
 	InitialBranch       string
 	IsTargetBranchLocal bool
-	TargetBranch        string
+	BranchToShip        string
 }
 
 var commitMessage string
@@ -63,22 +63,22 @@ To ship a nested child branch, all ancestor branches have to be shipped or kille
 func checkShipPreconditions(args []string) (result shipConfig) {
 	result.InitialBranch = git.GetCurrentBranchName()
 	if len(args) == 0 {
-		result.TargetBranch = result.InitialBranch
+		result.BranchToShip = result.InitialBranch
 	} else {
-		result.TargetBranch = args[0]
+		result.BranchToShip = args[0]
 	}
-	if result.TargetBranch == result.InitialBranch {
+	if result.BranchToShip == result.InitialBranch {
 		git.EnsureDoesNotHaveOpenChanges("Did you mean to commit them before shipping?")
 	}
 	if git.HasRemote("origin") {
 		script.Fetch()
 	}
-	if result.TargetBranch != result.InitialBranch {
-		git.EnsureHasBranch(result.TargetBranch)
+	if result.BranchToShip != result.InitialBranch {
+		git.EnsureHasBranch(result.BranchToShip)
 	}
-	git.EnsureIsFeatureBranch(result.TargetBranch, "Only feature branches can be shipped.")
-	prompt.EnsureKnowsParentBranches([]string{result.TargetBranch})
-	ensureParentBranchIsMainBranch(result.TargetBranch)
+	git.EnsureIsFeatureBranch(result.BranchToShip, "Only feature branches can be shipped.")
+	prompt.EnsureKnowsParentBranches([]string{result.BranchToShip})
+	ensureParentBranchIsMainBranch(result.BranchToShip)
 	return
 }
 
@@ -96,23 +96,23 @@ func ensureParentBranchIsMainBranch(branchName string) {
 
 func getShipStepList(config shipConfig) (result steps.StepList) {
 	mainBranch := git.GetMainBranch()
-	areInitialAndTargetDifferent := config.TargetBranch != config.InitialBranch
+	areInitialAndTargetDifferent := config.BranchToShip != config.InitialBranch
 	result.AppendList(steps.GetSyncBranchSteps(mainBranch))
-	result.Append(steps.CheckoutBranchStep{BranchName: config.TargetBranch})
+	result.Append(steps.CheckoutBranchStep{BranchName: config.BranchToShip})
 	result.Append(steps.MergeTrackingBranchStep{})
 	result.Append(steps.MergeBranchStep{BranchName: mainBranch})
-	result.Append(steps.EnsureHasShippableChangesStep{BranchName: config.TargetBranch})
+	result.Append(steps.EnsureHasShippableChangesStep{BranchName: config.BranchToShip})
 	result.Append(steps.CheckoutBranchStep{BranchName: mainBranch})
-	result.Append(steps.SquashMergeBranchStep{BranchName: config.TargetBranch, CommitMessage: commitMessage})
+	result.Append(steps.SquashMergeBranchStep{BranchName: config.BranchToShip, CommitMessage: commitMessage})
 	if git.HasRemote("origin") {
 		result.Append(steps.PushBranchStep{BranchName: mainBranch, Undoable: true})
 	}
-	childBranches := git.GetChildBranches(config.TargetBranch)
-	if git.HasTrackingBranch(config.TargetBranch) && len(childBranches) == 0 {
-		result.Append(steps.DeleteRemoteBranchStep{BranchName: config.TargetBranch, IsTracking: true})
+	childBranches := git.GetChildBranches(config.BranchToShip)
+	if git.HasTrackingBranch(config.BranchToShip) && len(childBranches) == 0 {
+		result.Append(steps.DeleteRemoteBranchStep{BranchName: config.BranchToShip, IsTracking: true})
 	}
-	result.Append(steps.DeleteLocalBranchStep{BranchName: config.TargetBranch})
-	result.Append(steps.DeleteParentBranchStep{BranchName: config.TargetBranch})
+	result.Append(steps.DeleteLocalBranchStep{BranchName: config.BranchToShip})
+	result.Append(steps.DeleteParentBranchStep{BranchName: config.BranchToShip})
 	for _, child := range childBranches {
 		result.Append(steps.SetParentBranchStep{BranchName: child, ParentBranchName: mainBranch})
 	}

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -13,9 +13,9 @@ import (
 )
 
 type shipConfig struct {
+	BranchToShip        string
 	InitialBranch       string
 	IsTargetBranchLocal bool
-	BranchToShip        string
 }
 
 var commitMessage string


### PR DESCRIPTION
The configuration value `shipConfig.TargetBranch` had a misleading name. `BranchToShip` makes it more clear what this config value is.