### PR TITLE
Use filepath instead of path for file path operations

### DIFF
--- a/src/cmd/install_fish_autocompletion.go
+++ b/src/cmd/install_fish_autocompletion.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/Originate/git-town/src/util"
 	"github.com/spf13/cobra"
@@ -24,9 +24,9 @@ var installFishAutocompletionCommand = &cobra.Command{
 }
 
 func installFishAutocompletion() error {
-	folderName := path.Join(os.Getenv("HOME"), ".config", "fish", "completions")
-	filename := path.Join(folderName, "git.fish")
-	err := os.MkdirAll(path.Dir(filename), 0700)
+	folderName := filepath.Join(os.Getenv("HOME"), ".config", "fish", "completions")
+	filename := filepath.Join(folderName, "git.fish")
+	err := os.MkdirAll(filepath.Dir(filename), 0700)
 	if err != nil {
 		return fmt.Errorf("cannot create folder %q: %w", folderName, err)
 	}

--- a/src/command/run_test.go
+++ b/src/command/run_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/Originate/git-town/src/command"
@@ -35,10 +35,10 @@ func TestCommand_Run_ExitCode(t *testing.T) {
 func TestCommand_RunInDir(t *testing.T) {
 	dir, err := ioutil.TempDir("", "")
 	assert.Nil(t, err)
-	dirPath := path.Join(dir, "mydir")
+	dirPath := filepath.Join(dir, "mydir")
 	err = os.Mkdir(dirPath, 0744)
 	assert.Nil(t, err)
-	err = ioutil.WriteFile(path.Join(dirPath, "one"), []byte{}, 0744)
+	err = ioutil.WriteFile(filepath.Join(dirPath, "one"), []byte{}, 0744)
 	assert.Nil(t, err)
 	res, err := command.RunInDir(dirPath, "ls", "-1")
 	assert.Nil(t, err)

--- a/src/steps/run_state_to_disk.go
+++ b/src/steps/run_state_to_disk.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 
 	"github.com/Originate/git-town/src/git"
@@ -59,5 +59,5 @@ func SaveRunState(runState *RunState) error {
 func getRunResultFilename() string {
 	replaceCharacterRegexp := regexp.MustCompile("[[:^alnum:]]")
 	directory := replaceCharacterRegexp.ReplaceAllString(git.GetRootDirectory(), "-")
-	return path.Join(os.TempDir(), directory)
+	return filepath.Join(os.TempDir(), directory)
 }

--- a/test/assert.go
+++ b/test/assert.go
@@ -6,21 +6,21 @@ package test
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func assertFileExists(t *testing.T, dir, filename string) {
-	filePath := path.Join(dir, filename)
+	filePath := filepath.Join(dir, filename)
 	info, err := os.Stat(filePath)
 	assert.Nilf(t, err, "file %q does not exist", filePath)
 	assert.Falsef(t, info.IsDir(), "%q is a directory", filePath)
 }
 
 func assertFileExistsWithContent(t *testing.T, dir, filename, expectedContent string) {
-	fileContent, err := ioutil.ReadFile(path.Join(dir, filename))
+	fileContent, err := ioutil.ReadFile(filepath.Join(dir, filename))
 	assert.Nil(t, err)
 	assert.Equal(t, expectedContent, string(fileContent))
 }

--- a/test/filesystem.go
+++ b/test/filesystem.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -52,8 +51,8 @@ func CopyDirectory(src, dst string) error {
 
 // createFile creates a file with the given filename in the given directory.
 func createFile(t *testing.T, dir, filename string) {
-	filePath := path.Join(dir, filename)
-	err := os.MkdirAll(path.Dir(filePath), 0744)
+	filePath := filepath.Join(dir, filename)
+	err := os.MkdirAll(filepath.Dir(filePath), 0744)
 	assert.Nil(t, err)
 	err = ioutil.WriteFile(filePath, []byte(filename+" content"), 0644)
 	assert.Nil(t, err)

--- a/test/filesystem_test.go
+++ b/test/filesystem_test.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,8 +9,8 @@ import (
 
 func TestCopyDirectory(t *testing.T) {
 	tmpDir := createTempDir(t)
-	srcDir := path.Join(tmpDir, "src")
-	dstDir := path.Join(tmpDir, "dst")
+	srcDir := filepath.Join(tmpDir, "src")
+	dstDir := filepath.Join(tmpDir, "dst")
 	createFile(t, srcDir, "one.txt")
 	createFile(t, srcDir, "f1/a.txt")
 	createFile(t, srcDir, "f2/b.txt")
@@ -25,8 +25,8 @@ func TestCopyDirectory(t *testing.T) {
 
 func TestCopyDirectory_GitRepo(t *testing.T) {
 	tmpDir := createTempDir(t)
-	srcDir := path.Join(tmpDir, "src")
-	dstDir := path.Join(tmpDir, "dst")
+	srcDir := filepath.Join(tmpDir, "src")
+	dstDir := filepath.Join(tmpDir, "dst")
 	_, err := InitGitRepository(srcDir, tmpDir)
 	assert.Nil(t, err)
 	createFile(t, srcDir, "one.txt")

--- a/test/git_environment.go
+++ b/test/git_environment.go
@@ -3,7 +3,7 @@ package test
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/DATA-DOG/godog/gherkin"
 )
@@ -30,8 +30,8 @@ func CloneGitEnvironment(original *GitEnvironment, dir string) (*GitEnvironment,
 	}
 	result := GitEnvironment{
 		Dir:           dir,
-		DeveloperRepo: NewGitRepository(path.Join(dir, "developer"), dir),
-		OriginRepo:    NewGitRepository(path.Join(dir, "origin"), dir),
+		DeveloperRepo: NewGitRepository(filepath.Join(dir, "developer"), dir),
+		OriginRepo:    NewGitRepository(filepath.Join(dir, "origin"), dir),
 	}
 	// Since we copied the files from the memoized directory,
 	// we have to set the "origin" remote to the copied origin repo here.
@@ -153,12 +153,12 @@ func (env GitEnvironment) CommitTable(fields []string) (result DataTable, err er
 
 // developerRepoPath provides the full path to the Git repository with the given name.
 func (env GitEnvironment) developerRepoPath() string {
-	return path.Join(env.Dir, "developer")
+	return filepath.Join(env.Dir, "developer")
 }
 
 // originRepoPath provides the full path to the Git repository with the given name.
 func (env GitEnvironment) originRepoPath() string {
-	return path.Join(env.Dir, "origin")
+	return filepath.Join(env.Dir, "origin")
 }
 
 // Remove deletes all files used by this GitEnvironment from disk.

--- a/test/git_environment_test.go
+++ b/test/git_environment_test.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,15 +9,15 @@ import (
 
 func TestCloneGitEnvironment(t *testing.T) {
 	dir := createTempDir(t)
-	memoizedGitEnv, err := NewStandardGitEnvironment(path.Join(dir, "memoized"))
+	memoizedGitEnv, err := NewStandardGitEnvironment(filepath.Join(dir, "memoized"))
 	assert.Nil(t, err, "cannot create memoized GitEnvironment")
 
-	_, err = CloneGitEnvironment(memoizedGitEnv, path.Join(dir, "cloned"))
+	_, err = CloneGitEnvironment(memoizedGitEnv, filepath.Join(dir, "cloned"))
 
 	assert.Nil(t, err, "cannot clone GitEnvironment")
-	assertIsNormalGitRepo(t, path.Join(dir, "cloned", "origin"))
-	assertIsNormalGitRepo(t, path.Join(dir, "cloned", "developer"))
-	assertHasGitBranch(t, path.Join(dir, "cloned", "developer"), "main")
+	assertIsNormalGitRepo(t, filepath.Join(dir, "cloned", "origin"))
+	assertIsNormalGitRepo(t, filepath.Join(dir, "cloned", "developer"))
+	assertHasGitBranch(t, filepath.Join(dir, "cloned", "developer"), "main")
 }
 
 func TestNewStandardGitEnvironment(t *testing.T) {
@@ -28,13 +28,13 @@ func TestNewStandardGitEnvironment(t *testing.T) {
 	assert.Nil(t, err)
 
 	// verify the origin repo
-	assertIsNormalGitRepo(t, path.Join(gitEnvRootDir, "origin"))
+	assertIsNormalGitRepo(t, filepath.Join(gitEnvRootDir, "origin"))
 	branch, err := result.OriginRepo.CurrentBranch()
 	assert.Nil(t, err)
 	assert.Equal(t, "master", branch, "the origin should be at the master branch so that we can push to it")
 
 	// verify the developer repo
-	assertIsNormalGitRepo(t, path.Join(gitEnvRootDir, "developer"))
+	assertIsNormalGitRepo(t, filepath.Join(gitEnvRootDir, "developer"))
 	assertHasGlobalGitConfiguration(t, gitEnvRootDir)
 	branch, err = result.DeveloperRepo.CurrentBranch()
 	assert.Nil(t, err)

--- a/test/git_manager.go
+++ b/test/git_manager.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/Originate/git-town/test/helpers"
 	"github.com/iancoleman/strcase"
@@ -30,7 +30,7 @@ func NewGitManager(baseDir string) *GitManager {
 // that makes cloning new GitEnvironment instances faster.
 func (manager *GitManager) CreateMemoizedEnvironment() error {
 	var err error
-	manager.memoized, err = NewStandardGitEnvironment(path.Join(manager.dir, "memoized"))
+	manager.memoized, err = NewStandardGitEnvironment(filepath.Join(manager.dir, "memoized"))
 	if err != nil {
 		return fmt.Errorf("cannot create memoized environment: %w", err)
 	}
@@ -40,6 +40,6 @@ func (manager *GitManager) CreateMemoizedEnvironment() error {
 // CreateScenarioEnvironment provides a new GitEnvironment for the scenario with the given name
 func (manager *GitManager) CreateScenarioEnvironment(scenarioName string) (*GitEnvironment, error) {
 	envDirName := strcase.ToSnake(scenarioName) + "_" + helpers.UniqueString()
-	envPath := path.Join(manager.dir, envDirName)
+	envPath := filepath.Join(manager.dir, envDirName)
 	return CloneGitEnvironment(manager.memoized, envPath)
 }

--- a/test/git_manager_test.go
+++ b/test/git_manager_test.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +15,7 @@ func TestGitManager_CreateMemoizedEnvironment(t *testing.T) {
 	err := gm.CreateMemoizedEnvironment()
 
 	assert.Nil(t, err, "creating memoized environment failed")
-	memoizedPath := path.Join(dir, "memoized")
+	memoizedPath := filepath.Join(dir, "memoized")
 	_, err = os.Stat(memoizedPath)
 	assert.Falsef(t, os.IsNotExist(err), "memoized directory %q not found", memoizedPath)
 }

--- a/test/git_repository.go
+++ b/test/git_repository.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -207,7 +207,7 @@ func (repo *GitRepository) CreateFeatureBranch(name string) error {
 
 // CreateFile creates a file with the given name and content in this repository.
 func (repo *GitRepository) CreateFile(name, content string) error {
-	err := ioutil.WriteFile(path.Join(repo.Dir, name), []byte(content), 0744)
+	err := ioutil.WriteFile(filepath.Join(repo.Dir, name), []byte(content), 0744)
 	if err != nil {
 		return fmt.Errorf("cannot create file %q: %w", name, err)
 	}
@@ -261,7 +261,7 @@ func (repo *GitRepository) FreshConfiguration() *git.Configuration {
 
 // HasFile indicates whether this repository contains a file with the given name and content.
 func (repo *GitRepository) HasFile(name, content string) (result bool, err error) {
-	rawContent, err := ioutil.ReadFile(path.Join(repo.Dir, name))
+	rawContent, err := ioutil.ReadFile(filepath.Join(repo.Dir, name))
 	if err != nil {
 		return result, fmt.Errorf("repo doesn't have file %q: %w", name, err)
 	}

--- a/test/git_repository_test.go
+++ b/test/git_repository_test.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"io/ioutil"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,10 +10,10 @@ import (
 
 func TestCloneGitRepository(t *testing.T) {
 	rootDir := createTempDir(t)
-	originPath := path.Join(rootDir, "origin")
+	originPath := filepath.Join(rootDir, "origin")
 	_, err := InitGitRepository(originPath, rootDir)
 	assert.Nil(t, err, "cannot initialze origin Git repository")
-	clonedPath := path.Join(rootDir, "cloned")
+	clonedPath := filepath.Join(rootDir, "cloned")
 
 	_, err = CloneGitRepository(originPath, clonedPath, rootDir)
 
@@ -50,7 +50,7 @@ func TestGitRepository_CreateFile(t *testing.T) {
 	err := repo.CreateFile("filename", "content")
 
 	assert.Nil(t, err, "cannot create file in repo")
-	content, err := ioutil.ReadFile(path.Join(repo.Dir, "filename"))
+	content, err := ioutil.ReadFile(filepath.Join(repo.Dir, "filename"))
 	assert.Nil(t, err, "cannot read file")
 	assert.Equal(t, "content", string(content))
 }

--- a/test/shell_runner.go
+++ b/test/shell_runner.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/Originate/git-town/src/command"
@@ -139,7 +139,7 @@ func (runner *ShellRunner) RunWith(opts command.Options, cmd string, args ...str
 	// run the command inside the custom environment
 	result, err = command.RunWith(opts, cmd, args...)
 	if Debug {
-		fmt.Println(path.Base(runner.workingDir), ">", cmd, strings.Join(args, " "))
+		fmt.Println(filepath.Base(runner.workingDir), ">", cmd, strings.Join(args, " "))
 		fmt.Println(result.Output())
 		if err != nil {
 			fmt.Printf("ERROR: %v\n", err)
@@ -150,5 +150,5 @@ func (runner *ShellRunner) RunWith(opts command.Options, cmd string, args ...str
 
 // tempShellOverrideFilePath provides the full file path where to store a temp shell command with the given name.
 func (runner *ShellRunner) tempShellOverrideFilePath(shellOverrideFilename string) string {
-	return path.Join(runner.tempShellOverridesDir, shellOverrideFilename)
+	return filepath.Join(runner.tempShellOverridesDir, shellOverrideFilename)
 }

--- a/test/steps/workspace_steps.go
+++ b/test/steps/workspace_steps.go
@@ -3,7 +3,7 @@ package steps
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/DATA-DOG/godog"
 )
@@ -15,7 +15,7 @@ func WorkspaceSteps(suite *godog.Suite, fs *FeatureState) {
 	})
 
 	suite.Step(`^my workspace is currently not a Git repository$`, func() error {
-		os.RemoveAll(path.Join(fs.activeScenarioState.gitEnvironment.DeveloperRepo.Dir, ".git"))
+		os.RemoveAll(filepath.Join(fs.activeScenarioState.gitEnvironment.DeveloperRepo.Dir, ".git"))
 		return nil
 	})
 


### PR DESCRIPTION
The [filepath](https://golang.org/pkg/path/filepath) package is for operations on file paths, while path is for URLs.