### PR TITLE
Set unit test timeout to 1s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test: lint unit cuke  # runs all the tests
 test-go: build unit cuke-go lint-go  # runs all tests for Golang
 
 unit:  # runs the unit tests
-	go test ./src/... ./test/...
+	go test -timeout 1s ./src/... ./test/...
 
 update:  # updates all dependencies
 	dep ensure -update


### PR DESCRIPTION
The default timeout is 30 sec. This makes it gruelsome to debug tests that produce deadlocks. 1s is more than enough since the unit tests run in milliseconds.