### PR TITLE
Command.OutputLines() method

### DIFF
--- a/src/command/command.go
+++ b/src/command/command.go
@@ -46,6 +46,12 @@ func (r *Command) Output() string {
 	return r.output
 }
 
+// OutputLines returns the output of this command, split into lines.
+// Runs if it hasn't so far.
+func (r *Command) OutputLines() []string {
+	return strings.Split(r.Output(), "\n")
+}
+
 // Err returns the error that this command encountered.
 // Runs the command if it hasn't so far.
 func (r *Command) Err() error {
@@ -56,9 +62,7 @@ func (r *Command) Err() error {
 // OutputContainsLine returns whether the output of this command
 // contains the given line
 func (r *Command) OutputContainsLine(line string) bool {
-	r.Run()
-	lines := strings.Split(r.output, "\n")
-	return util.DoesStringArrayContain(lines, line)
+	return util.DoesStringArrayContain(r.OutputLines(), line)
 }
 
 // OutputContainsText returns whether the output of this command

--- a/src/git/branch.go
+++ b/src/git/branch.go
@@ -59,7 +59,7 @@ func GetExpectedPreviouslyCheckedOutBranch(initialPreviouslyCheckedOutBranch, in
 // GetLocalBranches returns the names of all branches in the local repository,
 // ordered alphabetically
 func GetLocalBranches() (result []string) {
-	for _, line := range strings.Split(command.New("git", "branch").Output(), "\n") {
+	for _, line := range command.New("git", "branch").OutputLines() {
 		line = strings.Trim(line, "* ")
 		line = strings.TrimSpace(line)
 		result = append(result, line)
@@ -82,7 +82,7 @@ func GetLocalBranchesWithoutMain() (result []string) {
 // GetLocalBranchesWithDeletedTrackingBranches returns the names of all branches
 // whose remote tracking branches have been deleted
 func GetLocalBranchesWithDeletedTrackingBranches() (result []string) {
-	for _, line := range strings.Split(command.New("git", "branch", "-vv").Output(), "\n") {
+	for _, line := range command.New("git", "branch", "-vv").OutputLines() {
 		line = strings.Trim(line, "* ")
 		parts := strings.SplitN(line, " ", 2)
 		branchName := parts[0]
@@ -127,7 +127,7 @@ func GetTrackingBranchName(branchName string) string {
 // HasBranch returns whether the repository contains a branch with the given name.
 // The branch does not have to be present on the local repository.
 func HasBranch(branchName string) bool {
-	for _, line := range strings.Split(command.New("git", "branch", "-a").Output(), "\n") {
+	for _, line := range command.New("git", "branch", "-a").OutputLines() {
 		line = strings.Trim(line, "* ")
 		line = strings.TrimSpace(line)
 		line = strings.Replace(line, "remotes/origin/", "", 1)
@@ -182,7 +182,7 @@ var remoteBranchesInitialized bool
 
 func getRemoteBranches() []string {
 	if !remoteBranchesInitialized {
-		remoteBranches = strings.Split(command.New("git", "branch", "-r").Output(), "\n")
+		remoteBranches = command.New("git", "branch", "-r").OutputLines()
 		remoteBranchesInitialized = true
 	}
 	return remoteBranches

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -310,7 +310,7 @@ var remotesInitialized bool
 
 func getRemotes() []string {
 	if !remotesInitialized {
-		remotes = strings.Split(command.New("git", "remote").Output(), "\n")
+		remotes = command.New("git", "remote").OutputLines()
 		remotesInitialized = true
 	}
 	return remotes

--- a/src/prompt/squash_commit_author.go
+++ b/src/prompt/squash_commit_author.go
@@ -40,8 +40,8 @@ func askForAuthor(authors []string) string {
 
 func getBranchAuthors(branchName string) (result []string) {
 	// Returns lines of "<number of commits>\t<name and email>"
-	output := command.New("git", "shortlog", "-s", "-n", "-e", git.GetMainBranch()+".."+branchName).Output()
-	for _, line := range strings.Split(output, "\n") {
+	output := command.New("git", "shortlog", "-s", "-n", "-e", git.GetMainBranch()+".."+branchName).OutputLines()
+	for _, line := range output {
 		line = strings.TrimSpace(line)
 		parts := strings.Split(line, "\t")
 		result = append(result, parts[1])


### PR DESCRIPTION
This removes some redundancy around splitting command output into lines. I would argue that this is a responsibility of the Command class anyways. It needs to be aware of which platform it runs on, execute its payload in a platform-specific way, and parse the output in a platform-specific way as well. 