### PR TITLE
support github enterprise,short hostname has to be github

### DIFF
--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -47,13 +47,13 @@ func (d *githubCodeHostingDriver) GetNewPullRequestURL(branch string, parentBran
 }
 
 func (d *githubCodeHostingDriver) GetRepositoryURL() string {
-	var repoUrl = ""
+	var repoURL
 	if (strings.HasPrefix(d.originURL, "http:")) || (strings.HasPrefix(d.originURL, "https:")) {
-		repoUrl = fmt.Sprintf("https://%s/%s/%s", d.hostname, d.owner, d.repository)
+		repoURL = fmt.Sprintf("https://%s/%s/%s", d.hostname, d.owner, d.repository)
 	} else {
-		repoUrl = fmt.Sprintf("https://github.com/%s/%s", d.owner, d.repository)
+		repoURL = fmt.Sprintf("https://github.com/%s/%s", d.owner, d.repository)
 	}
-	return repoUrl
+	return repoURL
 }
 
 func (d *githubCodeHostingDriver) MergePullRequest(options MergePullRequestOptions) (string, error) {

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -47,11 +47,13 @@ func (d *githubCodeHostingDriver) GetNewPullRequestURL(branch string, parentBran
 }
 
 func (d *githubCodeHostingDriver) GetRepositoryURL() string {
+	var repoUrl = ""
 	if (strings.HasPrefix(d.originURL, "http:")) || (strings.HasPrefix(d.originURL, "https:")) {
-		return fmt.Sprintf("https://%s/%s/%s", d.hostname, d.owner, d.repository)
+		repoUrl = fmt.Sprintf("https://%s/%s/%s", d.hostname, d.owner, d.repository)
 	} else {
-		return fmt.Sprintf("https://github.com/%s/%s", d.owner, d.repository)
+		repoUrl = fmt.Sprintf("https://github.com/%s/%s", d.owner, d.repository)
 	}
+	return repoUrl
 }
 
 func (d *githubCodeHostingDriver) MergePullRequest(options MergePullRequestOptions) (string, error) {

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -47,13 +47,13 @@ func (d *githubCodeHostingDriver) GetNewPullRequestURL(branch string, parentBran
 }
 
 func (d *githubCodeHostingDriver) GetRepositoryURL() string {
-	var repoURL
+
 	if (strings.HasPrefix(d.originURL, "http:")) || (strings.HasPrefix(d.originURL, "https:")) {
-		repoURL = fmt.Sprintf("https://%s/%s/%s", d.hostname, d.owner, d.repository)
-	} else {
-		repoURL = fmt.Sprintf("https://github.com/%s/%s", d.owner, d.repository)
+		return fmt.Sprintf("https://%s/%s/%s", d.hostname, d.owner, d.repository)
 	}
-	return repoURL
+
+	return fmt.Sprintf("https://github.com/%s/%s", d.owner, d.repository)
+
 }
 
 func (d *githubCodeHostingDriver) MergePullRequest(options MergePullRequestOptions) (string, error) {

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -47,7 +47,7 @@ func (d *githubCodeHostingDriver) GetNewPullRequestURL(branch string, parentBran
 }
 
 func (d *githubCodeHostingDriver) GetRepositoryURL() string {
-	return fmt.Sprintf("https://github.com/%s/%s", d.owner, d.repository)
+	return fmt.Sprintf("https://%s/%s/%s", d.hostname, d.owner, d.repository)
 }
 
 func (d *githubCodeHostingDriver) MergePullRequest(options MergePullRequestOptions) (string, error) {

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -47,7 +47,11 @@ func (d *githubCodeHostingDriver) GetNewPullRequestURL(branch string, parentBran
 }
 
 func (d *githubCodeHostingDriver) GetRepositoryURL() string {
-	return fmt.Sprintf("https://%s/%s/%s", d.hostname, d.owner, d.repository)
+	if (strings.HasPrefix(d.originURL, "http:")) || (strings.HasPrefix(d.originURL, "https:")) {
+		return fmt.Sprintf("https://%s/%s/%s", d.hostname, d.owner, d.repository)
+	} else {
+		return fmt.Sprintf("https://github.com/%s/%s", d.owner, d.repository)
+	}
 }
 
 func (d *githubCodeHostingDriver) MergePullRequest(options MergePullRequestOptions) (string, error) {


### PR DESCRIPTION
I'm trying to get git-town running against our github enterprise server. The short name of our server is github, and therefore the server is correctly detected to  be of type github.
Unfortunately when running "new-pull-request" github.com is  used in the URL.
This simple change fixes this issue. Note that I haven't tested all the features. 