### PR TITLE
Support GitHub Enterprise.

### DIFF
--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -23,7 +24,7 @@ type githubCodeHostingDriver struct {
 }
 
 func (d *githubCodeHostingDriver) CanBeUsed(driverType string) bool {
-	return driverType == "github" || d.hostname == "github.com"
+	return driverType == "github" || d.hostname == "github.com" || d.hostname == os.Getenv("GHE_HOST")
 }
 
 func (d *githubCodeHostingDriver) CanMergePullRequest(branch, parentBranch string) (bool, string, error) {

--- a/vendor/github.com/google/go-github/github/github.go
+++ b/vendor/github.com/google/go-github/github/github.go
@@ -17,6 +17,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -222,8 +223,8 @@ func NewClient(httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	baseURL, _ := url.Parse(defaultBaseURL)
-	uploadURL, _ := url.Parse(uploadBaseURL)
+	baseURL, _ := url.Parse(GetEnv("GHE_API_ENDPOINT", defaultBaseURL))
+	uploadURL, _ := url.Parse(GetEnv("GHE_UPLOAD_ENDPOINT", uploadBaseURL))
 
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent, UploadURL: uploadURL}
 	c.common.client = c
@@ -656,6 +657,13 @@ type Error struct {
 	Field    string `json:"field"`    // field on which the error occurred
 	Code     string `json:"code"`     // validation error code
 	Message  string `json:"message"`  // Message describing the error. Errors with Code == "custom" will always have this set.
+}
+
+func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
 }
 
 func (e *Error) Error() string {


### PR DESCRIPTION
If user defines below 3 environment variables, git-town will go with Enterprise GitHub. Otherwise, git-town will still go with github.com. 

User can easily switch between GitHub enterprise and github.com by set and unset Environment Variables.

- GHE_HOST: Github Enterprise host. Example: https://example.domain.com/

- GHE_API_ENDPOINT: GitHub Enterprise API point. Example: https://example.domain.com/api/v3/

- GHE_UPLOAD_ENDPOINT: GitHub Enterprise Upload point. Example: https://example.domain.com/uploads/"
