### PR TITLE
Remove temp variable

### DIFF
--- a/src/prompt/squash_commit_author.go
+++ b/src/prompt/squash_commit_author.go
@@ -41,8 +41,7 @@ func askForAuthor(authors []string) string {
 
 func getBranchAuthors(branchName string) (result []string) {
 	// Returns lines of "<number of commits>\t<name and email>"
-	outcome := command.MustRun("git", "shortlog", "-s", "-n", "-e", git.Config().GetMainBranch()+".."+branchName)
-	for _, line := range outcome.OutputLines() {
+	for _, line := range command.MustRun("git", "shortlog", "-s", "-n", "-e", git.Config().GetMainBranch()+".."+branchName).OutputLines() {
 		line = strings.TrimSpace(line)
 		parts := strings.Split(line, "\t")
 		result = append(result, parts[1])

--- a/src/prompt/squash_commit_author.go
+++ b/src/prompt/squash_commit_author.go
@@ -41,8 +41,8 @@ func askForAuthor(authors []string) string {
 
 func getBranchAuthors(branchName string) (result []string) {
 	// Returns lines of "<number of commits>\t<name and email>"
-	output := command.MustRun("git", "shortlog", "-s", "-n", "-e", git.Config().GetMainBranch()+".."+branchName).OutputLines()
-	for _, line := range output {
+	outcome := command.MustRun("git", "shortlog", "-s", "-n", "-e", git.Config().GetMainBranch()+".."+branchName)
+	for _, line := range outcome.OutputLines() {
 		line = strings.TrimSpace(line)
 		parts := strings.Split(line, "\t")
 		result = append(result, parts[1])


### PR DESCRIPTION
This is more consistent with how the results of `command.MustRun` are used throughout the code base. The temp variable doesn't add readability here.