### PR TITLE
add version to binary names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build-release: cross-compile  # builds the artifacts for a new release
 cross-compile:  # builds the binary for all platforms
 	go get github.com/mitchellh/gox
 	gox -ldflags "-X github.com/Originate/git-town/src/cmd.version=${TRAVIS_TAG} -X github.com/Originate/git-town/src/cmd.buildDate=${date}" \
-			-output "dist/{{.Dir}}-{{.OS}}-{{.Arch}}"
+			-output "dist/{{.Dir}}-${TRAVIS_TAG}-{{.OS}}-{{.Arch}}"
 
 cuke: cuke-go cuke-ruby  # runs the feature tests
 


### PR DESCRIPTION
Update our binaries to include the version number. Seen this commonly with other tools and noticed we weren't doing it. Always nice to have the version in the binary you download

![Screen Shot 2019-11-05 at 9 49 34 PM](https://user-images.githubusercontent.com/1676758/68271689-3bc0e800-0016-11ea-9daa-b345a93559a5.png)
