### PR TITLE
Make step names more consistent

### DIFF
--- a/features/git-town-append/on-perennial-branch.feature
+++ b/features/git-town-append/on-perennial-branch.feature
@@ -6,7 +6,7 @@ Feature: Appending a branch to a perennial branch
 
 
   Background:
-    Given my code base has the perennial branches "qa" and "production"
+    Given my repository has the perennial branches "qa" and "production"
     And the following commits exist in my repository
       | BRANCH     | LOCATION | MESSAGE           |
       | production | remote   | production_commit |

--- a/test/steps/branch_steps.go
+++ b/test/steps/branch_steps.go
@@ -47,7 +47,11 @@ func BranchSteps(suite *godog.Suite, fs *FeatureState) {
 		return nil
 	})
 
-	suite.Step(`^my code base has the perennial branches "([^"]+)" and "([^"]+)"$`, func(branch1, branch2 string) error {
+	suite.Step(`^my repository has a feature branch named "([^"]*)"$`, func(branch string) error {
+		return fs.activeScenarioState.gitEnvironment.DeveloperRepo.CreateFeatureBranch(branch)
+	})
+
+	suite.Step(`^my repository has the perennial branches "([^"]+)" and "([^"]+)"$`, func(branch1, branch2 string) error {
 		err := fs.activeScenarioState.gitEnvironment.DeveloperRepo.CreatePerennialBranches(branch1, branch2)
 		if err != nil {
 			return errors.Wrap(err, "cannot create perennial branches")
@@ -57,9 +61,5 @@ func BranchSteps(suite *godog.Suite, fs *FeatureState) {
 			return errors.Wrapf(err, "cannot push branch %q", branch1)
 		}
 		return fs.activeScenarioState.gitEnvironment.DeveloperRepo.PushBranch(branch2)
-	})
-
-	suite.Step(`^my repository has a feature branch named "([^"]*)"$`, func(branch string) error {
-		return fs.activeScenarioState.gitEnvironment.DeveloperRepo.CreateFeatureBranch(branch)
 	})
 }


### PR DESCRIPTION
The Ruby cukes have a number of duplicate steps that are hard to detect because they use such flowery language. This PR makes the existing step names in the Go cukes more consistent. 

This makes the Gherkin sound a bit more repetitive but is simpler and more idiot-proof overall, and good enough in this case since we aren't trying to win a prose writing competition here.