### PR TITLE
Optimize setting the remote

### DIFF
--- a/test/git_environment.go
+++ b/test/git_environment.go
@@ -79,6 +79,7 @@ func NewStandardGitEnvironment(dir string) (gitEnv *GitEnvironment, err error) {
 		// NOTE: the developer repo receives the master branch from origin
 		//       but we don't want it here because it isn't used in tests.
 		{"git", "branch", "-d", "master"},
+		{"git", "remote", "remove", "origin"}, // disconnect the remote here since we copy this and connect to another directory in tests
 	})
 	return gitEnv, err
 }

--- a/test/git_repository.go
+++ b/test/git_repository.go
@@ -309,7 +309,6 @@ func (repo *GitRepository) SetOffline(enabled bool) error {
 // SetRemote sets the remote of this Git repository to the given target.
 func (repo *GitRepository) SetRemote(target string) error {
 	return repo.RunMany([][]string{
-		{"git", "remote", "remove", "origin"},
 		{"git", "remote", "add", "origin", target},
 	})
 }


### PR DESCRIPTION
This saves 1 shell operation per scenario.

Since the new Go test framework copies a memorized Git environment, we have to set the remote after copying to point to the new origin. 