### PR TITLE
Remove exit - part 1

### DIFF
--- a/src/cfmt/print.go
+++ b/src/cfmt/print.go
@@ -2,7 +2,6 @@ package cfmt
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/fatih/color"
 )
@@ -12,8 +11,7 @@ import (
 func Print(a ...interface{}) {
 	_, err := fmt.Fprint(color.Output, a...)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		panic(err)
 	}
 }
 
@@ -22,8 +20,7 @@ func Print(a ...interface{}) {
 func Printf(format string, a ...interface{}) {
 	_, err := fmt.Fprintf(color.Output, format, a...)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		panic(err)
 	}
 }
 
@@ -32,7 +29,6 @@ func Printf(format string, a ...interface{}) {
 func Println(a ...interface{}) {
 	_, err := fmt.Fprintln(color.Output, a...)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		panic(err)
 	}
 }

--- a/src/cfmt/print.go
+++ b/src/cfmt/print.go
@@ -2,8 +2,8 @@ package cfmt
 
 import (
 	"fmt"
+	"os"
 
-	"github.com/Originate/exit"
 	"github.com/fatih/color"
 )
 
@@ -11,19 +11,28 @@ import (
 // in a way where colors work on Windows
 func Print(a ...interface{}) {
 	_, err := fmt.Fprint(color.Output, a...)
-	exit.If(err)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }
 
 // Printf prints the given text using fmt.Printf
 // in a way where colors work on Windows
 func Printf(format string, a ...interface{}) {
 	_, err := fmt.Fprintf(color.Output, format, a...)
-	exit.If(err)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }
 
 // Println prints the given text using fmt.Println
 // in a way where colors work on Windows
 func Println(a ...interface{}) {
 	_, err := fmt.Fprintln(color.Output, a...)
-	exit.If(err)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/src/cmd/install_fish_autocompletion.go
+++ b/src/cmd/install_fish_autocompletion.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path"
 
-	"github.com/Originate/exit"
 	"github.com/Originate/git-town/src/util"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -15,21 +15,31 @@ var installFishAutocompletionCommand = &cobra.Command{
 	Use:   "install-fish-autocompletion",
 	Short: "Installs the autocompletion definition for Fish shell",
 	Run: func(cmd *cobra.Command, args []string) {
-		installFishAutocompletion()
+		err := installFishAutocompletion()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 	},
 	Args: cobra.NoArgs,
 }
 
-func installFishAutocompletion() {
-	filename := path.Join(os.Getenv("HOME"), ".config", "fish", "completions", "git.fish")
+func installFishAutocompletion() error {
+	folderName := path.Join(os.Getenv("HOME"), ".config", "fish", "completions")
+	filename := path.Join(folderName, "git.fish")
 	err := os.MkdirAll(path.Dir(filename), 0700)
-	exit.If(err)
+	if err != nil {
+		return errors.Wrapf(err, "cannot create folder %q", folderName)
+	}
 	if util.DoesFileExist(filename) {
 		util.ExitWithErrorMessage("Git autocompletion for Fish shell already exists")
 	}
 	err = ioutil.WriteFile(filename, []byte(buildAutocompletionDefinition()), 0644)
-	exit.If(err)
+	if err != nil {
+		return errors.Wrapf(err, "cannot write file %q", filename)
+	}
 	fmt.Println("Git autocompletion for Fish shell installed")
+	return nil
 }
 
 var fishAutocompletionTemplate = `

--- a/src/command/debug.go
+++ b/src/command/debug.go
@@ -1,9 +1,10 @@
 package command
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
-	"github.com/Originate/exit"
 	"github.com/fatih/color"
 )
 
@@ -19,6 +20,9 @@ func logRun(cmd string, args ...string) {
 	if debug {
 		count++
 		_, err := color.New(color.FgBlue).Printf("DEBUG (%d): %s %s\n", count, cmd, strings.Join(args, " "))
-		exit.If(err)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 	}
 }

--- a/src/command/debug.go
+++ b/src/command/debug.go
@@ -1,8 +1,6 @@
 package command
 
 import (
-	"fmt"
-	"os"
 	"strings"
 
 	"github.com/fatih/color"
@@ -21,8 +19,7 @@ func logRun(cmd string, args ...string) {
 		count++
 		_, err := color.New(color.FgBlue).Printf("DEBUG (%d): %s %s\n", count, cmd, strings.Join(args, " "))
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			panic(err)
 		}
 	}
 }

--- a/src/drivers/util.go
+++ b/src/drivers/util.go
@@ -2,7 +2,6 @@ package drivers
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/fatih/color"
 )
@@ -11,7 +10,6 @@ func printLog(message string) {
 	fmt.Println()
 	_, err := color.New(color.Bold).Println(message)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		panic(err)
 	}
 }

--- a/src/drivers/util.go
+++ b/src/drivers/util.go
@@ -2,13 +2,16 @@ package drivers
 
 import (
 	"fmt"
+	"os"
 
-	"github.com/Originate/exit"
 	"github.com/fatih/color"
 )
 
 func printLog(message string) {
 	fmt.Println()
 	_, err := color.New(color.Bold).Println(message)
-	exit.If(err)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
I have removed a number of occurrences of `exit.If` and found that there are many cases where the correct way to do things  (exit vs bubble up the error) is debatable. Because of this, the large number of `exit.If` occurrences in the code base, and the fact that these changes have ripple effects all over the code base, I'm going to do this also as a series of PRs that perform a gradual code repair. Hopefully, this allows for a more efficient review process and makes it easier to find bugs that might get introduced through this shotgun refactor.