### PR TITLE
Improve Make task names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - make setup
 
 script:
-  - make spec
+  - make test
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,8 @@ setup:  # the setup steps necessary on developer machines
 	bundle install
 	yarn install
 
-spec: lint unit cuke  # runs all the tests
+test: lint unit cuke  # runs all the tests
+.PHONY: test
 
 unit:  # runs the unit tests
 	ginkgo src/...

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,9 @@ setup:  # the setup steps necessary on developer machines
 	bundle install
 	yarn install
 
-spec: lint tests cuke  # runs all the tests
+spec: lint unit cuke  # runs all the tests
 
-tests:  # runs the unit tests
+unit:  # runs the unit tests
 	ginkgo src/...
 
 update:  # updates all dependencies

--- a/documentation/development/testing.md
+++ b/documentation/development/testing.md
@@ -12,7 +12,7 @@ Unit tests are written as normal Go tests using [Ginkgo](https://github.com/onsi
 
 ```bash
 # running the different test types
-make spec       # runs all tests
+make test       # runs all tests
 make lint       # runs the linters
 make lint-go    # runs the Go linters
 make cuke       # runs the feature tests


### PR DESCRIPTION
The names of the make tasks were confusing. For example, `make tests` sounds like it runs all the tests, but it only runs the unit tests. `make spec` sounds like it runs the feature specs, but it runs all the tests including checking formatting. This PR changes them to:

* `make test` runs all the tests
* `make unit` runs the unit tests