### PR TITLE
Update RELEASE_NOTES.md with unreleased changes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+#### BREAKING CHANGES
+
+* `git town config`: `reset` and `setup` are now subcommands instead of flags 
+
+#### Bug Fixes
+
+* skip perennial branch prompt if there are no options
+
 ## 6.0.2 (2018-01-26)
 
 #### Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@
 
 #### BREAKING CHANGES
 
-* `git town config`: `reset` and `setup` are now subcommands instead of flags 
+* `git town config`: `reset` and `setup` are now subcommands instead of flags
 
 #### Bug Fixes
 


### PR DESCRIPTION
Lets try and require this for PRs with user facing changes going forward. Can probably do a release now but I'll do a quick scan for any other breaking changes on the horizon