### PR TITLE
Prettify more file types

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,16 +14,14 @@ exemptLabels:
   - help wanted
   - improvement
   - refactoring
-  
+
 # Comment to post when marking as stale. Set to `false` to disable
 pulls:
   daysUntilStale: 7
   markComment: >
-    This pull request is losing momentum.
-    Please help resolve it.
+    This pull request is losing momentum. Please help resolve it.
 
 issues:
   daysUntilStale: 14
   markComment: >
-    This issue is losing momentum.
-    Please help resolve it.
+    This issue is losing momentum. Please help resolve it.

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+semi: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,74 +3,57 @@
 AllCops:
   TargetRubyVersion: 2.3
   Exclude:
-    - 'node_modules/**/*'
-
+    - "node_modules/**/*"
 
   DisplayCopNames: true
 
   DisplayStyleGuide: true
 
-
 Layout/DotPosition:
   EnforcedStyle: leading
   Enabled: true
 
-
 Layout/EmptyLines:
   Enabled: false
-
 
 Layout/EmptyLinesAroundClassBody:
   EnforcedStyle: empty_lines
 
-
 Layout/EmptyLineBetweenDefs:
-  NumberOfEmptyLines: [1,2]
-
+  NumberOfEmptyLines: [1, 2]
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
-
 Metrics/AbcSize:
   Max: 19
-
 
 Metrics/CyclomaticComplexity:
   Max: 7
 
-
 Metrics/LineLength:
   Enabled: false
-
 
 Metrics/ParameterLists:
   Max: 6
 
-
 Style/EmptyCaseCondition:
   Enabled: false
-
 
 Style/GuardClause:
   Enabled: false
 
-
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
-
 
 Style/NestedParenthesizedCalls:
   Enabled: false
 
-
 Style/SignalException:
   EnforcedStyle: only_fail
 
-
 Style/StringLiterals:
   EnforcedStyle: single_quotes
-
 
 Style/TernaryParentheses:
   Enabled: false

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,14 @@ fix-cucumber:  # auto-fixes all Cucumber lint issues
 	bundle exec cucumber_lint --fix
 
 fix-markdown:  # auto-fixes all Markdown lint issues
-	node_modules/.bin/prettier --write "{,!(vendor)/**/}*.md"
+	@find . -type f \( \
+		-path '**/*.md' -o \
+		-path '**/*.yml' -o \
+		-path '**/*.json' -o \
+		-path '**/*.js' \) | \
+		grep -v node_modules | \
+		grep -v vendor | \
+		xargs node_modules/.bin/prettier --write
 
 fix-ruby:  # auto-fixes all Ruby lint issues
 	bundle exec rubocop --auto-correct
@@ -54,7 +61,14 @@ lint-go:  # lints the Go files
 	gometalinter.v2
 
 lint-markdown: build  # lints the Markdown files
-	node_modules/.bin/prettier -l "{,!(vendor)/**/}*.md"
+	@find . -type f \( \
+		-path '**/*.md' -o \
+		-path '**/*.yml' -o \
+		-path '**/*.json' -o \
+		-path '**/*.js' \) | \
+		grep -v node_modules | \
+		grep -v vendor | \
+		xargs node_modules/.bin/prettier -l
 	node_modules/.bin/text-run --offline
 
 lint-ruby:  # lints the Ruby files

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,4 +1,3 @@
-<% common = "-r features/step_definitions -r features/support --strict" %>
-
-default: <%= common %>
-parallel: <%= common %> --format=progress
+---
+default: -r features/step_definitions -r features/support --strict
+parallel: -r features/step_definitions -r features/support --strict --format=progress

--- a/features/step_definitions/.rubocop.yml
+++ b/features/step_definitions/.rubocop.yml
@@ -1,5 +1,4 @@
 inherit_from: ../../.rubocop.yml
 
-
 Metrics/LineLength:
   Max: 130

--- a/tertestrial.yml
+++ b/tertestrial.yml
@@ -1,18 +1,17 @@
 actions:
-
   - match:
       filename: '\.feature$'
-    command: 'make build && bundle exec cucumber {{filename}}'
+    command: "make build && bundle exec cucumber {{filename}}"
 
   - match:
       filename: '\.feature$'
       line: '\d+'
