### PR TITLE
Remove "he" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "dependencies": {},
   "devDependencies": {
     "harp": "0.30.0",
-    "he": "1.2.0",
     "jsdiff-console": "2.2.1",
     "prettier": "1.17.0",
     "prettier-standard": "9.1.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "devDependencies": {
     "assert-no-diff": "3.0.3",
     "harp": "0.30.0",
-    "jsdiff-console": "2.2.1",
     "prettier": "1.18.2",
     "prettier-standard": "9.1.1",
     "tertestrial": "0.3.2",

--- a/text-run/command-usage.js
+++ b/text-run/command-usage.js
@@ -4,7 +4,6 @@ const getCommand = require("./helpers/get-command.js")
 
 module.exports = async function(activity) {
   const mdUsage = unescape(activity.nodes.text().trim())
-  console.log(mdUsage)
   const cliUsage = getCliUsage(activity)
   diff(mdUsage, cliUsage)
 }

--- a/text-run/command-usage.js
+++ b/text-run/command-usage.js
@@ -3,7 +3,11 @@ const diff = require("jsdiff-console")
 const getCommand = require("./helpers/get-command.js")
 
 module.exports = async function(activity) {
-  const mdUsage = unescape(activity.nodes.text().trim())
+  const mdUsage = activity.nodes
+    .text()
+    .trim()
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
   const cliUsage = getCliUsage(activity)
   diff(mdUsage, cliUsage)
 }

--- a/text-run/command-usage.js
+++ b/text-run/command-usage.js
@@ -1,13 +1,12 @@
 const child_process = require("child_process")
 const diff = require("jsdiff-console")
 const getCommand = require("./helpers/get-command.js")
-const he = require("he")
 
 module.exports = async function(activity) {
-  const mdUsage = activity.nodes.text().trim()
+  const mdUsage = unescape(activity.nodes.text().trim())
+  console.log(mdUsage)
   const cliUsage = getCliUsage(activity)
-  const cliEncoded = he.encode(cliUsage, { useNamedReferences: true })
-  diff(mdUsage, cliEncoded)
+  diff(mdUsage, cliUsage)
 }
 
 function getCliUsage(activity) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,11 +2729,6 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-he@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
-  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
The NPM ecosystem is plagued with bloat and countless security issues of various packages. Because of this, I have been on a journey to reduce dependencies on external libraries recently. All we are ever going to need here is decoding angle brackets, which can be implemented with just a few lines of code. This prevents downloading and parsing a full-fledged library containing a whopping [![install size](https://packagephobia.now.sh/badge?p=he)](https://packagephobia.now.sh/result?p=he) of stuff. 