### PR TITLE
Import tmpdir gem in tests

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,6 +6,7 @@ require 'mortadella'
 require 'open4'
 require 'pathname'
 require 'rspec'
+require 'tmpdir'
 
 
 SOURCE_DIRECTORY = File.join(File.dirname(__FILE__), '..', '..', 'src')


### PR DESCRIPTION
This fixes the error 

```
undefined method `mktmpdir' for Dir:Class
```

Running tests in parallel was masking this error, it was only visible when running a single test.