-    command: 'make build && bundle exec cucumber {{filename}}:{{line}}'
+    command: "make build && bundle exec cucumber {{filename}}:{{line}}"
 
   - match:
       filename: '\.go$'
-    command: 'make build ; make lint'
+    command: "make build ; make lint"
 
   - match:
       filename: '\.md$'
-    command: 'make build && text-run {{filename}}'
+    command: "make build && text-run {{filename}}"

--- a/text-run.yml
+++ b/text-run.yml
@@ -2,11 +2,11 @@
 # This is a glob expression, see https://github.com/isaacs/node-glob#glob-primer
 # The folder "node_modules" is already excluded.
 # To exclude the "vendor" folder: '{,!(vendor)/**/}*.md'
-files: '**/*.md'
+files: "**/*.md"
 
 # black-list of files not to test
 # This is applied after the white-list above.
-exclude: 'vendor/'
+exclude: "vendor/"
 
 # the formatter to use
 format: dot
@@ -22,7 +22,7 @@ format: dot
 #     publicExtension: ''
 
 # prefix that makes anchor tags active regions
-classPrefix: 'textrun'
+classPrefix: "textrun"
 
 # whether to run the tests in an external temp directory,
 # uses ./tmp if false,

--- a/text-run/command-description.js
+++ b/text-run/command-description.js
@@ -1,47 +1,47 @@
-const child_process = require('child_process')
-const diff = require('jsdiff-console')
-const getCommand = require('./helpers/get-command.js')
+const child_process = require("child_process")
+const diff = require("jsdiff-console")
+const getCommand = require("./helpers/get-command.js")
 
