### PR TITLE
update docs for code-hosting config

### DIFF
--- a/documentation/commands/new-pull-request.md
+++ b/documentation/commands/new-pull-request.md
@@ -13,12 +13,12 @@ against the immediate parent branch.
 
 Supported only for repositories hosted on [GitHub](http://github.com/),
 [GitLab](http://gitlab.com/), and [Bitbucket](https://bitbucket.org/).
-When using hosted versions of GitHub, GitLab, or Bitbucket,
-make sure that your SSH identity contains the phrase "github", "gitlab" or
-"bitbucket", so that Git Town can derive which hosting service you use.
-
-Example: your SSH identity should be something like "git@github-as-account1:Originate/git-town.git"
-</a>
+When using self-hosted versions this command needs to be configured with
+`git config git-town.code-hosting-driver <driver>`
+where driver is "github", "gitlab", or "bitbucket".
+When using SSH identities, this command needs to be configured with
+`git config git-town.code-hosting-origin-hostname <hostname>`
+where hostname matches what is in your ssh config file.
 
 #### Usage
 

--- a/documentation/commands/new-pull-request.md
+++ b/documentation/commands/new-pull-request.md
@@ -19,6 +19,7 @@ where driver is "github", "gitlab", or "bitbucket".
 When using SSH identities, this command needs to be configured with
 `git config git-town.code-hosting-origin-hostname <hostname>`
 where hostname matches what is in your ssh config file.
+</a>
 
 #### Usage
 

--- a/documentation/commands/repo.md
+++ b/documentation/commands/repo.md
@@ -8,9 +8,12 @@ Opens the repository homepage
 
 Supported only for repositories hosted on [GitHub](http://github.com/),
 [GitLab](http://gitlab.com/), and [Bitbucket](https://bitbucket.org/).
-When using hosted versions of GitHub, GitLab, or Bitbucket,
-make sure that your SSH identity contains the phrase "github", "gitlab", or "bitbucket",
-so that Git Town can guess which hosting service you use.
+When using self-hosted versions this command needs to be configured with
+`git config git-town.code-hosting-driver <driver>`
+where driver is "github", "gitlab", or "bitbucket".
+When using SSH identities, this command needs to be configured with
+`git config git-town.code-hosting-origin-hostname <hostname>`
+where hostname matches what is in your ssh config file.
 
 Example:
 your SSH identity should be something like

--- a/documentation/commands/repo.md
+++ b/documentation/commands/repo.md
@@ -14,10 +14,6 @@ where driver is "github", "gitlab", or "bitbucket".
 When using SSH identities, this command needs to be configured with
 `git config git-town.code-hosting-origin-hostname <hostname>`
 where hostname matches what is in your ssh config file.
-
-Example:
-your SSH identity should be something like
-"git@github-as-account1:Originate/git-town.git"
 </a>
 
 #### Usage

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -28,12 +28,12 @@ so that the pull request only shows the changes made
 against the immediate parent branch.
 
 Supported only for repositories hosted on GitHub, GitLab, and Bitbucket.
-When using hosted versions of GitHub, GitLab, or Bitbucket,
-make sure that your SSH identity contains the phrase "github", "gitlab" or
-"bitbucket", so that Git Town can derive which hosting service you use.
-
-Example: your SSH identity should be something like
-         "git@github-as-account1:Originate/git-town.git"`,
+When using self-hosted versions this command needs to be configured with
+"git config git-town.code-hosting-driver <driver>"
+where driver is "github", "gitlab", or "bitbucket".
+When using SSH identities, this command needs to be configured with
+"git config git-town.code-hosting-origin-hostname <hostname>"
+where hostname matches what is in your ssh config file."`,
 	Run: func(cmd *cobra.Command, args []string) {
 		config := getNewPullRequestConfig()
 		stepList := getNewPullRequestStepList(config)

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -33,7 +33,7 @@ When using self-hosted versions this command needs to be configured with
 where driver is "github", "gitlab", or "bitbucket".
 When using SSH identities, this command needs to be configured with
 "git config git-town.code-hosting-origin-hostname <hostname>"
-where hostname matches what is in your ssh config file."`,
+where hostname matches what is in your ssh config file.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		config := getNewPullRequestConfig()
 		stepList := getNewPullRequestStepList(config)

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -19,7 +19,7 @@ When using self-hosted versions this command needs to be configured with
 where driver is "github", "gitlab", or "bitbucket".
 When using SSH identities, this command needs to be configured with
 "git config git-town.code-hosting-origin-hostname <hostname>"
-where hostname matches what is in your ssh config file.""`,
+where hostname matches what is in your ssh config file.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		driver := drivers.GetActiveDriver()
 		script.OpenBrowser(driver.GetRepositoryURL())

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -14,12 +14,12 @@ var repoCommand = &cobra.Command{
 	Long: `Opens the repository homepage
 
 Supported only for repositories hosted on GitHub, GitLab, and Bitbucket.
-When using hosted versions of GitHub, GitLab, or Bitbucket,
-make sure that your SSH identity contains the phrase "github", "gitlab", or
- "bitbucket", so that Git Town can guess which hosting service you use.
-
-Example: your SSH identity should be something like
-         "git@github-as-account1:Originate/git-town.git"`,
+When using self-hosted versions this command needs to be configured with
+"git config git-town.code-hosting-driver <driver>"
+where driver is "github", "gitlab", or "bitbucket".
+When using SSH identities, this command needs to be configured with
+"git config git-town.code-hosting-origin-hostname <hostname>"
+where hostname matches what is in your ssh config file.""`,
 	Run: func(cmd *cobra.Command, args []string) {
 		driver := drivers.GetActiveDriver()
 		script.OpenBrowser(driver.GetRepositoryURL())


### PR DESCRIPTION
Resolves #1205 

Originally implemented here: #1040 where I updated only the files in `documentation/commands` and missing those in `src/cmd`. The feature is noted in the 5.0.0 release notes

Then #1161 reverted the changes to #1040 as it brought them back in line with was in `src/cmd` as text runner required them to match.

