### PR TITLE
Add versions for dependencies

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -2,7 +2,9 @@ package: github.com/Originate/git-town
 import:
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
+  version: v1.0.0
 - package: github.com/fatih/color
+  version: v1.5.0
 - package: github.com/google/go-github
   subpackages:
   - github


### PR DESCRIPTION
Using stable releases is critical since the `master` branches of libraries are apparently not *that* stable in the Go world. This is the result of running `glide cw`.

I skip updating the vendored source code here since that requires updating all other dependencies (a know missing feature of glide). This will be done in #1018.