### PR TITLE
Website: updates screencast link

### DIFF
--- a/website/index.jade
+++ b/website/index.jade
@@ -51,7 +51,7 @@ html
         All while being as generic and unopinionated as Git.
 
       .buttons
-        a.button.view-more(href="https://youtu.be/quYrf9ssi1A" target="_blank") View screencast
+        a.button.view-more(href="https://youtu.be/oLaUsUlFfTo" target="_blank") View screencast
         a.button.learn-more(href="/tutorial.html") view tutorial
 
 


### PR DESCRIPTION
Noticed this linked to a "Video Unavailable" page. Searched up youtube, and this seems to be the correct one.