### PR TITLE
Fix uninstall command for Debian/Ubuntu distros

### DIFF
--- a/website/install.md
+++ b/website/install.md
@@ -30,7 +30,7 @@ please use the manual install and ensure your Git version is 2.7.0 or higher._
 * Install / Update:
   * Download the deb file from the latest release [here](https://github.com/Originate/git-town/releases).
   * Run `dpkg -i /path/to/debfile`
-* Uninstall: run `apt-get remove git-town`
+* Uninstall: run `apt-get remove gittown`
 
 ---
 


### PR DESCRIPTION
Fix package name in uninstall command
```bash
dpkg --list | grep 'town'
```
```
ii  gittown        7.2.0        amd64        Generic, high-level Git workflow support
```