### PR TITLE
Document that ship tokens need the repo scope

### DIFF
--- a/documentation/commands/ship.md
+++ b/documentation/commands/ship.md
@@ -30,7 +30,7 @@ To ship a nested child branch, all ancestor branches have to be shipped or kille
 
 If you are using GitHub, this command can squash merge pull requests via the GitHub API. Setup:
 
-1. Get a GitHub personal access token
+1. Get a GitHub personal access token with the `repo` scope ([see how](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line))
 2. Run `git config git-town.github-token XXX` (optionally add the `--global` flag)
 
 Now anytime you ship a branch with a pull request on GitHub, it will squash merge via the GitHub API.

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -41,7 +41,7 @@ Only shipping of direct children of the main branch is allowed.
 To ship a nested child branch, all ancestor branches have to be shipped or killed.
 
 If you are using GitHub, this command can squash merge pull requests via the GitHub API. Setup:
-1. Get a GitHub personal access token
+1. Get a GitHub personal access token with the "repo" scope
 2. Run 'git config git-town.github-token XXX' (optionally add the '--global' flag)
 Now anytime you ship a branch with a pull request on GitHub, it will squash merge via the GitHub API.
 It will also update the base branch for any pull requests against that branch.`,


### PR DESCRIPTION
While setting up the awesome new shipping via the Github API, I noticed that the documentation leaves out which scopes the access token needs. Giving it no scopes only grants read-only access to the repo.