### PR TITLE
Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 
 language: go
-go: 1.12
+go: 1.13
 
 install:
   - rvm install 2.6.5

--- a/vendor/github.com/DATA-DOG/godog/go.mod
+++ b/vendor/github.com/DATA-DOG/godog/go.mod
@@ -1,1 +1,3 @@
 module github.com/DATA-DOG/godog
+
+go 1.13


### PR DESCRIPTION
Some of these changes keep occurring in my dev environment, so let's make Go 1.13 the official version for Git Town. It seems robust.