### PR TITLE
Local variables don't shadow package names

### DIFF
--- a/src/browsers/browsers.go
+++ b/src/browsers/browsers.go
@@ -18,8 +18,8 @@ func GetOpenBrowserCommand() string {
 		return "start"
 	}
 	for _, browserCommand := range openBrowserCommands {
-		command := command.New("which", browserCommand)
-		if command.Err() == nil && command.Output() != "" {
+		cmd := command.New("which", browserCommand)
+		if cmd.Err() == nil && cmd.Output() != "" {
 			return browserCommand
 		}
 	}

--- a/src/git/branch.go
+++ b/src/git/branch.go
@@ -113,11 +113,11 @@ func GetLocalBranchesWithMainBranchFirst() (result []string) {
 
 // GetPreviouslyCheckedOutBranch returns the name of the previously checked out branch
 func GetPreviouslyCheckedOutBranch() string {
-	command := command.New("git", "rev-parse", "--verify", "--abbrev-ref", "@{-1}")
-	if command.Err() != nil {
+	cmd := command.New("git", "rev-parse", "--verify", "--abbrev-ref", "@{-1}")
+	if cmd.Err() != nil {
 		return ""
 	}
-	return command.Output()
+	return cmd.Output()
 }
 
 // GetTrackingBranchName returns the name of the remote branch
@@ -172,8 +172,8 @@ func IsBranchInSync(branchName string) bool {
 // contains commits that have not been pushed to the remote.
 func ShouldBranchBePushed(branchName string) bool {
 	trackingBranchName := GetTrackingBranchName(branchName)
-	command := command.New("git", "rev-list", "--left-right", branchName+"..."+trackingBranchName)
-	return command.Output() != ""
+	cmd := command.New("git", "rev-list", "--left-right", branchName+"..."+trackingBranchName)
+	return cmd.Output() != ""
 }
 
 // Helpers


### PR DESCRIPTION
These files import a package `command`. The local variable `command` was shadowing them.