### PR TITLE
Godoc

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,9 +1,13 @@
 /*
 Git Town - a high-level CLI for Git
 
-Git Town provides additional Git commands
-that make working in large teams
-easy and fun.
+Git Town makes software development teams
+who use Git even more productive and happy.
+It adds Git commands that support GitHub Flow,
+Git Flow, the Nvie model, GitLab Flow,
+and other workflows more directly,
+and it allows you to perform
+many common Git operations faster and easier.
 More information at https://github.com/Originate/git-town.
 
 Installation alternatives:

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,19 @@
+/*
+Git Town - a high-level CLI for Git
+
+Git Town provides additional Git commands
+that make working in large teams
+easy and fun.
+
+More information at https://github.com/Originate/git-town
+
+Installation alternatives:
+	- HomeBrew (macOS): brew install git-town
+	- AUR package for Arch Linux: https://aur.archlinux.org/packages/git-town
+	- go get github.com/Originate/git-town
+	- direct download of platform-specific binaries: https://github.com/Originate/git-town/releases/latest
+
+Usage:
+  git town help
+*/
+package main

--- a/doc.go
+++ b/doc.go
@@ -4,8 +4,7 @@ Git Town - a high-level CLI for Git
 Git Town provides additional Git commands
 that make working in large teams
 easy and fun.
-
-More information at https://github.com/Originate/git-town
+More information at https://github.com/Originate/git-town.
 
 Installation alternatives:
 	- HomeBrew (macOS): brew install git-town
@@ -13,7 +12,7 @@ Installation alternatives:
 	- go get github.com/Originate/git-town
 	- direct download of platform-specific binaries: https://github.com/Originate/git-town/releases/latest
 
-Usage:
+Available commands and usage:
   git town help
 */
 package main


### PR DESCRIPTION
Adds some basic Godoc to the main file. All our public methods already have Godoc, so this should be all we need here in order to be listed properly on the [official Godoc server](https://godoc.org/github.com/Originate/git-town).

resolves #1049 