### PR TITLE
Improve Linter infrastructure

### DIFF
--- a/bin/fix
+++ b/bin/fix
@@ -3,5 +3,5 @@ set -ex
 
 # Runs all the auto-fixes
 
-./bin/fix_cucumber
-./bin/fix_ruby
+bin/fix_cucumber
+bin/fix_ruby

--- a/bin/fix
+++ b/bin/fix
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 # Runs all the auto-fixes
 
 ./bin/fix_cucumber
+./bin/fix_ruby

--- a/bin/fix
+++ b/bin/fix
@@ -3,4 +3,4 @@ set -e
 
 # Runs all the auto-fixes
 
-bundle exec cucumber_lint --fix
+./bin/fix_cucumber

--- a/bin/fix_ruby
+++ b/bin/fix_ruby
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+# Runs the Ruby auto-fixes
+
+bundle exec rubocop --auto-correct

--- a/bin/lint
+++ b/bin/lint
@@ -3,5 +3,5 @@ set -e
 
 # Runs all the available linters
 
-lint_go
-lint_ruby
+bin/lint_go
+bin/lint_ruby

--- a/bin/lint
+++ b/bin/lint
@@ -4,3 +4,4 @@ set -e
 # Runs all the available linters
 
 lint_go
+lint_ruby

--- a/bin/lint_ruby
+++ b/bin/lint_ruby
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+# Runs the Ruby linter
+
+bundle exec rubocop

--- a/bin/spec
+++ b/bin/spec
@@ -3,12 +3,6 @@ set -ex
 
 # Runs all the tests
 
-
-# linters
 bin/lint
-
-# unit tests
 bin/tests
-
-# feature tests
 bin/cuke

--- a/bin/spec
+++ b/bin/spec
@@ -5,9 +5,7 @@ set -ex
 
 
 # linters
-bin/lint_go
-bundle exec rubocop
-bundle exec cucumber_lint
+bin/lint
 
 # unit tests
 bin/tests


### PR DESCRIPTION
There is now a clean hierarchy of scripts:
- `lint`: runs all linters
  - `lint_go`: lint only Go
  - `lint_ruby`: lint only Ruby
- fix: runs all autofixes
  - `fix_cucumber`
  - `fix_ruby`