### PR TITLE
Update cache before file operations

### DIFF
--- a/src/git/config.go
+++ b/src/git/config.go
@@ -317,8 +317,8 @@ func (c *Configuration) removeGlobalConfigValue(key string) *command.Result {
 
 // removeLocalConfigurationValue deletes the configuration value with the given key from the local Git Town configuration.
 func (c *Configuration) removeLocalConfigValue(key string) {
-	command.MustRunInDir(c.localDir, "git", "config", "--unset", key)
 	delete(c.localConfigCache, key)
+	command.MustRunInDir(c.localDir, "git", "config", "--unset", key)
 }
 
 // RemoveLocalGitConfiguration removes all Git Town configuration


### PR DESCRIPTION
This PR makes the order in which configuration cache and file operations happen consistent. This sets up the code base for cleaner changes later. No changes to functionality.