### PR TITLE
Use src/command to run subshell commands in tests

### DIFF
--- a/src/browsers/browsers.go
+++ b/src/browsers/browsers.go
@@ -19,7 +19,7 @@ func GetOpenBrowserCommand() string {
 	}
 	for _, browserCommand := range openBrowserCommands {
 		res := command.Run("which", browserCommand)
-		if res.Err() == nil && res.Output() != "" {
+		if res.Err() == nil && res.OutputSanitized() != "" {
 			return browserCommand
 		}
 	}

--- a/src/command/command_test.go
+++ b/src/command/command_test.go
@@ -12,7 +12,7 @@ var res *command.Result
 var _ = Describe("Run", func() {
 	It("Runs the given command", func() {
 		res = command.Run("echo", "foo")
-		Expect(res.Output()).To(Equal("foo"))
+		Expect(res.OutputSanitized()).To(Equal("foo"))
 	})
 })
 

--- a/src/command/debug.go
+++ b/src/command/debug.go
@@ -15,10 +15,10 @@ func SetDebug(value bool) {
 	debug = value
 }
 
-func logRun(argv ...string) {
+func logRun(cmd string, args ...string) {
 	if debug {
 		count++
-		_, err := color.New(color.FgBlue).Printf("DEBUG (%d): %s\n", count, strings.Join(argv, " "))
+		_, err := color.New(color.FgBlue).Printf("DEBUG (%d): %s %s\n", count, cmd, strings.Join(args, " "))
 		exit.If(err)
 	}
 }

--- a/src/git/branch.go
+++ b/src/git/branch.go
@@ -11,7 +11,7 @@ import (
 // DoesBranchHaveUnmergedCommits returns whether the branch with the given name
 // contains commits that are not merged into the main branch
 func DoesBranchHaveUnmergedCommits(branchName string) bool {
-	return command.Run("git", "log", GetMainBranch()+".."+branchName).Output() != ""
+	return command.Run("git", "log", GetMainBranch()+".."+branchName).OutputSanitized() != ""
 }
 
 // EnsureBranchInSync enforces that a branch with the given name is in sync with its tracking branch
@@ -115,7 +115,7 @@ func GetPreviouslyCheckedOutBranch() string {
 	if cmd.Err() != nil {
 		return ""
 	}
-	return cmd.Output()
+	return cmd.OutputSanitized()
 }
 
 // GetTrackingBranchName returns the name of the remote branch
@@ -171,7 +171,7 @@ func IsBranchInSync(branchName string) bool {
 func ShouldBranchBePushed(branchName string) bool {
 	trackingBranchName := GetTrackingBranchName(branchName)
 	cmd := command.Run("git", "rev-list", "--left-right", branchName+"..."+trackingBranchName)
-	return cmd.Output() != ""
+	return cmd.OutputSanitized() != ""
 }
 
 // Helpers

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -123,12 +123,12 @@ func GetRemoteOriginURL() string {
 			return mockRemoteURL
 		}
 	}
-	return command.Run("git", "remote", "get-url", "origin").Output()
+	return command.Run("git", "remote", "get-url", "origin").OutputSanitized()
 }
 
 // GetRemoteUpstreamURL returns the URL of the "upstream" remote.
 func GetRemoteUpstreamURL() string {
-	return command.Run("git", "remote", "get-url", "upstream").Output()
+	return command.Run("git", "remote", "get-url", "upstream").OutputSanitized()
 }
 
 // GetURLHostname returns the hostname contained within the given Git URL.
@@ -196,7 +196,7 @@ func IsPerennialBranch(branchName string) bool {
 
 // RemoveAllConfiguration removes all Git Town configuration
 func RemoveAllConfiguration() {
-	command.Run("git", "config", "--remove-section", "git-town").Output()
+	command.Run("git", "config", "--remove-section", "git-town").OutputSanitized()
 }
 
 // RemoveOutdatedConfiguration removes outdated Git Town configuration

--- a/src/git/config_map.go
+++ b/src/git/config_map.go
@@ -65,16 +65,16 @@ func (c *ConfigMap) initialize() {
 	if c.initialized {
 		return
 	}
-	cmdArgs := []string{"git", "config", "-lz"}
+	cmdArgs := []string{"config", "-lz"}
 	if c.global {
 		cmdArgs = append(cmdArgs, "--global")
 	}
-	cmd := command.Run(cmdArgs...)
+	cmd := command.Run("git", cmdArgs...)
 	if cmd.Err() != nil && strings.Contains(cmd.Output(), "No such file or directory") {
 		return
 	}
 	exit.If(cmd.Err())
-	if cmd.Output() == "" {
+	if cmd.OutputSanitized() == "" {
 		return
 	}
 	for _, line := range strings.Split(cmd.Output(), "\x00") {

--- a/src/git/current_branch.go
+++ b/src/git/current_branch.go
@@ -22,7 +22,7 @@ func GetCurrentBranchName() string {
 		if IsRebaseInProgress() {
 			currentBranchCache = getCurrentBranchNameDuringRebase()
 		} else {
-			currentBranchCache = command.Run("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+			currentBranchCache = command.Run("git", "rev-parse", "--abbrev-ref", "HEAD").OutputSanitized()
 		}
 	}
 	return currentBranchCache

--- a/src/git/log.go
+++ b/src/git/log.go
@@ -4,5 +4,5 @@ import "github.com/Originate/git-town/src/command"
 
 // GetLastCommitMessage returns the commit message for the last commit
 func GetLastCommitMessage() string {
-	return command.Run("git", "log", "-1", "--format=%B").Output()
+	return command.Run("git", "log", "-1", "--format=%B").OutputSanitized()
 }

--- a/src/git/sha.go
+++ b/src/git/sha.go
@@ -5,7 +5,7 @@ import "github.com/Originate/git-town/src/command"
 // GetBranchSha returns the SHA1 of the latest commit
 // on the branch with the given name.
 func GetBranchSha(branchName string) string {
-	return command.Run("git", "rev-parse", branchName).Output()
+	return command.Run("git", "rev-parse", branchName).OutputSanitized()
 }
 
 // GetCurrentSha returns the SHA of the currently checked out commit.

--- a/src/git/status.go
+++ b/src/git/status.go
@@ -27,7 +27,7 @@ var rootDirectory string
 // i.e. the directory that contains the ".git" folder.
 func GetRootDirectory() string {
 	if rootDirectory == "" {
-		rootDirectory = command.Run("git", "rev-parse", "--show-toplevel").Output()
+		rootDirectory = command.Run("git", "rev-parse", "--show-toplevel").OutputSanitized()
 	}
 	return rootDirectory
 }
@@ -39,13 +39,13 @@ func HasConflicts() bool {
 
 // HasOpenChanges returns whether the local repository contains uncommitted changes.
 func HasOpenChanges() bool {
-	return command.Run("git", "status", "--porcelain").Output() != ""
+	return command.Run("git", "status", "--porcelain").OutputSanitized() != ""
 }
 
 // HasShippableChanges returns whether the supplied branch has an changes
 // not currently on the main branchName
 func HasShippableChanges(branchName string) bool {
-	return command.Run("git", "diff", GetMainBranch()+".."+branchName).Output() != ""
+	return command.Run("git", "diff", GetMainBranch()+".."+branchName).OutputSanitized() != ""
 }
 
 // IsMergeInProgress returns whether the local repository is in the middle of

--- a/src/git/user.go
+++ b/src/git/user.go
@@ -4,7 +4,7 @@ import "github.com/Originate/git-town/src/command"
 
 // GetLocalAuthor returns the locally Git configured user
 func GetLocalAuthor() string {
-	name := command.Run("git", "config", "user.name").Output()
-	email := command.Run("git", "config", "user.email").Output()
+	name := command.Run("git", "config", "user.name").OutputSanitized()
+	email := command.Run("git", "config", "user.email").OutputSanitized()
 	return name + " <" + email + ">"
 }

--- a/src/git/version.go
+++ b/src/git/version.go
@@ -19,7 +19,7 @@ func EnsureVersionRequirementSatisfied() {
 
 func isVersionRequirementSatisfied() bool {
 	versionRegexp := regexp.MustCompile(`git version (\d+).(\d+).(\d+)`)
-	matches := versionRegexp.FindStringSubmatch(command.Run("git", "version").Output())
+	matches := versionRegexp.FindStringSubmatch(command.Run("git", "version").OutputSanitized())
 	if matches == nil {
 		log.Fatal("'git version' returned unexpected output. Please open an issue and supply the output of running 'git version'.")
 	}

--- a/test/shell_runner.go
+++ b/test/shell_runner.go
@@ -3,10 +3,10 @@ package test
 import (
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 
+	"github.com/Originate/git-town/src/command"
 	"github.com/kballard/go-shellquote"
 	"github.com/pkg/errors"
 )
@@ -86,11 +86,8 @@ func (runner *ShellRunner) Run(name string, arguments ...string) (output string,
 	}
 
 	// run the command inside the custom environment
-	cmd := exec.Command(name, arguments...)
-	cmd.Dir = runner.dir
-	cmd.Env = customEnv
-	rawOutput, err := cmd.CombinedOutput()
-	return string(rawOutput), err
+	outcome := command.RunDirEnv(runner.dir, customEnv, name, arguments...)
+	return outcome.Output(), outcome.Err()
 }
 
 // RunString runs the given command (including possible arguments)


### PR DESCRIPTION
This PR makes the Go Cucumber tests use the existing facilities in the source code (src/command/command.go) to run subshells. In order to make this possible, I had to extend it a bit to provide the unsanitized output and the command run.

This also makes the API more idiot-proof:
- `Run` requires at least the command, before it was possible to call it with an empty slice
- `Result` is immutable now, access to its properties happens via read-only getter methods