### PR TITLE
Fix panic when aliasing without arguments

### DIFF
--- a/src/cmd/alias.go
+++ b/src/cmd/alias.go
@@ -40,9 +40,13 @@ Note that this can conflict with other tools that also define additional Git com
 		}
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		arg := ""
+		if len(args) > 0 {
+			arg = args[0]
+		}
 		return util.FirstError(
 			validateArgsCountFunc(args, 1),
-			validateBooleanArgumentFunc(args[0]),
+			validateBooleanArgumentFunc(arg),
 		)
 	},
 }

--- a/src/cmd/alias_test.go
+++ b/src/cmd/alias_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import "testing"
+
+func TestAliasPreRunE(t *testing.T) {
+	cases := []struct {
+		name   string
+		args   []string
+		expErr bool
+	}{
+		{"TrueArgument", []string{"true"}, false},
+		{"FalseArgument", []string{"false"}, false},
+		{"NoArguments", []string{}, true},
+		{"MutipleArguments", []string{"true", "false"}, true},
+		{"InvalidArgument", []string{"f"}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := aliasCommand.PreRunE(nil, tc.args)
+			if tc.expErr && err == nil {
+				t.Error("expected PreRunE to return an error")
+			}
+			if !tc.expErr && err != nil {
+				t.Errorf("expeced err to be nil; got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Calling `git town alias` without any additional arguments resulted in a panic. The validation logic used to determine if the alias argument is valid looked for the first value in the args slice, however the slice is empty when no arguments are supplied. This modification ensures that the first value of the args slice can be read, otherwise will pass an empty string to the argument validation function.