### PR TITLE
Delete the master branch in the dev repos

### DIFF
--- a/test/git_environment.go
+++ b/test/git_environment.go
@@ -75,6 +75,7 @@ func NewStandardGitEnvironment(dir string) (gitEnv *GitEnvironment, err error) {
 		{"git", "config", "git-town.main-branch-name", "main"},
 		{"git", "config", "git-town.perennial-branch-names", ""},
 		{"git", "checkout", "main"},
+		{"git", "branch", "-d", "master"},
 	})
 	return gitEnv, err
 }

--- a/test/git_environment.go
+++ b/test/git_environment.go
@@ -42,6 +42,11 @@ func CloneGitEnvironment(original *GitEnvironment, dir string) (*GitEnvironment,
 
 // NewStandardGitEnvironment provides a GitEnvironment in the given directory,
 // fully populated as a standardized setup for scenarios.
+//
+// The origin repo has the master branch checked out.
+// Git repos cannot receive pushes of the currently checked out branch
+// because that will change files in the current workspace.
+// The tests don't use the master branch.
 func NewStandardGitEnvironment(dir string) (gitEnv *GitEnvironment, err error) {
 	// create the folder
 	err = os.MkdirAll(dir, 0744)
@@ -75,6 +80,8 @@ func NewStandardGitEnvironment(dir string) (gitEnv *GitEnvironment, err error) {
 		{"git", "config", "git-town.main-branch-name", "main"},
 		{"git", "config", "git-town.perennial-branch-names", ""},
 		{"git", "checkout", "main"},
+		// NOTE: the developer repo receives the master branch from origin
+		//       but we don't want it here because it isn't used in tests.
 		{"git", "branch", "-d", "master"},
 	})
 	return gitEnv, err


### PR DESCRIPTION
One side effect of having the origin repos not be bare repos anymore is that they now have a `master` branch that propagates down to the developer repos when cloning them. I found that this causes problems in some tests that I'm currently working on where I verify branches in the developer repo. I don't want to [complect](https://youtu.be/rI8tNMsozo0) (mix up two things, thereby making things more complicated) later PRs with this bug and its fix, so here it comes in its own PR.

The master branch is created on line 63 in the origin repo. The origin repo must have the master branch checked out in order to be able to receive pushes of other branches.