-module.exports = async function (activity) {
+module.exports = async function(activity) {
   const mdDesc = getMd(activity)
   const cliDesc = getCliDesc(activity)
   diff(mdDesc, cliDesc)
 }
 
-function getMd (activity) {
+function getMd(activity) {
   return normalize(
     activity.nodes
       .map(nodeContent)
       .map(text => text.trim())
-      .join('\n')
-      .replace(/\n<\/?a>\n/g, ' ')
-      .replace(/ \./g, '.')
-      .replace(/ \,/g, ',')
+      .join("\n")
+      .replace(/\n<\/?a>\n/g, " ")
+      .replace(/ \./g, ".")
+      .replace(/ \,/g, ",")
   )
 }
 
-function nodeContent (node) {
-  if (node.type === 'link_open') return '<a>'
-  if (node.type === 'link_close') return '</a>'
+function nodeContent(node) {
+  if (node.type === "link_open") return "<a>"
+  if (node.type === "link_close") return "</a>"
   return node.content
 }
 
-function getCliDesc (activity) {
+function getCliDesc(activity) {
   const command = getCommand(activity.file)
   const output = child_process.execSync(`git-town help ${command}`).toString()
   const matches = output.match(/^.*\n\n([\s\S]*)\n\nUsage:\n/m)
-  return normalize(matches[1].replace(/- /g, '\n').replace(/[0-9]\./g, '\n'))
+  return normalize(matches[1].replace(/- /g, "\n").replace(/[0-9]\./g, "\n"))
 }
 
-function normalize (text) {
+function normalize(text) {
   return text
-    .replace(/\./g, '.\n')
-    .replace(/\,/g, ',\n')
-    .replace(/[ ]+/g, ' ')
-    .replace(/\n+/g, '\n')
-    .replace(/"/g, '\n')
-    .replace(/:/g, '\n')
-    .replace(/^\s+/gm, '')
-    .replace(/\s+$/gm, '')
+    .replace(/\./g, ".\n")
+    .replace(/\,/g, ",\n")
+    .replace(/[ ]+/g, " ")
+    .replace(/\n+/g, "\n")
+    .replace(/"/g, "\n")
+    .replace(/:/g, "\n")
+    .replace(/^\s+/gm, "")
+    .replace(/\s+$/gm, "")
     .trim()
 }

--- a/text-run/command-flags.js
+++ b/text-run/command-flags.js
@@ -1,27 +1,27 @@
-const child_process = require('child_process')
-const diff = require('jsdiff-console')
-const getCommand = require('./helpers/get-command.js')
+const child_process = require("child_process")
+const diff = require("jsdiff-console")
+const getCommand = require("./helpers/get-command.js")
 
-module.exports = async function (activity) {
+module.exports = async function(activity) {
   const mdFlags = getMdFlags(activity)
   const cliFlags = getCliFlags(activity)
   diff(mdFlags, cliFlags)
 }
 
-function getMdFlags (activity) {
+function getMdFlags(activity) {
   return activity.nodes
     .text()
     .trim()
-    .split('\n')
+    .split("\n")
 }
 
-function getCliFlags (activity) {
+function getCliFlags(activity) {
   return child_process
     .execSync(`git-town help ${getCommand(activity.file)}`)
     .toString()
     .match(/\nFlags:\n([\s\S]*)\nGlobal Flags:\n/)[1]
-    .split('\n')
+    .split("\n")
     .filter(line => line)
-    .filter(line => !line.includes('help'))
+    .filter(line => !line.includes("help"))
     .map(line => line.trim())
 }

--- a/text-run/command-heading.js
+++ b/text-run/command-heading.js
@@ -1,13 +1,13 @@
-const diff = require('jsdiff-console')
-const getCommand = require('./helpers/get-command.js')
+const diff = require("jsdiff-console")
+const getCommand = require("./helpers/get-command.js")
 
-module.exports = async function (activity) {
+module.exports = async function(activity) {
   diff(getCommand(activity.file), getHeadingText(activity))
 }
 
-function getHeadingText (activity) {
+function getHeadingText(activity) {
   return activity.nodes
     .text()
-    .replace(' command', '')
+    .replace(" command", "")
     .toLowerCase()
 }

--- a/text-run/command-subcommands.js
+++ b/text-run/command-subcommands.js
@@ -1,14 +1,14 @@
-const child_process = require('child_process')
-const diff = require('jsdiff-console')
-const getCommand = require('./helpers/get-command.js')
+const child_process = require("child_process")
+const diff = require("jsdiff-console")
+const getCommand = require("./helpers/get-command.js")
 
-module.exports = async function (activity) {
+module.exports = async function(activity) {
   const mdCommands = await getMdCommands(activity.nodes)
   const cliCommands = getCliCommands(activity)
   diff(mdCommands, cliCommands)
 }
 
-function getCliCommands (activity) {
+function getCliCommands(activity) {
   const result = []
   const command = getCommand(activity.file)
   const cliOutput = child_process
@@ -16,23 +16,23 @@ function getCliCommands (activity) {
     .toString()
   const matches = cliOutput.match(/\nAvailable Commands:\n([\s\S]*?)\n\n/)
   const text = matches[1]
-  for (const line of text.split('\n')) {
+  for (const line of text.split("\n")) {
     const words = line.trim().split(/\s+/)
     const command = words[0]
-    const desc = words.slice(1).join(' ')
+    const desc = words.slice(1).join(" ")
     result.push([command, desc])
   }
   return result
 }
 
-async function getMdCommands (nodes) {
+async function getMdCommands(nodes) {
   const result = []
-  const table = nodes.getNodeOfTypes('table_open')
+  const table = nodes.getNodeOfTypes("table_open")
   const tableNodes = nodes.getNodesFor(table)
-  for (const tableRow of tableNodes.getNodesOfTypes('table_row_open')) {
+  for (const tableRow of tableNodes.getNodesOfTypes("table_row_open")) {
     const rowNodes = tableNodes.getNodesFor(tableRow)
-    const commandName = rowNodes.getNodeOfTypes('table_heading')
-    const commandDesc = rowNodes.getNodeOfTypes('table_cell')
+    const commandName = rowNodes.getNodeOfTypes("table_heading")
+    const commandDesc = rowNodes.getNodeOfTypes("table_cell")
     result.push([commandName.content, commandDesc.content])
   }
   return result

--- a/text-run/command-summary.js
+++ b/text-run/command-summary.js
@@ -1,14 +1,14 @@
-const child_process = require('child_process')
-const diff = require('jsdiff-console')
-const getCommand = require('./helpers/get-command.js')
+const child_process = require("child_process")
+const diff = require("jsdiff-console")
+const getCommand = require("./helpers/get-command.js")
 
-module.exports = async function (activity) {
+module.exports = async function(activity) {
   const mdSummary = activity.nodes.text().trim()
   const cliSummary = getCliDescription(activity)
   diff(mdSummary, cliSummary)
 }
 
-function getCliDescription (activity) {
+function getCliDescription(activity) {
   const command = getCommand(activity.file)
   const cliOutput = child_process
     .execSync(`git-town help ${command}`)

--- a/text-run/command-usage.js
+++ b/text-run/command-usage.js
@@ -1,16 +1,16 @@
-const child_process = require('child_process')
-const diff = require('jsdiff-console')
-const getCommand = require('./helpers/get-command.js')
-const he = require('he')
+const child_process = require("child_process")
+const diff = require("jsdiff-console")
+const getCommand = require("./helpers/get-command.js")
+const he = require("he")
 
-module.exports = async function (activity) {
+module.exports = async function(activity) {
   const mdUsage = activity.nodes.text().trim()
   const cliUsage = getCliUsage(activity)
   const cliEncoded = he.encode(cliUsage, { useNamedReferences: true })
   diff(mdUsage, cliEncoded)
 }
 
-function getCliUsage (activity) {
+function getCliUsage(activity) {
   const command = getCommand(activity.file)
   const cliOutput = child_process
     .execSync(`git-town help ${command}`)
@@ -18,7 +18,7 @@ function getCliUsage (activity) {
   const matches = cliOutput.match(/\nUsage:\n([\s\S]*?)\n\n/)
   return matches[1]
     .trim()
-    .replace(' [flags]', '')
-    .replace(/git-town/g, 'git town')
-    .replace(/^\s+/gm, '')
+    .replace(" [flags]", "")
+    .replace(/git-town/g, "git town")
+    .replace(/^\s+/gm, "")
 }

--- a/text-run/helpers/get-command.js
+++ b/text-run/helpers/get-command.js
@@ -1,5 +1,5 @@
-const path = require('path')
+const path = require("path")
 
-module.exports = function getCommand (filename) {
-  return path.basename(filename, '.md')
+module.exports = function getCommand(filename) {
+  return path.basename(filename, ".md")
 }

--- a/text-run/verify-make-command.js
+++ b/text-run/verify-make-command.js
@@ -1,18 +1,18 @@
-const { cyan } = require('chalk')
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
-const util = require('util')
+const { cyan } = require("chalk")
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const util = require("util")
 const readFile = util.promisify(fs.readFile)
 
-module.exports = async function ({ configuration, formatter, nodes }) {
+module.exports = async function({ configuration, formatter, nodes }) {
   const expected = nodes
     .text()
-    .replace(/make\s+/, '')
+    .replace(/make\s+/, "")
     .trim()
   formatter.name(`verify Make command ${cyan(expected)} exists`)
-  const makefilePath = path.join(configuration.sourceDir, 'Makefile')
-  const makefileContent = await readFile(makefilePath, 'utf8')
+  const makefilePath = path.join(configuration.sourceDir, "Makefile")
+  const makefileContent = await readFile(makefilePath, "utf8")
   const commands = makefileContent
     .split(os.EOL)
     .filter(lineDefinesMakeCommand)
@@ -24,13 +24,13 @@ module.exports = async function ({ configuration, formatter, nodes }) {
 
 // returns whether the given line from a Makefile
 // defines a Make command
-function lineDefinesMakeCommand (line) {
+function lineDefinesMakeCommand(line) {
   return makeCommandRE.test(line)
 }
 const makeCommandRE = /^[^ ]+:/
 
 // returns the defined command name
 // from a Makefile line that defines a Make command
-function extractMakeCommand (line) {
-  return line.split(':')[0]
+function extractMakeCommand(line) {
+  return line.split(":")[0]
 }

--- a/website/_harp.json
+++ b/website/_harp.json
@@ -1,11 +1,11 @@
 {
-  "globals" : {
-    "site_name"   : "Git Town",
-    "site_description" : "Git Town.",
-    "site_keywords"    : "git, gittown, town",
-    "facebook_meta"    : {
-      "type"        : "",
-      "image"       : ""
+  "globals": {
+    "site_name": "Git Town",
+    "site_description": "Git Town.",
+    "site_keywords": "git, gittown, town",
+    "facebook_meta": {
+      "type": "",
+      "image": ""
     },
     "page_titles": {
       "index": "Welcome to GitTown",


### PR DESCRIPTION
Prettier can standardize a lot more files than Markdown. This adds prettification of `yml`, `json`, `js`.