### PR TITLE
Essential subshell commands

### DIFF
--- a/src/command/command.go
+++ b/src/command/command.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -17,11 +18,14 @@ type Result struct {
 	output  string
 }
 
-// MustRun executes the command given in argv notation.
+// MustRun executes an essential subshell command given in argv notation.
+// Essential subshell commands are essential for the functioning of Git Town.
+// If they fail, Git Town ends right there.
 func MustRun(cmd string, args ...string) *Result {
 	result := RunInDir("", cmd, args...)
 	if result.Err() != nil {
-		panic(result.Err())
+		fmt.Printf("\n\nError running '%s %s': %s", cmd, strings.Join(args, " "), result.Err())
+		os.Exit(1)
 	}
 	return result
 }

--- a/src/command/command.go
+++ b/src/command/command.go
@@ -19,9 +19,9 @@ type Result struct {
 
 // MustRun executes the command given in argv notation.
 func MustRun(cmd string, args ...string) *Result {
-	result, err := RunInDir("", cmd, args...)
-	if err != nil {
-		panic(err)
+	result := RunInDir("", cmd, args...)
+	if result.Err() != nil {
+		panic(result.Err())
 	}
 	return result
 }

--- a/src/command/command.go
+++ b/src/command/command.go
@@ -17,6 +17,15 @@ type Result struct {
 	output  string
 }
 
+// MustRun executes the command given in argv notation.
+func MustRun(cmd string, args ...string) *Result {
+	result, err := RunInDir("", cmd, args...)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
 // Run executes the command given in argv notation.
 func Run(cmd string, args ...string) *Result {
 	return RunInDir("", cmd, args...)

--- a/src/command/command.go
+++ b/src/command/command.go
@@ -30,6 +30,18 @@ func MustRun(cmd string, args ...string) *Result {
 	return result
 }
 
+// MustRunInDir executes an essential subshell command given in argv notation.
+// Essential subshell commands are essential for the functioning of Git Town.
+// If they fail, Git Town ends right there.
+func MustRunInDir(dir string, cmd string, args ...string) *Result {
+	result := RunInDir(dir, cmd, args...)
+	if result.Err() != nil {
+		fmt.Printf("\n\nError running '%s %s' in %s: %s", cmd, strings.Join(args, " "), dir, result.Err())
+		os.Exit(1)
+	}
+	return result
+}
+
 // Run executes the command given in argv notation.
 func Run(cmd string, args ...string) *Result {
 	return RunInDir("", cmd, args...)

--- a/src/git/branch.go
+++ b/src/git/branch.go
@@ -111,7 +111,7 @@ func GetLocalBranchesWithMainBranchFirst() (result []string) {
 
 // GetPreviouslyCheckedOutBranch returns the name of the previously checked out branch
 func GetPreviouslyCheckedOutBranch() string {
-	return command.MustRun("git", "rev-parse", "--verify", "--abbrev-ref", "@{-1}").OutputSanitized()
+	return command.Run("git", "rev-parse", "--verify", "--abbrev-ref", "@{-1}").OutputSanitized()
 }
 
 // GetTrackingBranchName returns the name of the remote branch

--- a/src/git/branch.go
+++ b/src/git/branch.go
@@ -111,7 +111,11 @@ func GetLocalBranchesWithMainBranchFirst() (result []string) {
 
 // GetPreviouslyCheckedOutBranch returns the name of the previously checked out branch
 func GetPreviouslyCheckedOutBranch() string {
-	return command.Run("git", "rev-parse", "--verify", "--abbrev-ref", "@{-1}").OutputSanitized()
+	cmd := command.Run("git", "rev-parse", "--verify", "--abbrev-ref", "@{-1}")
+	if cmd.Err() != nil {
+		return ""
+	}
+	return cmd.OutputSanitized()
 }
 
 // GetTrackingBranchName returns the name of the remote branch

--- a/src/git/branch.go
+++ b/src/git/branch.go
@@ -11,7 +11,7 @@ import (
 // DoesBranchHaveUnmergedCommits returns whether the branch with the given name
 // contains commits that are not merged into the main branch
 func DoesBranchHaveUnmergedCommits(branchName string) bool {
-	return command.Run("git", "log", Config().GetMainBranch()+".."+branchName).OutputSanitized() != ""
+	return command.MustRun("git", "log", Config().GetMainBranch()+".."+branchName).OutputSanitized() != ""
 }
 
 // EnsureBranchInSync enforces that a branch with the given name is in sync with its tracking branch
@@ -59,7 +59,7 @@ func GetExpectedPreviouslyCheckedOutBranch(initialPreviouslyCheckedOutBranch, in
 // GetLocalBranches returns the names of all branches in the local repository,
 // ordered alphabetically
 func GetLocalBranches() (result []string) {
-	for _, line := range command.Run("git", "branch").OutputLines() {
+	for _, line := range command.MustRun("git", "branch").OutputLines() {
 		line = strings.Trim(line, "* ")
 		line = strings.TrimSpace(line)
 		result = append(result, line)
@@ -82,7 +82,7 @@ func GetLocalBranchesWithoutMain() (result []string) {
 // GetLocalBranchesWithDeletedTrackingBranches returns the names of all branches
 // whose remote tracking branches have been deleted
 func GetLocalBranchesWithDeletedTrackingBranches() (result []string) {
-	for _, line := range command.Run("git", "branch", "-vv").OutputLines() {
+	for _, line := range command.MustRun("git", "branch", "-vv").OutputLines() {
 		line = strings.Trim(line, "* ")
 		parts := strings.SplitN(line, " ", 2)
 		branchName := parts[0]
@@ -111,11 +111,7 @@ func GetLocalBranchesWithMainBranchFirst() (result []string) {
 
 // GetPreviouslyCheckedOutBranch returns the name of the previously checked out branch
 func GetPreviouslyCheckedOutBranch() string {
-	cmd := command.Run("git", "rev-parse", "--verify", "--abbrev-ref", "@{-1}")
-	if cmd.Err() != nil {
-		return ""
-	}
-	return cmd.OutputSanitized()
+	return command.MustRun("git", "rev-parse", "--verify", "--abbrev-ref", "@{-1}").OutputSanitized()
 }
 
 // GetTrackingBranchName returns the name of the remote branch
@@ -127,7 +123,7 @@ func GetTrackingBranchName(branchName string) string {
 // HasBranch returns whether the repository contains a branch with the given name.
 // The branch does not have to be present on the local repository.
 func HasBranch(branchName string) bool {
-	for _, line := range command.Run("git", "branch", "-a").OutputLines() {
+	for _, line := range command.MustRun("git", "branch", "-a").OutputLines() {
 		line = strings.Trim(line, "* ")
 		line = strings.TrimSpace(line)
 		line = strings.Replace(line, "remotes/origin/", "", 1)
@@ -170,8 +166,7 @@ func IsBranchInSync(branchName string) bool {
 // contains commits that have not been pushed to the remote.
 func ShouldBranchBePushed(branchName string) bool {
 	trackingBranchName := GetTrackingBranchName(branchName)
-	cmd := command.Run("git", "rev-list", "--left-right", branchName+"..."+trackingBranchName)
-	return cmd.OutputSanitized() != ""
+	return command.MustRun("git", "rev-list", "--left-right", branchName+"..."+trackingBranchName).OutputSanitized() != ""
 }
 
 // Helpers
@@ -182,7 +177,7 @@ var remoteBranchesInitialized bool
 
 func getRemoteBranches() []string {
 	if !remoteBranchesInitialized {
-		remoteBranches = command.Run("git", "branch", "-r").OutputLines()
+		remoteBranches = command.MustRun("git", "branch", "-r").OutputLines()
 		remoteBranchesInitialized = true
 	}
 	return remoteBranches

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -317,7 +317,7 @@ func (c *Configuration) removeGlobalConfigValue(key string) *command.Result {
 
 // removeLocalConfigurationValue deletes the configuration value with the given key from the local Git Town configuration.
 func (c *Configuration) removeLocalConfigValue(key string) {
-	command.RunInDir(c.localDir, "git", "config", "--unset", key)
+	command.MustRunInDir(c.localDir, "git", "config", "--unset", key)
 	delete(c.localConfigCache, key)
 }
 

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -312,7 +312,7 @@ func (c *Configuration) RemoveGitAlias(command string) *command.Result {
 
 func (c *Configuration) removeGlobalConfigValue(key string) *command.Result {
 	delete(c.globalConfigCache, key)
-	return command.RunInDir(c.localDir, "git", "config", "--global", "--unset", key)
+	return command.MustRunInDir(c.localDir, "git", "config", "--global", "--unset", key)
 }
 
 // removeLocalConfigurationValue deletes the configuration value with the given key from the local Git Town configuration.
@@ -337,7 +337,7 @@ func (c *Configuration) RemoveOutdatedConfiguration() {
 
 func (c *Configuration) setGlobalConfigValue(key, value string) *command.Result {
 	c.globalConfigCache[key] = value
-	return command.RunInDir(c.localDir, "git", "config", "--global", key, value)
+	return command.MustRunInDir(c.localDir, "git", "config", "--global", key, value)
 }
 
 // setConfigurationValue sets the local configuration with the given key to the given value.

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -226,7 +226,7 @@ func (c *Configuration) GetRemoteOriginURL() string {
 			return mockRemoteURL
 		}
 	}
-	return command.RunInDir(c.localDir, "git", "remote", "get-url", "origin").OutputSanitized()
+	return command.MustRunInDir(c.localDir, "git", "remote", "get-url", "origin").OutputSanitized()
 }
 
 // GetURLHostname returns the hostname contained within the given Git URL.

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -343,7 +343,7 @@ func (c *Configuration) setGlobalConfigValue(key, value string) *command.Result 
 // setConfigurationValue sets the local configuration with the given key to the given value.
 func (c *Configuration) setLocalConfigValue(key, value string) *command.Result {
 	c.localConfigCache[key] = value
-	return command.RunInDir(c.localDir, "git", "config", key, value)
+	return command.MustRunInDir(c.localDir, "git", "config", key, value)
 }
 
 // SetMainBranch marks the given branch as the main branch

--- a/src/git/current_branch.go
+++ b/src/git/current_branch.go
@@ -21,7 +21,7 @@ func GetCurrentBranchName() string {
 		if IsRebaseInProgress() {
 			currentBranchCache = getCurrentBranchNameDuringRebase()
 		} else {
-			currentBranchCache = command.Run("git", "rev-parse", "--abbrev-ref", "HEAD").OutputSanitized()
+			currentBranchCache = command.MustRun("git", "rev-parse", "--abbrev-ref", "HEAD").OutputSanitized()
 		}
 	}
 	return currentBranchCache

--- a/src/git/log.go
+++ b/src/git/log.go
@@ -4,5 +4,5 @@ import "github.com/Originate/git-town/src/command"
 
 // GetLastCommitMessage returns the commit message for the last commit
 func GetLastCommitMessage() string {
-	return command.Run("git", "log", "-1", "--format=%B").OutputSanitized()
+	return command.MustRun("git", "log", "-1", "--format=%B").OutputSanitized()
 }

--- a/src/git/remotes.go
+++ b/src/git/remotes.go
@@ -11,7 +11,7 @@ var remotesInitialized bool
 
 func getRemotes() []string {
 	if !remotesInitialized {
-		remotes = command.Run("git", "remote").OutputLines()
+		remotes = command.MustRun("git", "remote").OutputLines()
 		remotesInitialized = true
 	}
 	return remotes

--- a/src/git/sha.go
+++ b/src/git/sha.go
@@ -5,7 +5,7 @@ import "github.com/Originate/git-town/src/command"
 // GetBranchSha returns the SHA1 of the latest commit
 // on the branch with the given name.
 func GetBranchSha(branchName string) string {
-	return command.Run("git", "rev-parse", branchName).OutputSanitized()
+	return command.MustRun("git", "rev-parse", branchName).OutputSanitized()
 }
 
 // GetCurrentSha returns the SHA of the currently checked out commit.

--- a/src/git/status.go
+++ b/src/git/status.go
@@ -27,25 +27,25 @@ var rootDirectory string
 // i.e. the directory that contains the ".git" folder.
 func GetRootDirectory() string {
 	if rootDirectory == "" {
-		rootDirectory = command.Run("git", "rev-parse", "--show-toplevel").OutputSanitized()
+		rootDirectory = command.MustRun("git", "rev-parse", "--show-toplevel").OutputSanitized()
 	}
 	return rootDirectory
 }
 
 // HasConflicts returns whether the local repository currently has unresolved merge conflicts.
 func HasConflicts() bool {
-	return command.Run("git", "status").OutputContainsText("Unmerged paths")
+	return command.MustRun("git", "status").OutputContainsText("Unmerged paths")
 }
 
 // HasOpenChanges returns whether the local repository contains uncommitted changes.
 func HasOpenChanges() bool {
-	return command.Run("git", "status", "--porcelain").OutputSanitized() != ""
+	return command.MustRun("git", "status", "--porcelain").OutputSanitized() != ""
 }
 
 // HasShippableChanges returns whether the supplied branch has an changes
 // not currently on the main branchName
 func HasShippableChanges(branchName string) bool {
-	return command.Run("git", "diff", Config().GetMainBranch()+".."+branchName).OutputSanitized() != ""
+	return command.MustRun("git", "diff", Config().GetMainBranch()+".."+branchName).OutputSanitized() != ""
 }
 
 // IsMergeInProgress returns whether the local repository is in the middle of
@@ -58,5 +58,5 @@ func IsMergeInProgress() bool {
 // IsRebaseInProgress returns whether the local repository is in the middle of
 // an unfinished rebase process.
 func IsRebaseInProgress() bool {
-	return command.Run("git", "status").OutputContainsText("rebase in progress")
+	return command.MustRun("git", "status").OutputContainsText("rebase in progress")
 }

--- a/src/git/user.go
+++ b/src/git/user.go
@@ -4,7 +4,7 @@ import "github.com/Originate/git-town/src/command"
 
 // GetLocalAuthor returns the locally Git configured user
 func GetLocalAuthor() string {
-	name := command.Run("git", "config", "user.name").OutputSanitized()
-	email := command.Run("git", "config", "user.email").OutputSanitized()
+	name := command.MustRun("git", "config", "user.name").OutputSanitized()
+	email := command.MustRun("git", "config", "user.email").OutputSanitized()
 	return name + " <" + email + ">"
 }

--- a/src/git/version.go
+++ b/src/git/version.go
@@ -19,7 +19,7 @@ func EnsureVersionRequirementSatisfied() {
 
 func isVersionRequirementSatisfied() bool {
 	versionRegexp := regexp.MustCompile(`git version (\d+).(\d+).(\d+)`)
-	matches := versionRegexp.FindStringSubmatch(command.Run("git", "version").OutputSanitized())
+	matches := versionRegexp.FindStringSubmatch(command.MustRun("git", "version").OutputSanitized())
 	if matches == nil {
 		log.Fatal("'git version' returned unexpected output. Please open an issue and supply the output of running 'git version'.")
 	}

--- a/src/prompt/squash_commit_author.go
+++ b/src/prompt/squash_commit_author.go
@@ -41,7 +41,7 @@ func askForAuthor(authors []string) string {
 
 func getBranchAuthors(branchName string) (result []string) {
 	// Returns lines of "<number of commits>\t<name and email>"
-	output := command.Run("git", "shortlog", "-s", "-n", "-e", git.Config().GetMainBranch()+".."+branchName).OutputLines()
+	output := command.MustRun("git", "shortlog", "-s", "-n", "-e", git.Config().GetMainBranch()+".."+branchName).OutputLines()
 	for _, line := range output {
 		line = strings.TrimSpace(line)
 		parts := strings.Split(line, "\t")

--- a/src/steps/preserve_checkout_history_step.go
+++ b/src/steps/preserve_checkout_history_step.go
@@ -17,8 +17,8 @@ func (step *PreserveCheckoutHistoryStep) Run() error {
 	expectedPreviouslyCheckedOutBranch := git.GetExpectedPreviouslyCheckedOutBranch(step.InitialPreviouslyCheckedOutBranch, step.InitialBranch)
 	if expectedPreviouslyCheckedOutBranch != git.GetPreviouslyCheckedOutBranch() {
 		currentBranch := git.GetCurrentBranchName()
-		command.Run("git", "checkout", expectedPreviouslyCheckedOutBranch)
-		command.Run("git", "checkout", currentBranch)
+		command.MustRun("git", "checkout", expectedPreviouslyCheckedOutBranch)
+		command.MustRun("git", "checkout", currentBranch)
 	}
 	return nil
 }


### PR DESCRIPTION
Git Town runs most Git commands without checking their exit code. Returning errors from all these places would make the code very cumbersome so I don't want to do it. At the same time, there is nothing we can do if Git doesn't work properly except exit. So I'm imitating the API of [regexp.MustCompile]( https://golang.org/pkg/regexp/#MustCompile) by introducing `command.MustRun`. What do you think?