### PR TITLE
docs: update config.md

### DIFF
--- a/documentation/commands/config.md
+++ b/documentation/commands/config.md
@@ -6,6 +6,6 @@ config - displays, resets, or prompts setup of the Git Town configuration
 
 ```
 git town config
-git town config reset
-git town config setup
+git town config --reset
+git town config --setup
 ```


### PR DESCRIPTION
git town help has `--reset` and `--setup` flags

```bash
⇒  git town config -h
Displays or resets your Git Town configuration

Usage:
  git-town config [flags]

Flags:
  -h, --help    help for config
      --reset   Remove all Git Town configuration from the current repository
      --setup   Run the Git Town configuration wizard

Global Flags:
      --debug   Developer tool to print git commands run under the hood
```