### PR TITLE
Make command API idiot-proof

### DIFF
--- a/src/browsers/browsers.go
+++ b/src/browsers/browsers.go
@@ -18,8 +18,8 @@ func GetOpenBrowserCommand() string {
 		return "start"
 	}
 	for _, browserCommand := range openBrowserCommands {
-		cmd := command.New("which", browserCommand)
-		if cmd.Err() == nil && cmd.Output() != "" {
+		res := command.Run("which", browserCommand)
+		if res.Err() == nil && res.Output() != "" {
 			return browserCommand
 		}
 	}

--- a/src/command/command_test.go
+++ b/src/command/command_test.go
@@ -1,118 +1,52 @@
 package command_test
 
 import (
-	"time"
-
 	"github.com/Originate/git-town/src/command"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var cmd *command.Command
-
-var _ = Describe("New", func() {
-
-	BeforeEach(func() {
-		cmd = command.New("cd", ".")
-	})
-
-	It("creates a new Cmd instance", func() {
-		Expect(cmd).ToNot(BeNil())
-	})
-})
+var res *command.Result
 
 var _ = Describe("Run", func() {
-
-	BeforeEach(func() {
-		cmd = command.New("cd", ".")
-	})
-
-	It("runs the given command", func() {
-		cmd.Run()
-	})
-
-	Describe("Idempotency", func() {
-
-		BeforeEach(func() {
-			cmd = command.New("ruby", "-e", "puts Time.now.to_f")
-		})
-
-		It("does not re-run the command", func() {
-			cmd.Run()
-			firstOutput := cmd.Output()
-			time.Sleep(1 * time.Millisecond)
-			cmd.Run()
-			secondOutput := cmd.Output()
-			Expect(firstOutput).To(Equal(secondOutput))
-		})
-	})
-})
-
-var _ = Describe("Output", func() {
-
-	Describe("return value", func() {
-
-		BeforeEach(func() {
-			cmd = command.New("echo", "foo")
-		})
-
-		It("returns the output of this command", func() {
-			cmd.Run()
-			Expect(cmd.Output()).To(Equal("foo"))
-		})
-
-		It("runs the command if it hasn't run so far", func() {
-			Expect(cmd.Output()).To(Equal("foo"))
-		})
-	})
-
-	Describe("Idempotency", func() {
-
-		BeforeEach(func() {
-			cmd = command.New("ruby", "-e", "puts Time.now.to_f")
-		})
-
-		It("does not re-run the command", func() {
-			firstOutput := cmd.Output()
-			time.Sleep(1 * time.Millisecond)
-			secondOutput := cmd.Output()
-			Expect(firstOutput).To(Equal(secondOutput))
-		})
+	It("Runs the given command", func() {
+		res = command.Run("echo", "foo")
+		Expect(res.Output()).To(Equal("foo"))
 	})
 })
 
 var _ = Describe("OutputContainsText", func() {
 
 	BeforeEach(func() {
-		cmd = command.New("echo", "hello world how are you?")
+		res = command.Run("echo", "hello world how are you?")
 	})
 
 	It("returns true if the output contains the given text", func() {
-		Expect(cmd.OutputContainsText("world")).To(BeTrue())
+		Expect(res.OutputContainsText("world")).To(BeTrue())
 	})
 
 	It("returns false if the output does not contain the given text", func() {
-		Expect(cmd.OutputContainsText("zonk")).To(BeFalse())
+		Expect(res.OutputContainsText("zonk")).To(BeFalse())
 	})
 })
 
 var _ = Describe("OutputContainsLine", func() {
 
 	BeforeEach(func() {
-		cmd = command.New("echo", "hello world")
+		res = command.Run("echo", "hello world")
 	})
 
 	It("returns true if the output contains the given line", func() {
-		Expect(cmd.OutputContainsLine("hello world")).To(BeTrue())
+		Expect(res.OutputContainsLine("hello world")).To(BeTrue())
 	})
 
 	It("returns false if the output contains only parts of the given line", func() {
-		Expect(cmd.OutputContainsLine("hello")).To(BeFalse())
+		Expect(res.OutputContainsLine("hello")).To(BeFalse())
 	})
 
 	It("returns false if the output does not contains the given line", func() {
-		Expect(cmd.OutputContainsLine("zonk")).To(BeFalse())
+		Expect(res.OutputContainsLine("zonk")).To(BeFalse())
 	})
 })
 
@@ -121,22 +55,22 @@ var _ = Describe("Err", func() {
 	Context("command not found", func() {
 
 		BeforeEach(func() {
-			cmd = command.New("zonk")
+			res = command.Run("zonk")
 		})
 
 		It("returns an error", func() {
-			Expect(cmd.Err()).To(HaveOccurred())
+			Expect(res.Err()).To(HaveOccurred())
 		})
 	})
 
 	Context("command returns exit code", func() {
 
 		BeforeEach(func() {
-			cmd = command.New("bash", "-c", "exit 2")
+			res = command.Run("bash", "-c", "exit 2")
 		})
 
 		It("returns an error", func() {
-			Expect(cmd.Err()).To(HaveOccurred())
+			Expect(res.Err()).To(HaveOccurred())
 		})
 	})
 })

--- a/src/command/debug.go
+++ b/src/command/debug.go
@@ -15,10 +15,10 @@ func SetDebug(value bool) {
 	debug = value
 }
 
-func logRun(c *Command) {
+func logRun(argv ...string) {
 	if debug {
 		count++
-		_, err := color.New(color.FgBlue).Printf("DEBUG (%d): %s\n", count, strings.Join(append([]string{c.name}, c.args...), " "))
+		_, err := color.New(color.FgBlue).Printf("DEBUG (%d): %s\n", count, strings.Join(argv, " "))
 		exit.If(err)
 	}
 }

--- a/src/git/branch.go
+++ b/src/git/branch.go
@@ -11,7 +11,7 @@ import (
 // DoesBranchHaveUnmergedCommits returns whether the branch with the given name
 // contains commits that are not merged into the main branch
 func DoesBranchHaveUnmergedCommits(branchName string) bool {
-	return command.New("git", "log", GetMainBranch()+".."+branchName).Output() != ""
+	return command.Run("git", "log", GetMainBranch()+".."+branchName).Output() != ""
 }
 
 // EnsureBranchInSync enforces that a branch with the given name is in sync with its tracking branch
@@ -59,7 +59,7 @@ func GetExpectedPreviouslyCheckedOutBranch(initialPreviouslyCheckedOutBranch, in
 // GetLocalBranches returns the names of all branches in the local repository,
 // ordered alphabetically
 func GetLocalBranches() (result []string) {
-	for _, line := range command.New("git", "branch").OutputLines() {
+	for _, line := range command.Run("git", "branch").OutputLines() {
 		line = strings.Trim(line, "* ")
 		line = strings.TrimSpace(line)
 		result = append(result, line)
@@ -82,7 +82,7 @@ func GetLocalBranchesWithoutMain() (result []string) {
 // GetLocalBranchesWithDeletedTrackingBranches returns the names of all branches
 // whose remote tracking branches have been deleted
 func GetLocalBranchesWithDeletedTrackingBranches() (result []string) {
-	for _, line := range command.New("git", "branch", "-vv").OutputLines() {
+	for _, line := range command.Run("git", "branch", "-vv").OutputLines() {
 		line = strings.Trim(line, "* ")
 		parts := strings.SplitN(line, " ", 2)
 		branchName := parts[0]
@@ -111,7 +111,7 @@ func GetLocalBranchesWithMainBranchFirst() (result []string) {
 
 // GetPreviouslyCheckedOutBranch returns the name of the previously checked out branch
 func GetPreviouslyCheckedOutBranch() string {
-	cmd := command.New("git", "rev-parse", "--verify", "--abbrev-ref", "@{-1}")
+	cmd := command.Run("git", "rev-parse", "--verify", "--abbrev-ref", "@{-1}")
 	if cmd.Err() != nil {
 		return ""
 	}
@@ -127,7 +127,7 @@ func GetTrackingBranchName(branchName string) string {
 // HasBranch returns whether the repository contains a branch with the given name.
 // The branch does not have to be present on the local repository.
 func HasBranch(branchName string) bool {
-	for _, line := range command.New("git", "branch", "-a").OutputLines() {
+	for _, line := range command.Run("git", "branch", "-a").OutputLines() {
 		line = strings.Trim(line, "* ")
 		line = strings.TrimSpace(line)
 		line = strings.Replace(line, "remotes/origin/", "", 1)
@@ -170,7 +170,7 @@ func IsBranchInSync(branchName string) bool {
 // contains commits that have not been pushed to the remote.
 func ShouldBranchBePushed(branchName string) bool {
 	trackingBranchName := GetTrackingBranchName(branchName)
-	cmd := command.New("git", "rev-list", "--left-right", branchName+"..."+trackingBranchName)
+	cmd := command.Run("git", "rev-list", "--left-right", branchName+"..."+trackingBranchName)
 	return cmd.Output() != ""
 }
 
@@ -182,7 +182,7 @@ var remoteBranchesInitialized bool
 
 func getRemoteBranches() []string {
 	if !remoteBranchesInitialized {
-		remoteBranches = command.New("git", "branch", "-r").OutputLines()
+		remoteBranches = command.Run("git", "branch", "-r").OutputLines()
 		remoteBranchesInitialized = true
 	}
 	return remoteBranches

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -123,12 +123,12 @@ func GetRemoteOriginURL() string {
 			return mockRemoteURL
 		}
 	}
-	return command.New("git", "remote", "get-url", "origin").Output()
+	return command.Run("git", "remote", "get-url", "origin").Output()
 }
 
 // GetRemoteUpstreamURL returns the URL of the "upstream" remote.
 func GetRemoteUpstreamURL() string {
-	return command.New("git", "remote", "get-url", "upstream").Output()
+	return command.Run("git", "remote", "get-url", "upstream").Output()
 }
 
 // GetURLHostname returns the hostname contained within the given Git URL.
@@ -155,7 +155,7 @@ func GetURLRepositoryName(url string) string {
 
 // HasGlobalConfigurationValue returns whether there is a global git configuration for the given key
 func HasGlobalConfigurationValue(key string) bool {
-	return command.New("git", "config", "-l", "--global", "--name").OutputContainsLine(key)
+	return command.Run("git", "config", "-l", "--global", "--name").OutputContainsLine(key)
 }
 
 // HasParentBranch returns whether or not the given branch has a parent
@@ -196,7 +196,7 @@ func IsPerennialBranch(branchName string) bool {
 
 // RemoveAllConfiguration removes all Git Town configuration
 func RemoveAllConfiguration() {
-	command.New("git", "config", "--remove-section", "git-town").Output()
+	command.Run("git", "config", "--remove-section", "git-town").Output()
 }
 
 // RemoveOutdatedConfiguration removes outdated Git Town configuration
@@ -289,18 +289,18 @@ func getConfigurationKeysMatching(toMatch string) (result []string) {
 }
 
 func setConfigurationValue(key, value string) {
-	command.New("git", "config", key, value).Run()
+	command.Run("git", "config", key, value)
 	configMap.Set(key, value)
 }
 
 func setGlobalConfigurationValue(key, value string) {
-	command.New("git", "config", "--global", key, value).Run()
+	command.Run("git", "config", "--global", key, value)
 	globalConfigMap.Set(key, value)
 	configMap.Reset() // Need to reset config in case it was inheriting
 }
 
 func removeConfigurationValue(key string) {
-	command.New("git", "config", "--unset", key).Run()
+	command.Run("git", "config", "--unset", key)
 	configMap.Delete(key)
 }
 
@@ -310,7 +310,7 @@ var remotesInitialized bool
 
 func getRemotes() []string {
 	if !remotesInitialized {
-		remotes = command.New("git", "remote").OutputLines()
+		remotes = command.Run("git", "remote").OutputLines()
 		remotesInitialized = true
 	}
 	return remotes

--- a/src/git/config_map.go
+++ b/src/git/config_map.go
@@ -69,7 +69,7 @@ func (c *ConfigMap) initialize() {
 	if c.global {
 		cmdArgs = append(cmdArgs, "--global")
 	}
-	cmd := command.New(cmdArgs...)
+	cmd := command.Run(cmdArgs...)
 	if cmd.Err() != nil && strings.Contains(cmd.Output(), "No such file or directory") {
 		return
 	}

--- a/src/git/current_branch.go
+++ b/src/git/current_branch.go
@@ -22,7 +22,7 @@ func GetCurrentBranchName() string {
 		if IsRebaseInProgress() {
 			currentBranchCache = getCurrentBranchNameDuringRebase()
 		} else {
-			currentBranchCache = command.New("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+			currentBranchCache = command.Run("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
 		}
 	}
 	return currentBranchCache

--- a/src/git/environment.go
+++ b/src/git/environment.go
@@ -35,7 +35,7 @@ var isRepositoryInitialized bool
 // IsRepository returns whether or not the current directory is in a repository
 func IsRepository() bool {
 	if !isRepositoryInitialized {
-		isRepository = command.New("git", "rev-parse").Err() == nil
+		isRepository = command.Run("git", "rev-parse").Err() == nil
 		isRepositoryInitialized = true
 	}
 	return isRepository

--- a/src/git/log.go
+++ b/src/git/log.go
@@ -4,5 +4,5 @@ import "github.com/Originate/git-town/src/command"
 
 // GetLastCommitMessage returns the commit message for the last commit
 func GetLastCommitMessage() string {
-	return command.New("git", "log", "-1", "--format=%B").Output()
+	return command.Run("git", "log", "-1", "--format=%B").Output()
 }

--- a/src/git/sha.go
+++ b/src/git/sha.go
@@ -5,7 +5,7 @@ import "github.com/Originate/git-town/src/command"
 // GetBranchSha returns the SHA1 of the latest commit
 // on the branch with the given name.
 func GetBranchSha(branchName string) string {
-	return command.New("git", "rev-parse", branchName).Output()
+	return command.Run("git", "rev-parse", branchName).Output()
 }
 
 // GetCurrentSha returns the SHA of the currently checked out commit.

--- a/src/git/status.go
+++ b/src/git/status.go
@@ -27,25 +27,25 @@ var rootDirectory string
 // i.e. the directory that contains the ".git" folder.
 func GetRootDirectory() string {
 	if rootDirectory == "" {
-		rootDirectory = command.New("git", "rev-parse", "--show-toplevel").Output()
+		rootDirectory = command.Run("git", "rev-parse", "--show-toplevel").Output()
 	}
 	return rootDirectory
 }
 
 // HasConflicts returns whether the local repository currently has unresolved merge conflicts.
 func HasConflicts() bool {
-	return command.New("git", "status").OutputContainsText("Unmerged paths")
+	return command.Run("git", "status").OutputContainsText("Unmerged paths")
 }
 
 // HasOpenChanges returns whether the local repository contains uncommitted changes.
 func HasOpenChanges() bool {
-	return command.New("git", "status", "--porcelain").Output() != ""
+	return command.Run("git", "status", "--porcelain").Output() != ""
 }
 
 // HasShippableChanges returns whether the supplied branch has an changes
 // not currently on the main branchName
 func HasShippableChanges(branchName string) bool {
-	return command.New("git", "diff", GetMainBranch()+".."+branchName).Output() != ""
+	return command.Run("git", "diff", GetMainBranch()+".."+branchName).Output() != ""
 }
 
 // IsMergeInProgress returns whether the local repository is in the middle of
@@ -58,5 +58,5 @@ func IsMergeInProgress() bool {
 // IsRebaseInProgress returns whether the local repository is in the middle of
 // an unfinished rebase process.
 func IsRebaseInProgress() bool {
-	return command.New("git", "status").OutputContainsText("rebase in progress")
+	return command.Run("git", "status").OutputContainsText("rebase in progress")
 }

--- a/src/git/user.go
+++ b/src/git/user.go
@@ -4,7 +4,7 @@ import "github.com/Originate/git-town/src/command"
 
 // GetLocalAuthor returns the locally Git configured user
 func GetLocalAuthor() string {
-	name := command.New("git", "config", "user.name").Output()
-	email := command.New("git", "config", "user.email").Output()
+	name := command.Run("git", "config", "user.name").Output()
+	email := command.Run("git", "config", "user.email").Output()
 	return name + " <" + email + ">"
 }

--- a/src/git/version.go
+++ b/src/git/version.go
@@ -19,7 +19,7 @@ func EnsureVersionRequirementSatisfied() {
 
 func isVersionRequirementSatisfied() bool {
 	versionRegexp := regexp.MustCompile(`git version (\d+).(\d+).(\d+)`)
-	matches := versionRegexp.FindStringSubmatch(command.New("git", "version").Output())
+	matches := versionRegexp.FindStringSubmatch(command.Run("git", "version").Output())
 	if matches == nil {
 		log.Fatal("'git version' returned unexpected output. Please open an issue and supply the output of running 'git version'.")
 	}

--- a/src/prompt/squash_commit_author.go
+++ b/src/prompt/squash_commit_author.go
@@ -40,7 +40,7 @@ func askForAuthor(authors []string) string {
 
 func getBranchAuthors(branchName string) (result []string) {
 	// Returns lines of "<number of commits>\t<name and email>"
-	output := command.New("git", "shortlog", "-s", "-n", "-e", git.GetMainBranch()+".."+branchName).OutputLines()
+	output := command.Run("git", "shortlog", "-s", "-n", "-e", git.GetMainBranch()+".."+branchName).OutputLines()
 	for _, line := range output {
 		line = strings.TrimSpace(line)
 		parts := strings.Split(line, "\t")

--- a/src/steps/preserve_checkout_history_step.go
+++ b/src/steps/preserve_checkout_history_step.go
@@ -17,8 +17,8 @@ func (step *PreserveCheckoutHistoryStep) Run() error {
 	expectedPreviouslyCheckedOutBranch := git.GetExpectedPreviouslyCheckedOutBranch(step.InitialPreviouslyCheckedOutBranch, step.InitialBranch)
 	if expectedPreviouslyCheckedOutBranch != git.GetPreviouslyCheckedOutBranch() {
 		currentBranch := git.GetCurrentBranchName()
-		command.New("git", "checkout", expectedPreviouslyCheckedOutBranch).Run()
-		command.New("git", "checkout", currentBranch).Run()
+		command.Run("git", "checkout", expectedPreviouslyCheckedOutBranch)
+		command.Run("git", "checkout", currentBranch)
 	}
 	return nil
 }


### PR DESCRIPTION
In preparation for merging the command package with my ShellRunner in the Cucumber tests, 
this simplifies the implementation of the command package and makes it abuse-proof:
- the only public API of the `command` package is a `Run` method. It executes the given command and returns a `command.Result` instance containing the output and error
- there is no way to execute that same command again, so we can get rid of a lot of boilerplate to ensure idempotency.