### PR TITLE
Remove empty lines inside function bodies

### DIFF
--- a/test/commit_table_builder.go
+++ b/test/commit_table_builder.go
@@ -46,14 +46,12 @@ func NewCommitTableBuilder() CommitTableBuilder {
 // Add registers the given commit from the given location into this table.
 func (builder *CommitTableBuilder) Add(commit Commit, location string) {
 	builder.commits[commit.SHA] = commit
-
 	commitsInBranch, exists := builder.commitsInBranch[commit.Branch]
 	if exists {
 		builder.commitsInBranch[commit.Branch] = commitsInBranch.Add(commit.SHA)
 	} else {
 		builder.commitsInBranch[commit.Branch] = helpers.NewOrderedStringSet(commit.SHA)
 	}
-
 	locationKey := commit.SHA + commit.Branch
 	locations, exists := builder.locations[locationKey]
 	if exists {

--- a/test/data_table.go
+++ b/test/data_table.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 
 	"github.com/DATA-DOG/godog/gherkin"
-	"github.com/sergi/go-diff/diffmatchpatch"
-
 	"github.com/Originate/git-town/test/helpers"
+	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
 // DataTable allows comparing user-generated data with Gherkin tables.

--- a/test/filesystem.go
+++ b/test/filesystem.go
@@ -18,7 +18,6 @@ import (
 func CopyDirectory(src, dst string) error {
 	return filepath.Walk(src, func(srcPath string, fi os.FileInfo, e error) error {
 		dstPath := strings.Replace(srcPath, src, dst, 1)
-
 		// handle directory
 		if fi.IsDir() {
 			err := os.Mkdir(dstPath, fi.Mode())
@@ -27,7 +26,6 @@ func CopyDirectory(src, dst string) error {
 			}
 			return nil
 		}
-
 		// handle file
 		sourceContent, err := os.Open(srcPath)
 		if err != nil {

--- a/test/filesystem_test.go
+++ b/test/filesystem_test.go
@@ -14,9 +14,7 @@ func TestCopyDirectory(t *testing.T) {
 	createFile(t, srcDir, "one.txt")
 	createFile(t, srcDir, "f1/a.txt")
 	createFile(t, srcDir, "f2/b.txt")
-
 	err := CopyDirectory(srcDir, dstDir)
-
 	assert.Nil(t, err)
 	assertFileExists(t, dstDir, "one.txt")
 	assertFileExists(t, dstDir, "f1/a.txt")
@@ -30,9 +28,7 @@ func TestCopyDirectory_GitRepo(t *testing.T) {
 	_, err := InitGitRepository(srcDir, tmpDir)
 	assert.Nil(t, err)
 	createFile(t, srcDir, "one.txt")
-
 	err = CopyDirectory(srcDir, dstDir)
-
 	assert.Nil(t, err)
 	assertFileExists(t, dstDir, "one.txt")
 	assertFileExistsWithContent(t, dstDir, ".git/HEAD", "ref: refs/heads/master\n")

--- a/test/git_environment.go
+++ b/test/git_environment.go
@@ -52,10 +52,8 @@ func NewStandardGitEnvironment(dir string) (gitEnv *GitEnvironment, err error) {
 	if err != nil {
 		return gitEnv, fmt.Errorf("cannot create folder %q for Git environment: %w", dir, err)
 	}
-
 	// create the GitEnvironment
 	gitEnv = &GitEnvironment{Dir: dir}
-
 	// create the origin repo
 	gitEnv.OriginRepo, err = InitGitRepository(gitEnv.originRepoPath(), gitEnv.Dir)
 	if err != nil {
@@ -69,7 +67,6 @@ func NewStandardGitEnvironment(dir string) (gitEnv *GitEnvironment, err error) {
 	if err != nil {
 		return gitEnv, err
 	}
-
 	// clone the "developer" repo
 	gitEnv.DeveloperRepo, err = CloneGitRepository(gitEnv.originRepoPath(), gitEnv.developerRepoPath(), gitEnv.Dir)
 	if err != nil {
@@ -131,7 +128,6 @@ func (env *GitEnvironment) CreateCommits(table *gherkin.DataTable) error {
 // CommitTable provides a table for all commits in this Git environment containing only the given fields.
 func (env GitEnvironment) CommitTable(fields []string) (result DataTable, err error) {
 	builder := NewCommitTableBuilder()
-
 	localCommits, err := env.DeveloperRepo.Commits(fields)
 	if err != nil {
 		return result, fmt.Errorf("cannot determine commits in the developer repo: %w", err)
@@ -139,7 +135,6 @@ func (env GitEnvironment) CommitTable(fields []string) (result DataTable, err er
 	for _, localCommit := range localCommits {
 		builder.Add(localCommit, "local")
 	}
-
 	remoteCommits, err := env.OriginRepo.Commits(fields)
 	if err != nil {
 		return result, fmt.Errorf("cannot determine commits in the origin repo: %w", err)
@@ -147,7 +142,6 @@ func (env GitEnvironment) CommitTable(fields []string) (result DataTable, err er
 	for _, remoteCommit := range remoteCommits {
 		builder.Add(remoteCommit, "remote")
 	}
-
 	return builder.Table(fields), nil
 }
 

--- a/test/git_environment_test.go
+++ b/test/git_environment_test.go
@@ -11,9 +11,7 @@ func TestCloneGitEnvironment(t *testing.T) {
 	dir := createTempDir(t)
 	memoizedGitEnv, err := NewStandardGitEnvironment(path.Join(dir, "memoized"))
 	assert.Nil(t, err, "cannot create memoized GitEnvironment")
-
 	_, err = CloneGitEnvironment(memoizedGitEnv, path.Join(dir, "cloned"))
-
 	assert.Nil(t, err, "cannot clone GitEnvironment")
 	assertIsNormalGitRepo(t, path.Join(dir, "cloned", "origin"))
 	assertIsNormalGitRepo(t, path.Join(dir, "cloned", "developer"))
@@ -22,17 +20,13 @@ func TestCloneGitEnvironment(t *testing.T) {
 
 func TestNewStandardGitEnvironment(t *testing.T) {
 	gitEnvRootDir := createTempDir(t)
-
 	result, err := NewStandardGitEnvironment(gitEnvRootDir)
-
 	assert.Nil(t, err)
-
 	// verify the origin repo
 	assertIsNormalGitRepo(t, path.Join(gitEnvRootDir, "origin"))
 	branch, err := result.OriginRepo.CurrentBranch()
 	assert.Nil(t, err)
 	assert.Equal(t, "master", branch, "the origin should be at the master branch so that we can push to it")
-
 	// verify the developer repo
 	assertIsNormalGitRepo(t, path.Join(gitEnvRootDir, "developer"))
 	assertHasGlobalGitConfiguration(t, gitEnvRootDir)

--- a/test/git_manager_test.go
+++ b/test/git_manager_test.go
@@ -11,9 +11,7 @@ import (
 func TestGitManager_CreateMemoizedEnvironment(t *testing.T) {
 	dir := createTempDir(t)
 	gm := NewGitManager(dir)
-
 	err := gm.CreateMemoizedEnvironment()
-
 	assert.Nil(t, err, "creating memoized environment failed")
 	memoizedPath := path.Join(dir, "memoized")
 	_, err = os.Stat(memoizedPath)
@@ -25,9 +23,7 @@ func TestGitManager_CreateScenarioEnvironment(t *testing.T) {
 	gm := NewGitManager(dir)
 	err := gm.CreateMemoizedEnvironment()
 	assert.Nil(t, err, "creating memoized environment failed")
-
 	result, err := gm.CreateScenarioEnvironment("foo")
-
 	assert.Nil(t, err, "cannot create scenario environment")
 	_, err = os.Stat(result.DeveloperRepo.Dir)
 	assert.False(t, os.IsNotExist(err), "scenario environment directory %q not found", result.DeveloperRepo.Dir)

--- a/test/git_repository.go
+++ b/test/git_repository.go
@@ -48,7 +48,6 @@ func InitGitRepository(workingDir string, homeDir string) (GitRepository, error)
 	if err != nil {
 		return GitRepository{}, fmt.Errorf("cannot create directory %q: %w", workingDir, err)
 	}
-
 	// initialize the repo in the folder
 	result := NewGitRepository(workingDir, homeDir)
 	outcome, err := result.Run("git", "init")

--- a/test/git_repository_test.go
+++ b/test/git_repository_test.go
@@ -14,9 +14,7 @@ func TestCloneGitRepository(t *testing.T) {
 	_, err := InitGitRepository(originPath, rootDir)
 	assert.Nil(t, err, "cannot initialze origin Git repository")
 	clonedPath := path.Join(rootDir, "cloned")
-
 	_, err = CloneGitRepository(originPath, clonedPath, rootDir)
-
 	assert.Nil(t, err, "cannot clone repo")
 	assertIsNormalGitRepo(t, clonedPath)
 }
@@ -38,7 +36,6 @@ func TestGitRepository_Branches(t *testing.T) {
 	assert.Nil(t, repo.CreateFeatureBranch("branch3"), "cannot create branch3")
 	assert.Nil(t, repo.CreateFeatureBranch("branch2"), "cannot create branch2")
 	assert.Nil(t, repo.CreateFeatureBranch("branch1"), "cannot create branch1")
-
 	branches, err := repo.Branches()
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"branch1", "branch2", "branch3", "master"}, branches)
@@ -46,9 +43,7 @@ func TestGitRepository_Branches(t *testing.T) {
 
 func TestGitRepository_CreateFile(t *testing.T) {
 	repo := createTestRepo(t)
-
 	err := repo.CreateFile("filename", "content")
-
 	assert.Nil(t, err, "cannot create file in repo")
 	content, err := ioutil.ReadFile(path.Join(repo.Dir, "filename"))
 	assert.Nil(t, err, "cannot read file")

--- a/test/git_town_output_parser.go
+++ b/test/git_town_output_parser.go
@@ -38,12 +38,9 @@ func lineContainsGitTownCommand(line string) bool {
 
 // parseLine provides the Git Town command and branchname in the given line.
 func parseLine(line string) ExecutedGitCommand {
-	// NOTE: implementing this without regex
-	// because the regex has gotten very complex and hard to maintain
-
+	// NOTE: implementing this without regex because the regex has gotten very complex and hard to maintain
 	// remove the color codes at the beginning
 	line = strings.Replace(line, gitCommandLineBeginning, "", 1)
-
 	// extract branch name if it exists
 	branchName := ""
 	if line[0] == '[' {
@@ -53,6 +50,5 @@ func parseLine(line string) ExecutedGitCommand {
 		branchName = parts[0]
 		line = parts[1]
 	}
-
 	return ExecutedGitCommand{Command: strings.TrimSpace(line), Branch: branchName}
 }

--- a/test/git_town_output_parser_test.go
+++ b/test/git_town_output_parser_test.go
@@ -11,12 +11,10 @@ func TestGitCommandsInGitTownOutput(t *testing.T) {
 		// simple
 		"\x1b[1m[mybranch] foo bar": {
 			{Command: "foo bar", Branch: "mybranch"}},
-
 		// multiline
 		"\x1b[1m[branch1] command one\n\n\x1b[1m[branch2] command two\n\n": {
 			{Command: "command one", Branch: "branch1"},
 			{Command: "command two", Branch: "branch2"}},
-
 		// no branch
 		"\x1b[1mcommand one": {
 			{Command: "command one", Branch: ""}},

--- a/test/shell_runner.go
+++ b/test/shell_runner.go
@@ -112,14 +112,12 @@ func (runner *ShellRunner) RunWith(opts command.Options, cmd string, args ...str
 	if opts.Env == nil {
 		opts.Env = os.Environ()
 	}
-
 	// set HOME to the given global directory so that Git puts the global configuration there.
 	for i := range opts.Env {
 		if strings.HasPrefix(opts.Env[i], "HOME=") {
 			opts.Env[i] = fmt.Sprintf("HOME=%s", runner.homeDir)
 		}
 	}
-
 	// enable shell overrides
 	if runner.hasTempShellOverrides() {
 		for i := range opts.Env {
@@ -132,10 +130,8 @@ func (runner *ShellRunner) RunWith(opts command.Options, cmd string, args ...str
 		}
 		defer runner.RemoveTempShellOverrides()
 	}
-
 	// set the working dir
 	opts.Dir = runner.workingDir
-
 	// run the command inside the custom environment
 	result, err = command.RunWith(opts, cmd, args...)
 	if Debug {


### PR DESCRIPTION
Looking at my test code after a while, and remembering how debatable empty lines in function bodies are on projects with other developers (everybody has a different opinion on what is "reasonable" here), I have decided to remove them altogether. The functions are short enough to not need further separation into code blocks inside them.

No functional changes.